### PR TITLE
feat: Terraform config for Tailscale tailnet management

### DIFF
--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,0 +1,6 @@
+.terraform/
+.terraform.lock.hcl
+terraform.tfstate
+terraform.tfstate.backup
+*.tfvars
+*.tfvars.json

--- a/terraform/acl.tf
+++ b/terraform/acl.tf
@@ -1,0 +1,34 @@
+resource "tailscale_acl" "main" {
+  # overwrite_existing_content bypasses the import requirement on first apply.
+  # Remove this after initial setup if you prefer explicit import.
+  overwrite_existing_content = true
+
+  acl = jsonencode({
+    tagOwners = {
+      # Kubernetes operator — manages subnet routes and proxy devices
+      "tag:k8s-operator" = ["autogroup:admin"]
+      "tag:k8s"          = ["autogroup:admin"]
+      # General servers (UDM Pro, NAS, etc.)
+      "tag:server"       = ["autogroup:admin"]
+    }
+
+    acls = [
+      # Default: allow all traffic. Tighten per-resource as needed.
+      {
+        action = "accept"
+        src    = ["*"]
+        dst    = ["*:*"]
+      },
+    ]
+
+    ssh = [
+      # Allow SSH from any tailnet device to tagged servers
+      {
+        action = "accept"
+        src    = ["autogroup:member"]
+        dst    = ["tag:server"]
+        users  = ["autogroup:nonroot"]
+      },
+    ]
+  })
+}

--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -1,0 +1,27 @@
+resource "tailscale_dns_preferences" "main" {
+  magic_dns = true
+}
+
+# Global fallback nameservers for domains not covered by split DNS
+resource "tailscale_dns_nameservers" "main" {
+  nameservers = [
+    "1.1.1.1",
+    "1.0.0.1",
+  ]
+}
+
+# Split DNS: route internal domain queries to UDM Pro dnsmasq,
+# which holds records synced by ExternalDNS
+resource "tailscale_dns_split_nameservers" "zebernst_dev" {
+  domain      = "zebernst.dev"
+  nameservers = [var.udm_pro_ip]
+}
+
+resource "tailscale_dns_split_nameservers" "internal" {
+  domain      = "internal"
+  nameservers = [var.udm_pro_ip]
+}
+
+resource "tailscale_dns_search_paths" "main" {
+  search_paths = ["internal"]
+}

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -1,0 +1,5 @@
+provider "tailscale" {
+  oauth_client_id     = var.tailscale_oauth_client_id
+  oauth_client_secret = var.tailscale_oauth_client_secret
+  tailnet             = var.tailnet
+}

--- a/terraform/settings.tf
+++ b/terraform/settings.tf
@@ -8,17 +8,3 @@ resource "tailscale_tailnet_settings" "main" {
   # Devices don't auto-expire keys; control expiry manually
   devices_key_duration_days = 180
 }
-
-resource "tailscale_contacts" "main" {
-  account {
-    email = "zach.bernstein@fastmail.com"
-  }
-
-  support {
-    email = "zach.bernstein@fastmail.com"
-  }
-
-  security {
-    email = "zach.bernstein@fastmail.com"
-  }
-}

--- a/terraform/settings.tf
+++ b/terraform/settings.tf
@@ -1,0 +1,24 @@
+resource "tailscale_tailnet_settings" "main" {
+  # Provision HTTPS certs for tailnet devices (needed for tailscale-unifi HTTPS)
+  https_enabled = true
+
+  # Prevent console edits since ACL is managed here
+  acls_externally_managed_on = true
+
+  # Devices don't auto-expire keys; control expiry manually
+  devices_key_duration_days = 180
+}
+
+resource "tailscale_contacts" "main" {
+  account {
+    email = "zach.bernstein@fastmail.com"
+  }
+
+  support {
+    email = "zach.bernstein@fastmail.com"
+  }
+
+  security {
+    email = "zach.bernstein@fastmail.com"
+  }
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,23 @@
+variable "tailscale_oauth_client_id" {
+  description = "Tailscale OAuth client ID for Terraform"
+  type        = string
+  sensitive   = true
+}
+
+variable "tailscale_oauth_client_secret" {
+  description = "Tailscale OAuth client secret for Terraform"
+  type        = string
+  sensitive   = true
+}
+
+variable "tailnet" {
+  description = "Tailscale tailnet name"
+  type        = string
+  default     = "kite-harmonic.ts.net"
+}
+
+variable "udm_pro_ip" {
+  description = "UDM Pro IP used as DNS nameserver for internal domains"
+  type        = string
+  default     = "192.168.1.1"
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    tailscale = {
+      source  = "tailscale/tailscale"
+      version = "~> 0.29"
+    }
+  }
+
+  # Uncomment to persist state to Backblaze B2
+  # backend "s3" {
+  #   bucket                      = "<bucket-name>"
+  #   key                         = "terraform/tailscale.tfstate"
+  #   region                      = "us-west-004"
+  #   endpoint                    = "https://s3.us-west-004.backblazeb2.com"
+  #   skip_credentials_validation = true
+  #   skip_metadata_api_check     = true
+  #   skip_region_validation      = true
+  #   force_path_style            = true
+  # }
+}


### PR DESCRIPTION
## Summary

- Adds `terraform/` with a new Tailscale provider config to codify tailnet settings as IaC
- **DNS** (`dns.tf`): MagicDNS enabled, global nameservers (1.1.1.1/1.0.0.1), split DNS routing `zebernst.dev` and `internal` to the UDM Pro (`192.168.1.1`), search path for `internal`
- **Settings** (`settings.tf`): HTTPS cert provisioning, 180-day key duration, `acls_externally_managed_on` to prevent console drift, contacts
- **ACL** (`acl.tf`): Baseline allow-all policy with `tagOwners` for `tag:k8s-operator`, `tag:k8s`, and `tag:server` — scaffolded for future tightening

## Notes

- Requires a dedicated Tailscale OAuth client (separate from the k8s operator's); create one at admin.tailscale.com with `all:write` scopes
- State defaults to local; `versions.tf` has a commented-out B2 backend block ready to enable
- `overwrite_existing_content = true` on the ACL resource handles first-apply bootstrap without needing an import step

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDqB8h58pmXq8j6ejT7Qtx)_