### PR TITLE
chore(dawarich): add prom alerting for location sync staleness

### DIFF
--- a/kubernetes/apps/self-hosted/dawarich/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/dawarich/app/helmrelease.yaml
@@ -101,6 +101,7 @@ spec:
               RAILS_LOG_TO_STDOUT: "true"
               SELF_HOSTED: "true"
               STORE_GEODATA: "true"
+              TIME_ZONE: America/Chicago
               BACKGROUND_PROCESSING_CONCURRENCY: "5"
               PROMETHEUS_EXPORTER_ENABLED: "true"
               PROMETHEUS_EXPORTER_HOST: "127.0.0.1"

--- a/kubernetes/apps/self-hosted/dawarich/app/kustomization.yaml
+++ b/kubernetes/apps/self-hosted/dawarich/app/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - cluster.yaml
   - externalsecret.yaml
   - helmrelease.yaml
+  - prometheusrule.yaml

--- a/kubernetes/apps/self-hosted/dawarich/app/prometheusrule.yaml
+++ b/kubernetes/apps/self-hosted/dawarich/app/prometheusrule.yaml
@@ -10,8 +10,8 @@ spec:
       rules:
         - alert: DawarichLocationSyncStale
           expr: |
-            changes(dawarich_points_count[25h]) == 0
-          for: 10m
+            increase(ruby_http_requests_total{controller="api/v1/points", action="create"}[25h]) == 0
+          for: 15m
           annotations:
             summary: Dawarich location sync stopped
             description: >-

--- a/kubernetes/apps/self-hosted/dawarich/app/prometheusrule.yaml
+++ b/kubernetes/apps/self-hosted/dawarich/app/prometheusrule.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/prometheusrule_v1.json
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: dawarich
+spec:
+  groups:
+    - name: dawarich.rules
+      rules:
+        - alert: DawarichLocationSyncStale
+          expr: |
+            changes(dawarich_points_count[25h]) == 0
+          for: 10m
+          annotations:
+            summary: Dawarich location sync stopped
+            description: >-
+              No new location data has been received by Dawarich in over 24 hours.
+              The iPhone app may have stopped syncing — check the app and its configuration.
+          labels:
+            severity: warning


### PR DESCRIPTION
## Summary

Adds monitoring and alerting for the Dawarich location tracking application to detect when location data syncing has stopped.

## Changes

- **New PrometheusRule**: Created `prometheusrule.yaml` with a `DawarichLocationSyncStale` alert that triggers when no location data has been received in over 24 hours
  - Alert expression monitors the `ruby_http_requests_total` metric for the location creation endpoint
  - 15-minute evaluation window to avoid flapping
  - Warning severity with actionable description for troubleshooting the iPhone app
- **Timezone configuration**: Added `TIME_ZONE: America/Chicago` environment variable to the Dawarich HelmRelease for proper timestamp handling
- **Kustomization update**: Registered the new PrometheusRule in `kustomization.yaml` for deployment

## Implementation Details

The alert uses the Prometheus metric `increase(ruby_http_requests_total{controller="api/v1/points", action="create"}[25h]) == 0` to detect when the location sync endpoint hasn't received requests in over 24 hours, indicating the mobile app has stopped syncing location data.

https://claude.ai/code/session_01Sbhzhi43y2oMHySuhNxSVR