### PR TITLE
fix(dawarich): remove trailing slash from OIDC_ISSUER

### DIFF
--- a/kubernetes/apps/self-hosted/dawarich/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/dawarich/app/helmrelease.yaml
@@ -41,7 +41,7 @@ spec:
               PROMETHEUS_EXPORTER_ENABLED: "true"
               PROMETHEUS_EXPORTER_HOST: "0.0.0.0"
               PROMETHEUS_EXPORTER_PORT: &metricsPort "9394"
-              OIDC_ISSUER: https://id.zebernst.dev/
+              OIDC_ISSUER: https://id.zebernst.dev
               OIDC_PROVIDER_NAME: Pocket ID
               OIDC_REDIRECT_URI: https://dawarich.zebernst.dev/users/auth/openid_connect/callback
               OIDC_AUTO_REGISTER: "true"


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Removes trailing slash from `OIDC_ISSUER` env var (`https://id.zebernst.dev/` → `https://id.zebernst.dev`)

OmniAuth OIDC performs an exact string comparison between the configured issuer and the `issuer` field in Pocket ID's OIDC discovery document. Pocket ID's `APP_URL` has no trailing slash, so its discovery document returns `https://id.zebernst.dev` — the extra slash caused an `Issuer mismatch` error on every login attempt.

## Test plan

- [ ] Deploy rolls out cleanly
- [ ] Navigate to dawarich.zebernst.dev — redirected to Pocket ID login
- [ ] Authenticate via Pocket ID — redirected back and logged in successfully

https://claude.ai/code/session_01PSbydbraHoudPUgLjVaTNa
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PSbydbraHoudPUgLjVaTNa)_