### PR TITLE
feat(ai): deploy HolmesGPT operator with local Ollama backend

### DIFF
--- a/kubernetes/apps/ai/holmesgpt/app/ciliumnetworkpolicy.yaml
+++ b/kubernetes/apps/ai/holmesgpt/app/ciliumnetworkpolicy.yaml
@@ -1,0 +1,101 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/cilium.io/ciliumnetworkpolicy_v2.json
+---
+# Holmes core pod (server + operator): cluster-internal only, no internet.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: holmesgpt
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: holmes
+  egress:
+    # DNS
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+    # Kubernetes API server
+    - toEntities:
+        - kube-apiserver
+    # Ollama LLM backend
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: ai
+            app.kubernetes.io/name: ollama
+      toPorts:
+        - ports:
+            - port: "11434"
+              protocol: TCP
+    # Prometheus
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: observability
+            app.kubernetes.io/name: prometheus
+      toPorts:
+        - ports:
+            - port: "9090"
+              protocol: TCP
+    # AlertManager
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: observability
+            app.kubernetes.io/name: alertmanager
+      toPorts:
+        - ports:
+            - port: "9093"
+              protocol: TCP
+    # Victoria Logs
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: observability
+            app.kubernetes.io/name: victoria-logs-single
+      toPorts:
+        - ports:
+            - port: "9428"
+              protocol: TCP
+    # GitHub MCP sidecar (in-namespace, chart-managed port 8000)
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: ai
+            app.kubernetes.io/component: github-mcp
+      toPorts:
+        - ports:
+            - port: "8000"
+              protocol: TCP
+---
+# GitHub MCP sidecar: only allowed to reach api.github.com.
+# All other internet egress is denied.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: holmesgpt-github-mcp
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/component: github-mcp
+  egress:
+    # DNS (required to resolve api.github.com)
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+    # GitHub API — named egress, no general internet
+    - toFQDNs:
+        - matchName: "api.github.com"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/apps/ai/holmesgpt/app/ciliumnetworkpolicy.yaml
+++ b/kubernetes/apps/ai/holmesgpt/app/ciliumnetworkpolicy.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/cilium.io/ciliumnetworkpolicy_v2.json
 ---
-# Holmes core pod (server + operator): cluster-internal + Pushover for LLM-formulated alerts.
+# Holmes core pod (server + operator): cluster-internal only, no internet.
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
@@ -68,13 +68,6 @@ spec:
       toPorts:
         - ports:
             - port: "8000"
-              protocol: TCP
-    # Pushover API — LLM sends rich notifications via bash/curl at end of each check
-    - toFQDNs:
-        - matchName: "api.pushover.net"
-      toPorts:
-        - ports:
-            - port: "443"
               protocol: TCP
 ---
 # GitHub MCP sidecar: only allowed to reach api.github.com.

--- a/kubernetes/apps/ai/holmesgpt/app/ciliumnetworkpolicy.yaml
+++ b/kubernetes/apps/ai/holmesgpt/app/ciliumnetworkpolicy.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/cilium.io/ciliumnetworkpolicy_v2.json
 ---
-# Holmes core pod (server + operator): cluster-internal only, no internet.
+# Holmes core pod (server + operator): cluster-internal + Pushover for LLM-formulated alerts.
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
@@ -68,6 +68,13 @@ spec:
       toPorts:
         - ports:
             - port: "8000"
+              protocol: TCP
+    # Pushover API — LLM sends rich notifications via bash/curl at end of each check
+    - toFQDNs:
+        - matchName: "api.pushover.net"
+      toPorts:
+        - ports:
+            - port: "443"
               protocol: TCP
 ---
 # GitHub MCP sidecar: only allowed to reach api.github.com.

--- a/kubernetes/apps/ai/holmesgpt/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/holmesgpt/app/externalsecret.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: holmesgpt
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: holmesgpt-secret
+  dataFrom:
+    - extract:
+        key: holmesgpt

--- a/kubernetes/apps/ai/holmesgpt/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/holmesgpt/app/externalsecret.yaml
@@ -14,24 +14,3 @@ spec:
   dataFrom:
     - extract:
         key: github-bot
