### PR TITLE
fix(vmalert): use glob pattern for rules directory

### DIFF
--- a/kubernetes/apps/observability/vmalert/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/vmalert/app/helmrelease.yaml
@@ -40,7 +40,7 @@ spec:
               repository: quay.io/victoriametrics/vmalert
               tag: v1.110.0@sha256:f4054ae50dede7e0c4439484802a26e195802ed300c6e085f682407e946afe46
             args:
-              - --rule=/rules
+              - --rule=/rules/*.yaml
               - --rule.defaultRuleType=vlogs
               - --datasource.url=http://victoria-logs-server.observability.svc.cluster.local:9428
               - --notifier.url=http://alertmanager-operated.observability.svc.cluster.local:9093


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

vmalert was failing to start with:

```
fatal: cannot parse configuration file: ... error while reading file "/rules": read /rules: is a directory
```

The `--rule` flag expects a file path or glob pattern, not a bare directory. The k8s-sidecar init container writes individual `.yaml` rule files into `/rules` from ConfigMaps labeled `vmalert.io/rule`.

## Fix

Change `--rule=/rules` to `--rule=/rules/*.yaml` so vmalert loads the sidecar-synced rule files instead of trying to read the mount point as a single file.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01df7aa9-b400-4c84-a61b-c44a18097f67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01df7aa9-b400-4c84-a61b-c44a18097f67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

