### PR TITLE
Replace Loki with VictoriaLogs in Grafana datasources

### DIFF
--- a/kubernetes/apps/observability/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/grafana/app/helmrelease.yaml
@@ -24,7 +24,7 @@ spec:
     env:
       GF_DATE_FORMATS_USE_BROWSER_LOCALE: true
       GF_EXPLORE_ENABLED: true
-      GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS: natel-discrete-panel,pr0ps-trackmap-panel,panodata-map-panel,victoriametrics-logs-datasource
+      GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS: natel-discrete-panel,pr0ps-trackmap-panel,panodata-map-panel
       GF_SECURITY_ANGULAR_SUPPORT_ENABLED: true
       GF_SERVER_ROOT_URL: https://grafana.kite-harmonic.ts.net
     grafana.ini:
@@ -53,7 +53,6 @@ spec:
           - { name: Alertmanager, orgId: 1 }
           - { name: Loki, orgId: 1 }
           - { name: Prometheus, orgId: 1 }
-          - { name: VictoriaLogs, orgId: 1 }
         datasources:
           - name: Prometheus
             type: prometheus

--- a/kubernetes/apps/observability/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/grafana/app/helmrelease.yaml
@@ -24,7 +24,7 @@ spec:
     env:
       GF_DATE_FORMATS_USE_BROWSER_LOCALE: true
       GF_EXPLORE_ENABLED: true
-      GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS: natel-discrete-panel,pr0ps-trackmap-panel,panodata-map-panel
+      GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS: natel-discrete-panel,pr0ps-trackmap-panel,panodata-map-panel,victoriametrics-logs-datasource
       GF_SECURITY_ANGULAR_SUPPORT_ENABLED: true
       GF_SERVER_ROOT_URL: https://grafana.kite-harmonic.ts.net
     grafana.ini:
@@ -53,6 +53,7 @@ spec:
           - { name: Alertmanager, orgId: 1 }
           - { name: Loki, orgId: 1 }
           - { name: Prometheus, orgId: 1 }
+          - { name: VictoriaLogs, orgId: 1 }
         datasources:
           - name: Prometheus
             type: prometheus
@@ -60,9 +61,9 @@ spec:
             access: proxy
             url: http://prometheus-operated.observability.svc.cluster.local:9090
             isDefault: true
-          - name: Loki
-            type: loki
-            uid: loki
+          - name: VictoriaLogs
+            type: victoriametrics-logs-datasource
+            uid: victorialogs
             access: proxy
             url: http://victoria-logs-server.observability.svc.cluster.local:9428
             jsonData:
@@ -361,6 +362,7 @@ spec:
       - natel-discrete-panel
       - pr0ps-trackmap-panel
       - vonage-status-panel
+      - victoriametrics-logs-datasource
     serviceMonitor:
       enabled: true
     ingress:

--- a/kubernetes/apps/observability/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/grafana/app/helmrelease.yaml
@@ -53,6 +53,7 @@ spec:
           - { name: Alertmanager, orgId: 1 }
           - { name: Loki, orgId: 1 }
           - { name: Prometheus, orgId: 1 }
+          - { name: VictoriaLogs, orgId: 1 }
         datasources:
           - name: Prometheus
             type: prometheus


### PR DESCRIPTION
## Summary

Migrate Grafana's log aggregation datasource from Loki to VictoriaLogs, updating both the datasource configuration and required plugins.

## Changes

- **Datasource replacement**: Changed Loki datasource to VictoriaLogs with updated type (`victoriametrics-logs-datasource`) and UID (`victorialogs`)
- **Datasource organization**: Added VictoriaLogs to the list of datasources displayed in Grafana's organization view
- **Plugin dependency**: Added `victoriametrics-logs-datasource` plugin to Grafana's plugin list to support the new datasource type
- **Endpoint**: Maintained existing Victoria Logs server endpoint (`victoria-logs-server.observability.svc.cluster.local:9428`)

## Implementation Details

The VictoriaLogs datasource maintains the same network endpoint and access configuration as the previous Loki setup, ensuring continuity in log collection and querying capabilities. The datasource type change from `loki` to `victoriametrics-logs-datasource` requires the corresponding Grafana plugin to be installed.

https://claude.ai/code/session_01MXFjN8YZevNk21K17a5Bzn