### PR TITLE
fix(ai/holmesgpt): fix CRD ordering and remove invalid healthCheckExprs

### DIFF
--- a/kubernetes/apps/ai/holmesgpt/ks.yaml
+++ b/kubernetes/apps/ai/holmesgpt/ks.yaml
@@ -25,9 +25,3 @@ spec:
   interval: 1h
   retryInterval: 1m
   timeout: 5m
-  healthCheckExprs:
-    - apiVersion: helm.toolkit.fluxcd.io/v2
-      kind: HelmRelease
-      name: holmesgpt
-      namespace: ai
-      current: status.conditions.filter(e, e.type == "Ready").all(e, e.status == "True")


### PR DESCRIPTION
## Summary

- Removes the invalid `healthCheckExprs` block from the HolmesGPT Flux Kustomization (the `name` field is not part of the schema)
- Splits ScheduledHealthCheck CRs into a separate Flux Kustomization (`checks/`) that depends on the operator Kustomization, so the CRDs exist before the CRs are applied — matches the `cloudnative-pg` split pattern
- Sets `wait: true` on the operator Kustomization so the HelmRelease (and its CRDs) are fully installed before the checks Kustomization begins

## Test plan

- [ ] Verify Flux accepts both Kustomizations without validation errors
- [ ] Confirm HolmesGPT HelmRelease reconciles and installs CRDs
- [ ] Confirm ScheduledHealthCheck resources are created after the operator is ready

https://claude.ai/code/session_01VVPAZCS1MPrAfwFM4u18GB