### PR TITLE
refactor(dawarich): migrate to sidecar Redis and fix health checks

### DIFF
--- a/kubernetes/apps/self-hosted/dawarich/app/externalsecret.yaml
+++ b/kubernetes/apps/self-hosted/dawarich/app/externalsecret.yaml
@@ -41,7 +41,7 @@ spec:
         DATABASE_USERNAME: "{{ .POSTGRES_SUPER_USER }}"
         DATABASE_PASSWORD: "{{ .POSTGRES_SUPER_PASS }}"
         DATABASE_NAME: dawarich_production
-        REDIS_URL: redis://hindwing.database.svc.cluster.local:6379
+        REDIS_URL: redis://localhost:6379
         SECRET_KEY_BASE: "{{ .SECRET_KEY_BASE }}"
         OIDC_CLIENT_ID: "{{ .OIDC_CLIENT_ID }}"
         OIDC_CLIENT_SECRET: "{{ .OIDC_CLIENT_SECRET }}"

--- a/kubernetes/apps/self-hosted/dawarich/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/dawarich/app/helmrelease.yaml
@@ -57,6 +57,9 @@ spec:
                   httpGet:
                     path: /up
                     port: 3000
+                    httpHeaders:
+                      - name: Host
+                        value: localhost
                   initialDelaySeconds: 0
                   periodSeconds: 10
                   timeoutSeconds: 5
@@ -69,6 +72,9 @@ spec:
                   httpGet:
                     path: /up
                     port: 3000
+                    httpHeaders:
+                      - name: Host
+                        value: localhost
                   initialDelaySeconds: 30
                   periodSeconds: 10
                   timeoutSeconds: 5
@@ -91,9 +97,7 @@ spec:
               SELF_HOSTED: "true"
               STORE_GEODATA: "true"
               BACKGROUND_PROCESSING_CONCURRENCY: "5"
-              PROMETHEUS_EXPORTER_ENABLED: "true"
-              PROMETHEUS_EXPORTER_HOST: "127.0.0.1"
-              PROMETHEUS_EXPORTER_PORT: *metricsPort
+              PROMETHEUS_EXPORTER_ENABLED: "false"
             envFrom: *envFrom
             resources:
               requests:
@@ -101,6 +105,17 @@ spec:
                 memory: 256Mi
               limits:
                 memory: 1Gi
+          redis:
+            image:
+              repository: docker.io/redis
+              tag: "7-alpine"
+            command: ["redis-server", "--save", "", "--loglevel", "warning"]
+            resources:
+              requests:
+                cpu: 5m
+                memory: 32Mi
+              limits:
+                memory: 128Mi
 
     defaultPodOptions:
       priorityClassName: internal-only

--- a/kubernetes/apps/self-hosted/dawarich/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/dawarich/app/helmrelease.yaml
@@ -108,7 +108,7 @@ spec:
           redis:
             image:
               repository: docker.io/redis
-              tag: "7-alpine"
+              tag: "7.4-alpine"
             command: ["redis-server", "--save", "", "--loglevel", "warning"]
             resources:
               requests:

--- a/kubernetes/apps/self-hosted/dawarich/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/dawarich/app/helmrelease.yaml
@@ -97,7 +97,9 @@ spec:
               SELF_HOSTED: "true"
               STORE_GEODATA: "true"
               BACKGROUND_PROCESSING_CONCURRENCY: "5"
-              PROMETHEUS_EXPORTER_ENABLED: "false"
+              PROMETHEUS_EXPORTER_ENABLED: "true"
+              PROMETHEUS_EXPORTER_HOST: "127.0.0.1"
+              PROMETHEUS_EXPORTER_PORT: *metricsPort
             envFrom: *envFrom
             resources:
               requests:


### PR DESCRIPTION
## Summary

Refactors the Dawarich deployment to use a sidecar Redis container instead of relying on an external Redis service, and adds Host headers to health check probes for improved reliability.

## Changes

- **Health checks**: Added `Host: localhost` header to both startup and liveness probes for the main container, ensuring probes work correctly when the service expects specific Host headers
- **Redis migration**: 
  - Changed `REDIS_URL` from external Hindwing database service to `localhost:6379` for sidecar connectivity
  - Added dedicated Redis sidecar container with Alpine image (7.4-alpine)
  - Configured Redis with persistence disabled (`--save ""`) and warning-level logging
  - Set appropriate resource requests (5m CPU, 32Mi memory) and limits (128Mi memory)

## Implementation Details

The Redis sidecar runs in the same pod as the main Dawarich application, eliminating the external service dependency and simplifying the deployment topology. The sidecar is configured for minimal resource usage with persistence disabled since it serves as a cache layer.

https://claude.ai/code/session_01PSbydbraHoudPUgLjVaTNa