----
-apiVersion: external-secrets.io/v1
-kind: ExternalSecret
-metadata:
-  name: holmesgpt-pushover
-spec:
-  refreshInterval: 5m
-  secretStoreRef:
-    kind: ClusterSecretStore
-    name: onepassword
-  target:
-    name: holmesgpt-pushover
-    template:
-      data:
-        PUSHOVER_TOKEN: "{{ .ALERTMANAGER_PUSHOVER_TOKEN }}"
-        PUSHOVER_USER_KEY: "{{ .PUSHOVER_USER_KEY }}"
-  dataFrom:
-    - extract:
-        key: pushover
-    - extract:
-        key: alertmanager

--- a/kubernetes/apps/ai/holmesgpt/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/holmesgpt/app/externalsecret.yaml
@@ -3,14 +3,14 @@
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
-  name: holmesgpt
+  name: holmesgpt-github-app
 spec:
   refreshInterval: 5m
   secretStoreRef:
     kind: ClusterSecretStore
     name: onepassword
   target:
-    name: holmesgpt-secret
+    name: holmesgpt-github-app
   dataFrom:
     - extract:
-        key: holmesgpt
+        key: github-bot

--- a/kubernetes/apps/ai/holmesgpt/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/holmesgpt/app/externalsecret.yaml
@@ -14,3 +14,24 @@ spec:
   dataFrom:
     - extract:
         key: github-bot
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: holmesgpt-pushover
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: holmesgpt-pushover
+    template:
+      data:
+        PUSHOVER_TOKEN: "{{ .ALERTMANAGER_PUSHOVER_TOKEN }}"
+        PUSHOVER_USER_KEY: "{{ .PUSHOVER_USER_KEY }}"
+  dataFrom:
+    - extract:
+        key: pushover
+    - extract:
+        key: alertmanager

--- a/kubernetes/apps/ai/holmesgpt/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/holmesgpt/app/helmrelease.yaml
@@ -1,0 +1,101 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: holmesgpt
+spec:
+  interval: 1h
+  chart:
+    spec:
+      chart: holmes
+      version: 0.30.0
+      sourceRef:
+        kind: HelmRepository
+        name: holmesgpt
+        namespace: flux-system
+
+  values:
+    # qwen3:8b is the best tool-calling model available locally
+    additionalEnvVars:
+      - name: OLLAMA_API_BASE
+        value: "http://ollama.ai.svc.cluster.local:11434"
+      - name: MODEL
+        value: "ollama_chat/qwen3:8b"
+      - name: ALERTMANAGER_URL
+        value: "http://alertmanager-operated.observability.svc.cluster.local:9093"
+
+    # Pull GitHub PAT from 1Password (item: holmesgpt, field: GITHUB_TOKEN)
+    additional_env_froms:
+      - secretRef:
+          name: holmesgpt-secret
+
+    k8sRBAC: true
+
+    crdPermissions:
+      flux: true
+      keda: true
+      gatewayApi: true
+      externalSecrets: true
+      argo: false
+      kafka: false
+      crossplane: false
+      istio: false
+      velero: false
+
+    toolsets:
+      kubernetes/core:
+        enabled: true
+      kubernetes/logs:
+        enabled: true
+      prometheus/metrics:
+        enabled: true
+        config:
+          prometheus_url: "http://prometheus-operated.observability.svc.cluster.local:9090"
+          subtype: prometheus
+      victorialogs:
+        enabled: true
+        config:
+          api_url: "http://victoria-logs-server.observability.svc.cluster.local:9428"
+      cilium/core:
+        enabled: true
+      hubble/observability:
+        enabled: true
+      connectivity_check:
+        enabled: true
+      bash:
+        enabled: true
+        config:
+          builtin_allowlist: "extended"
+      skills:
+        enabled: true
+      robusta:
+        enabled: false
+      internet:
+        enabled: false
+
+    resources:
+      requests:
+        cpu: 100m
+        memory: 2Gi
+      limits:
+        memory: 2Gi
+
+    operator:
+      enabled: true
+      logLevel: INFO
+      maxHistoryItems: 10
+      cleanupCompletedChecks: true
+      completedCheckTTLHours: 24
+
+    mcpAddons:
+      github:
+        enabled: true
+        auth:
+          secretName: holmesgpt-secret
+          secretKey: GITHUB_TOKEN
+        config:
+          # Restrict to the minimum tools needed for PR proposals — no issue/action access
+          tools: "get_file_contents,create_branch,create_or_update_file,create_pull_request,list_commits,get_me,get_pull_request"
+        networkPolicy:
+          enabled: true

