### PR TITLE
fix(vmalert-rules): enable Flux substitution for APP variable

### DIFF
--- a/kubernetes/components/vmalert-rules/kustomization.yaml
+++ b/kubernetes/components/vmalert-rules/kustomization.yaml
@@ -11,5 +11,3 @@ configMapGenerator:
         vmalert.io/rule: "true"
 generatorOptions:
   disableNameSuffixHash: true
-  annotations:
-    kustomize.toolkit.fluxcd.io/substitute: disabled


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Flux reconciliation fails for downloads apps using the `vmalert-rules` component (bazarr, lidarr, prowlarr, radarr, sonarr, whisparr):

```
ConfigMap "${APP}-vmalert-rules" is invalid: metadata.name: Invalid value: "${APP}-vmalert-rules"
```

## Root cause

The `vmalert-rules` component generates a ConfigMap with `${APP}` placeholders in the name and data keys. These are meant to be substituted by Flux `postBuild.substitute` (configured in each app's `ks.yaml`).

However, the component had `kustomize.toolkit.fluxcd.io/substitute: disabled` on its `generatorOptions`, which prevented Flux from performing that substitution — leaving literal `${APP}` in the rendered manifest.

The `gatus` component uses the same `${APP}` pattern without this annotation and works correctly.

## Fix

Remove the `substitute: disabled` annotation from `kubernetes/components/vmalert-rules/kustomization.yaml` so Flux can substitute `${APP}` in the ConfigMap name, data key, and alert rule content.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a7a0073d-86e1-4f6a-ab6b-06fe9c93c2e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a7a0073d-86e1-4f6a-ab6b-06fe9c93c2e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

