### PR TITLE
feat(unwrapped): add USER_BIRTHDAY env var from 1Password

### DIFF
--- a/kubernetes/apps/self-hosted/unwrapped/app/externalsecret.yaml
+++ b/kubernetes/apps/self-hosted/unwrapped/app/externalsecret.yaml
@@ -29,7 +29,8 @@ spec:
           pool_recycle = 300
 
           [connections.nocodb.create_engine_kwargs.connect_args]
-          options = "-c search_path={{ .UNWRAPPED_NOCODB_SCHEMA }}"
+          options = "-c search_path={{ .UNWRAPPED__NOCODB_SCHEMA }}"
+        USER_BIRTHDAY: '{{ .UNWRAPPED__USER_BIRTHDAY | toDate "1/2/2006" | date "2006-01-02" }}'
   dataFrom:
     - extract:
         key: nocodb

--- a/kubernetes/apps/self-hosted/unwrapped/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/unwrapped/app/helmrelease.yaml
@@ -21,6 +21,12 @@ spec:
             image:
               repository: ghcr.io/zebernst/unwrapped
               tag: 83f210c  # short SHA from main branch
+            env:
+              - name: USER_BIRTHDAY
+                valueFrom:
+                  secretKeyRef:
+                    name: unwrapped-secret
+                    key: USER_BIRTHDAY
             probes:
               liveness: &probe
                 enabled: true


### PR DESCRIPTION
## Summary

- Adds `UNWRAPPED__USER_BIRTHDAY` from the `unwrapped` 1Password item as a `USER_BIRTHDAY` env var in the container, converting the `M/D/YYYY`-formatted value to ISO 8601 at the ExternalSecret template layer via Sprig (`toDate "1/2/2006" | date "2006-01-02"`) so `date.fromisoformat()` in the app works correctly
- Fixes `UNWRAPPED_NOCODB_SCHEMA` → `UNWRAPPED__NOCODB_SCHEMA` in the ExternalSecret template to match the renamed 1Password field

## Test plan

- [ ] ExternalSecret syncs successfully and `unwrapped-secret` contains a `USER_BIRTHDAY` key with ISO-formatted date
- [ ] App pod starts without `KeyError: 'USER_BIRTHDAY'`
- [ ] Confirm `partner_age.py` section renders correctly

https://claude.ai/code/session_01Qkfs9VwFWAxJ5zXbdRXdFm