--- a/kubernetes/apps/ai/holmesgpt/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/holmesgpt/app/helmrelease.yaml
@@ -25,6 +25,10 @@ spec:
       - name: ALERTMANAGER_URL
         value: "http://alertmanager-operated.observability.svc.cluster.local:9093"
 
+    additional_env_froms:
+      - secretRef:
+          name: holmesgpt-pushover
+
     k8sRBAC: true
 
     crdPermissions:

--- a/kubernetes/apps/ai/holmesgpt/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/holmesgpt/app/helmrelease.yaml
@@ -25,10 +25,6 @@ spec:
       - name: ALERTMANAGER_URL
         value: "http://alertmanager-operated.observability.svc.cluster.local:9093"
 
-    additional_env_froms:
-      - secretRef:
-          name: holmesgpt-pushover
-
     k8sRBAC: true
 
     crdPermissions:

--- a/kubernetes/apps/ai/holmesgpt/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/holmesgpt/app/helmrelease.yaml
@@ -25,11 +25,6 @@ spec:
       - name: ALERTMANAGER_URL
         value: "http://alertmanager-operated.observability.svc.cluster.local:9093"
 
-    # Pull GitHub PAT from 1Password (item: holmesgpt, field: GITHUB_TOKEN)
-    additional_env_froms:
-      - secretRef:
-          name: holmesgpt-secret
-
     k8sRBAC: true
 
     crdPermissions:
@@ -92,8 +87,8 @@ spec:
       github:
         enabled: true
         auth:
-          secretName: holmesgpt-secret
-          secretKey: GITHUB_TOKEN
+          githubApp:
+            secretName: holmesgpt-github-app
         config:
           # Restrict to the minimum tools needed for PR proposals — no issue/action access
           tools: "get_file_contents,create_branch,create_or_update_file,create_pull_request,list_commits,get_me,get_pull_request"

--- a/kubernetes/apps/ai/holmesgpt/app/kustomization.yaml
+++ b/kubernetes/apps/ai/holmesgpt/app/kustomization.yaml
@@ -2,11 +2,9 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: ai
-components:
-  - ../../components/common
 resources:
-  - holmesgpt/ks.yaml
-  - ollama/ks.yaml
-  - open-webui/ks.yaml
-#  - paperless-ai/ks.yaml
+  - externalsecret.yaml
+  - helmrelease.yaml
+  - ciliumnetworkpolicy.yaml
+  - prometheusrule.yaml
+  - scheduledhealthchecks.yaml

--- a/kubernetes/apps/ai/holmesgpt/app/prometheusrule.yaml
+++ b/kubernetes/apps/ai/holmesgpt/app/prometheusrule.yaml
@@ -11,18 +11,11 @@ spec:
   groups:
     - name: holmesgpt
       rules:
-        - alert: HolmesHealthCheckFailed
-          expr: |
-            kube_customresource_scheduled_health_check_last_result_info{result="fail"} == 1
-          for: 0m
-          labels:
-            severity: warning
-          annotations:
-            summary: "HolmesGPT health check failed: {{ $labels.name }}"
-            description: >-
-              Scheduled health check {{ $labels.namespace }}/{{ $labels.name }}
-              last result was failure. Check kubectl get shc -n {{ $labels.namespace }}
-              or look for a new PR in zebernst/homelab with proposed fixes.
+        # Fired when Holmes itself errors (LLM/tooling failure) — Holmes can't
+        # self-notify in this state so AlertManager → Pushover is the fallback.
+        # HolmesHealthCheckFailed is intentionally absent: when a check finds
+        # real issues, the LLM sends a richer Pushover notification directly via
+        # bash/curl (including PR link and LLM-formulated summary).
         - alert: HolmesHealthCheckError
           expr: |
             kube_customresource_scheduled_health_check_last_result_info{result="error"} == 1
