### PR TITLE
fix(unwrapped): correctly parse USER_BIRTHDAY from 1Password date field

### DIFF
--- a/kubernetes/apps/self-hosted/unwrapped/app/externalsecret.yaml
+++ b/kubernetes/apps/self-hosted/unwrapped/app/externalsecret.yaml
@@ -30,7 +30,7 @@ spec:
 
           [connections.nocodb.create_engine_kwargs.connect_args]
           options = "-c search_path={{ .UNWRAPPED__NOCODB_SCHEMA }}"
-        USER_BIRTHDAY: '{{ .UNWRAPPED__USER_BIRTHDAY | toDate "1/2/2006" | date "2006-01-02" }}'
+        USER_BIRTHDAY: '{{ .UNWRAPPED__USER_BIRTHDAY }}'
   dataFrom:
     - extract:
         key: nocodb

--- a/kubernetes/apps/self-hosted/unwrapped/app/externalsecret.yaml
+++ b/kubernetes/apps/self-hosted/unwrapped/app/externalsecret.yaml
@@ -30,7 +30,7 @@ spec:
 
           [connections.nocodb.create_engine_kwargs.connect_args]
           options = "-c search_path={{ .UNWRAPPED__NOCODB_SCHEMA }}"
-        USER_BIRTHDAY: '{{ .UNWRAPPED__USER_BIRTHDAY }}'
+        USER_BIRTHDAY: '{{- $ts := printf "%ds" (.UNWRAPPED__USER_BIRTHDAY | int64) -}}{{- "1970-01-01" | toDate "2006-01-02" | dateModify $ts | date "2006-01-02" -}}'
   dataFrom:
     - extract:
         key: nocodb


### PR DESCRIPTION
1Password date-type fields are serialized as Unix timestamps by the
Connect API, causing `toDate "1/2/2006"` to silently fail and return
Go's zero time (`0001-01-01`).

Fix by converting the Unix timestamp to a date using epoch math in the
ESO template: add the timestamp as a seconds duration to the Unix epoch
(`1970-01-01`), then format the result as `2006-01-02`. This is
necessary because Sprig has no built-in function to parse a Unix
timestamp directly into a `time.Time`.

https://claude.ai/code/session_01NwvVqLj6zUqGiFKYNMPGQe