### PR TITLE
ci: restrict flux-local test to flux-system namespace

### DIFF
--- a/.github/workflows/flux-check.yaml
+++ b/.github/workflows/flux-check.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Run flux-local test
         uses: docker://ghcr.io/allenporter/flux-local:v8.2.0
         with:
-          args: test --enable-helm --all-namespaces --path /github/workspace/kubernetes/flux/cluster -v
+          args: test --enable-helm --all-namespaces --path /github/workspace/kubernetes/flux/cluster --sources "flux-system" -v
 
   diff:
     name: Flux Diff


### PR DESCRIPTION
## Summary
Restricts the flux-local test in the CI workflow to only validate the `flux-system` namespace, improving test performance and focusing validation on core Flux components.

## Changes
- Updated `flux-check.yaml` workflow to add `--sources "flux-system"` flag to the flux-local test command
- This narrows the scope of the test from all namespaces to only the flux-system namespace where Flux core components are deployed

## Details
The flux-local test now explicitly targets the `flux-system` namespace via the `--sources` parameter. This change reduces test execution time by avoiding validation of application namespaces and focuses the CI check on validating the integrity of the Flux GitOps configuration itself.

https://claude.ai/code/session_01PSbydbraHoudPUgLjVaTNa