@@ -30,8 +23,9 @@ spec:
           labels:
             severity: warning
           annotations:
-            summary: "HolmesGPT health check errored: {{ $labels.name }}"
+            summary: "HolmesGPT check errored: {{ $labels.name }}"
             description: >-
               Scheduled health check {{ $labels.namespace }}/{{ $labels.name }}
-              encountered an error (LLM or tooling failure). Check Holmes logs
-              with kubectl logs -l app.kubernetes.io/name=holmes -n ai.
+              encountered an execution error (LLM or tooling failure). Holmes
+              could not complete the investigation. Check logs:
+              kubectl logs -l app.kubernetes.io/name=holmes -n ai

--- a/kubernetes/apps/ai/holmesgpt/app/prometheusrule.yaml
+++ b/kubernetes/apps/ai/holmesgpt/app/prometheusrule.yaml
@@ -11,11 +11,24 @@ spec:
   groups:
     - name: holmesgpt
       rules:
-        # Fired when Holmes itself errors (LLM/tooling failure) — Holmes can't
-        # self-notify in this state so AlertManager → Pushover is the fallback.
-        # HolmesHealthCheckFailed is intentionally absent: when a check finds
-        # real issues, the LLM sends a richer Pushover notification directly via
-        # bash/curl (including PR link and LLM-formulated summary).
+        # Labels are fully deterministic (name + namespace + result only) so
+        # AlertManager deduplicates correctly across repeated failing runs.
+        # repeatInterval: 12h suppresses re-notification while the issue persists.
+        # The alert resolves automatically when the check next passes.
+        - alert: HolmesHealthCheckFailed
+          expr: |
+            kube_customresource_scheduled_health_check_last_result_info{result="fail"} == 1
+          for: 0m
+          labels:
+            severity: warning
+          annotations:
+            summary: "HolmesGPT health check failed: {{ $labels.name }}"
+            description: >-
+              Scheduled health check {{ $labels.namespace }}/{{ $labels.name }}
+              last result was failure. Check for a proposed fix:
+              kubectl describe shc {{ $labels.name }} -n {{ $labels.namespace }}
+        # Fired when Holmes itself errors (LLM/tooling failure) — distinct from a
+        # check that runs successfully and finds a real problem.
         - alert: HolmesHealthCheckError
           expr: |
             kube_customresource_scheduled_health_check_last_result_info{result="error"} == 1
@@ -26,6 +39,5 @@ spec:
             summary: "HolmesGPT check errored: {{ $labels.name }}"
             description: >-
               Scheduled health check {{ $labels.namespace }}/{{ $labels.name }}
-              encountered an execution error (LLM or tooling failure). Holmes
-              could not complete the investigation. Check logs:
+              encountered an execution error (LLM or tooling failure). Check logs:
               kubectl logs -l app.kubernetes.io/name=holmes -n ai

--- a/kubernetes/apps/ai/holmesgpt/app/prometheusrule.yaml
+++ b/kubernetes/apps/ai/holmesgpt/app/prometheusrule.yaml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/prometheusrule_v1.json
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: holmesgpt
+  labels:
+    prometheus: kube-prometheus
+    role: alert-rules
+spec:
+  groups:
+    - name: holmesgpt
+      rules:
+        - alert: HolmesHealthCheckFailed
+          expr: |
+            kube_customresource_scheduled_health_check_last_result_info{result="fail"} == 1
+          for: 0m
+          labels:
+            severity: warning
+          annotations:
+            summary: "HolmesGPT health check failed: {{ $labels.name }}"
+            description: >-
+              Scheduled health check {{ $labels.namespace }}/{{ $labels.name }}
+              last result was failure. Check kubectl get shc -n {{ $labels.namespace }}
+              or look for a new PR in zebernst/homelab with proposed fixes.
+        - alert: HolmesHealthCheckError
+          expr: |
+            kube_customresource_scheduled_health_check_last_result_info{result="error"} == 1
+          for: 0m
+          labels:
+            severity: warning
+          annotations:
+            summary: "HolmesGPT health check errored: {{ $labels.name }}"
+            description: >-
+              Scheduled health check {{ $labels.namespace }}/{{ $labels.name }}
+              encountered an error (LLM or tooling failure). Check Holmes logs
+              with kubectl logs -l app.kubernetes.io/name=holmes -n ai.

--- a/kubernetes/apps/ai/holmesgpt/app/scheduledhealthchecks.yaml
+++ b/kubernetes/apps/ai/holmesgpt/app/scheduledhealthchecks.yaml
@@ -14,13 +14,16 @@ spec:
     containers, OOMKilled pods in the last hour (cross-reference Prometheus
     kube_pod_container_status_last_terminated_reason), pods stuck in Pending
     for more than 10 minutes, and high restart counts. Query Victoria Logs for
-    related error messages from affected workloads. If you find issues that
-    require a configuration change to fix (e.g. resource limits too low, bad
-    image tag, missing secret), create a pull request in the zebernst/homelab
-    GitHub repository with the minimal GitOps patch needed, following the
-    existing Kustomize/Flux conventions in the repo. The PR branch should be
-    named fix/holmes-<issue-slug>. Do not apply any changes directly to the
-    cluster.
+    related error messages from affected workloads.
+
+    If you find issues that require a configuration change to fix (e.g. resource
+    limits too low, bad image tag, missing secret): first search the
+    zebernst/homelab repository for any open pull requests whose branch name
+    starts with fix/holmes- that address the same problem. If one already exists,
+    reference it in your analysis and do not open another. Only open a new pull
+    request if no existing one covers the issue. New PR branch names must follow
+    the pattern fix/holmes-<issue-slug>. Do not apply any changes directly to
+    the cluster.
 ---
 # Observability stack: Prometheus, AlertManager, Victoria Logs
 apiVersion: holmesgpt.dev/v1alpha1
@@ -36,9 +39,15 @@ spec:
     Check: Prometheus retention and storage usage (alert if >80% of retentionSize),
     whether AlertManager is receiving and routing alerts correctly, Victoria Logs
     ingestion rate and retention, and that all ServiceMonitors have active scrape
-    targets. Use Prometheus metrics to validate. Report any degradation or
-    misconfiguration, and propose a PR to zebernst/homelab if a config change
-    is needed to fix it.
+    targets. Use Prometheus metrics to validate.
+
+    If a configuration change is needed to fix a problem: first search the
+    zebernst/homelab repository for any open pull requests whose branch name
+    starts with fix/holmes- that address the same problem. If one already exists,
+    reference it in your analysis and do not open another. Only open a new pull
+    request if no existing one covers the issue. New PR branch names must follow
+    the pattern fix/holmes-<issue-slug>. Do not apply any changes directly to
+    the cluster.
 ---
 # Storage: Rook/Ceph cluster health and PVC status
 apiVersion: holmesgpt.dev/v1alpha1
@@ -54,8 +63,15 @@ spec:
     health status (ceph_health_status), OSD status, pool usage, and any
     degraded PGs. Check for PersistentVolumeClaims in a Pending or Lost state
     across all namespaces. Check for any Rook/Ceph operator warnings in Victoria
-    Logs. Report findings and propose a PR to zebernst/homelab if remediation
-    is needed.
+    Logs.
+
+    If remediation requires a configuration change: first search the
+    zebernst/homelab repository for any open pull requests whose branch name
+    starts with fix/holmes- that address the same problem. If one already exists,
+    reference it in your analysis and do not open another. Only open a new pull
+    request if no existing one covers the issue. New PR branch names must follow
+    the pattern fix/holmes-<issue-slug>. Do not apply any changes directly to
+    the cluster.
 ---
 # GitOps: Flux Kustomizations and HelmReleases
 apiVersion: holmesgpt.dev/v1alpha1
@@ -71,8 +87,14 @@ spec:
     Look for resources that are not Ready, have failed reconciliation, or are
     stuck in a retry loop. For any HelmRelease in a failed state, check Victoria
     Logs for the helm controller error messages to understand the root cause.
-    If the fix requires a values change or chart version bump in the GitOps repo,
-    propose a PR to zebernst/homelab with the fix.
+
+    If the fix requires a values change or chart version bump: first search the
+    zebernst/homelab repository for any open pull requests whose branch name
+    starts with fix/holmes- that address the same problem. If one already exists,
+    reference it in your analysis and do not open another. Only open a new pull
+    request if no existing one covers the issue. New PR branch names must follow
+    the pattern fix/holmes-<issue-slug>. Do not apply any changes directly to
+    the cluster.
 ---
 # Network: Cilium agent health and Hubble flow anomalies
 apiVersion: holmesgpt.dev/v1alpha1
@@ -88,6 +110,12 @@ spec:
     are running and healthy, check for recent policy drops in Hubble that indicate
     unexpected traffic blocks, look for DNS resolution failures, and check for
     any pods failing connectivity checks. Query Victoria Logs for cilium or
-    coredns error messages. Report any persistent network issues and propose a
-    PR to zebernst/homelab if a CiliumNetworkPolicy or Gateway config change
-    is needed.
+    coredns error messages.
+
+    If a persistent network issue requires a config change: first search the
+    zebernst/homelab repository for any open pull requests whose branch name
+    starts with fix/holmes- that address the same problem. If one already exists,
+    reference it in your analysis and do not open another. Only open a new pull
+    request if no existing one covers the issue. New PR branch names must follow
+    the pattern fix/holmes-<issue-slug>. Do not apply any changes directly to
+    the cluster.

--- a/kubernetes/apps/ai/holmesgpt/app/scheduledhealthchecks.yaml
+++ b/kubernetes/apps/ai/holmesgpt/app/scheduledhealthchecks.yaml
@@ -1,0 +1,93 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/holmesgpt.dev/scheduledhealthcheck_v1alpha1.json
+---
+# Cluster-wide pod health: catches crashloops, OOMKills, pending pods
+apiVersion: holmesgpt.dev/v1alpha1
+kind: ScheduledHealthCheck
+metadata:
+  name: cluster-pod-health
+spec:
+  schedule: "0 * * * *"
+  timeout: 120
+  mode: monitor
+  query: >-
+    Check the health of all pods across every namespace. Look for: crashlooping
+    containers, OOMKilled pods in the last hour (cross-reference Prometheus
+    kube_pod_container_status_last_terminated_reason), pods stuck in Pending
+    for more than 10 minutes, and high restart counts. Query Victoria Logs for
+    related error messages from affected workloads. If you find issues that
+    require a configuration change to fix (e.g. resource limits too low, bad
+    image tag, missing secret), create a pull request in the zebernst/homelab
+    GitHub repository with the minimal GitOps patch needed, following the
+    existing Kustomize/Flux conventions in the repo. The PR branch should be
+    named fix/holmes-<issue-slug>. Do not apply any changes directly to the
+    cluster.
+---
+# Observability stack: Prometheus, AlertManager, Victoria Logs
+apiVersion: holmesgpt.dev/v1alpha1
+kind: ScheduledHealthCheck
+metadata:
+  name: observability-stack-health
+spec:
+  schedule: "0 6 * * *"
+  timeout: 120
+  mode: monitor
+  query: >-
+    Verify the health of the observability stack in the observability namespace.
+    Check: Prometheus retention and storage usage (alert if >80% of retentionSize),
+    whether AlertManager is receiving and routing alerts correctly, Victoria Logs
+    ingestion rate and retention, and that all ServiceMonitors have active scrape
+    targets. Use Prometheus metrics to validate. Report any degradation or
+    misconfiguration, and propose a PR to zebernst/homelab if a config change
+    is needed to fix it.
+---
+# Storage: Rook/Ceph cluster health and PVC status
+apiVersion: holmesgpt.dev/v1alpha1
+kind: ScheduledHealthCheck
+metadata:
+  name: storage-health
+spec:
+  schedule: "0 7 * * *"
+  timeout: 120
+  mode: monitor
+  query: >-
+    Check the health of cluster storage. Query Prometheus for Ceph cluster
+    health status (ceph_health_status), OSD status, pool usage, and any
+    degraded PGs. Check for PersistentVolumeClaims in a Pending or Lost state
+    across all namespaces. Check for any Rook/Ceph operator warnings in Victoria
+    Logs. Report findings and propose a PR to zebernst/homelab if remediation
+    is needed.
+---
+# GitOps: Flux Kustomizations and HelmReleases
+apiVersion: holmesgpt.dev/v1alpha1
+kind: ScheduledHealthCheck
+metadata:
+  name: flux-gitops-health
+spec:
+  schedule: "30 6 * * *"
+  timeout: 120
+  mode: monitor
+  query: >-
+    Check the health of all Flux Kustomizations and HelmReleases in the cluster.
+    Look for resources that are not Ready, have failed reconciliation, or are
+    stuck in a retry loop. For any HelmRelease in a failed state, check Victoria
+    Logs for the helm controller error messages to understand the root cause.
+    If the fix requires a values change or chart version bump in the GitOps repo,
+    propose a PR to zebernst/homelab with the fix.
+---
+# Network: Cilium agent health and Hubble flow anomalies
+apiVersion: holmesgpt.dev/v1alpha1
+kind: ScheduledHealthCheck
+metadata:
+  name: network-health
+spec:
+  schedule: "0 8 * * *"
+  timeout: 120
+  mode: monitor
+  query: >-
+    Check Cilium and network health across the cluster. Verify all Cilium agents
+    are running and healthy, check for recent policy drops in Hubble that indicate
+    unexpected traffic blocks, look for DNS resolution failures, and check for
+    any pods failing connectivity checks. Query Victoria Logs for cilium or
+    coredns error messages. Report any persistent network issues and propose a
+    PR to zebernst/homelab if a CiliumNetworkPolicy or Gateway config change
+    is needed.

--- a/kubernetes/apps/ai/holmesgpt/ks.yaml
+++ b/kubernetes/apps/ai/holmesgpt/ks.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app holmesgpt
+  namespace: &ns ai
+spec:
+  targetNamespace: *ns
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: ollama
+      namespace: ai
+    - name: kube-prometheus-stack
+      namespace: observability
+  path: kubernetes/apps/ai/holmesgpt/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false
+  interval: 1h
+  retryInterval: 1m
+  timeout: 5m
+  healthCheckExprs:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: holmesgpt
+      namespace: ai
+      current: status.conditions.filter(e, e.type == "Ready").all(e, e.status == "True")

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
@@ -127,6 +127,28 @@ spec:
               replacement: $1
               sourceLabels: ["__meta_kubernetes_pod_node_name"]
               targetLabel: kubernetes_node
+      rbac:
+        extraRules:
+          - apiGroups: ["holmesgpt.dev"]
+            resources: ["healthchecks", "scheduledhealthchecks"]
+            verbs: ["list", "watch"]
+      customResourceState:
+        enabled: true
+        config:
+          spec:
+            resources:
+              - groupVersionKind:
+                  group: holmesgpt.dev
+                  version: v1alpha1
+                  kind: ScheduledHealthCheck
+                metrics:
+                  - name: scheduled_health_check_last_result_info
+                    help: "Last result of a HolmesGPT scheduled health check"
+                    each:
+                      type: Info
+                      info:
+                        labelsFromPath:
+                          result: [status, lastResult]
     grafana:
       enabled: false
       forceDeployDashboards: true

--- a/kubernetes/flux/meta/repositories/helm/holmesgpt.yaml
+++ b/kubernetes/flux/meta/repositories/helm/holmesgpt.yaml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/helmrepository_v1.json
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: holmesgpt
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://robusta-charts.storage.googleapis.com

--- a/kubernetes/flux/meta/repositories/helm/kustomization.yaml
+++ b/kubernetes/flux/meta/repositories/helm/kustomization.yaml
@@ -18,6 +18,7 @@ resources:
   - go-skynet.yaml
   - grafana.yaml
   - hajimari-charts.yaml
+  - holmesgpt.yaml
   - ingress-nginx.yaml
   - intel.yaml
   - jetstack.yaml


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Deploys [HolmesGPT](https://github.com/HolmesGPT/holmesgpt) in operator mode to the `ai` namespace, using `qwen3:8b` via the existing Ollama deployment as the LLM backend
- Connects to all available local data sources: Kubernetes core/logs, Prometheus, AlertManager, Victoria Logs, Cilium/Hubble
- GitHub MCP addon (authenticated via the `github-bot` GitHub App) allows Holmes to propose remediation as PRs — no direct cluster writes
- CiliumNetworkPolicy enforces no general internet access; only named exceptions are `api.github.com` (GitHub MCP sidecar only) and cluster-internal services
- Notifications route through the existing AlertManager → Pushover pipeline via a PrometheusRule watching `ScheduledHealthCheck` CRD status; alert labels are fully deterministic so AlertManager deduplicates correctly across repeated failing runs
- Each health check query instructs Holmes to search for an existing open `fix/holmes-*` PR before creating a new one, preventing duplicate PRs for unresolved issues

## New files

| File | Purpose |
|------|---------|
| `flux/meta/repositories/helm/holmesgpt.yaml` | HelmRepository (`https://robusta-charts.storage.googleapis.com`) |
| `apps/ai/holmesgpt/ks.yaml` | Flux Kustomization; depends on `ollama` + `kube-prometheus-stack` |
| `apps/ai/holmesgpt/app/helmrelease.yaml` | Holmes chart v0.30.0 with all toolset + operator config |
| `apps/ai/holmesgpt/app/externalsecret.yaml` | GitHub App credentials from `github-bot` 1Password item |
| `apps/ai/holmesgpt/app/ciliumnetworkpolicy.yaml` | Holmes pod: cluster-internal only; GitHub MCP pod: `api.github.com` only |
| `apps/ai/holmesgpt/app/prometheusrule.yaml` | `HolmesHealthCheckFailed` + `HolmesHealthCheckError` alerts |
| `apps/ai/holmesgpt/app/scheduledhealthchecks.yaml` | 5 scheduled checks: pods (hourly), observability/storage/Flux/network (daily) |

## Modified files

| File | Change |
|------|--------|
| `flux/meta/repositories/helm/kustomization.yaml` | Add `holmesgpt.yaml` |
| `apps/ai/kustomization.yaml` | Add `holmesgpt/ks.yaml` |
| `apps/observability/kube-prometheus-stack/app/helmrelease.yaml` | Add kube-state-metrics `customResourceState` to expose `ScheduledHealthCheck.status.lastResult` as a Prometheus metric; add RBAC for `holmesgpt.dev` CRDs |

## Pre-merge checklist

- [ ] Create `holmesgpt` 1Password item (or confirm `github-bot` item has `GITHUB_APP_INSTALLATION_ID` — already added per discussion)
- [ ] Confirm `qwen3:8b` is pulled in Ollama (`kubectl exec -n ai deploy/ollama -- ollama list`)
- [ ] Verify Cilium DNS proxy is enabled (required for `toFQDNs` rules to resolve `api.github.com`)

## Notification flow

```
ScheduledHealthCheck .status.lastResult = "fail"
  → kube-state-metrics customResourceState metric
  → PrometheusRule (deterministic labels: name + namespace + result)
  → AlertManager (deduplicates; repeatInterval: 12h)
  → Pushover
```

https://claude.ai/code/session_01VVPAZCS1MPrAfwFM4u18GB
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VVPAZCS1MPrAfwFM4u18GB)_