### PR TITLE
Close backup gaps: dawarich-db, hindwing, Minecraft mc-backup, stash metadata

### DIFF
--- a/kubernetes/apps/database/dragonfly/cluster/cluster.yaml
+++ b/kubernetes/apps/database/dragonfly/cluster/cluster.yaml
@@ -13,19 +13,32 @@ spec:
     - --cluster_mode=emulated
     - --lock_on_hashtags
     - --default_lua_flags=allow-undeclared-keys
+    - --s3_endpoint=https://s3.us-west-001.backblazeb2.com
   env:
     - name: MAX_MEMORY
       valueFrom:
         resourceFieldRef:
           resource: limits.memory
           divisor: 1Mi
+    - name: AWS_ACCESS_KEY_ID
+      valueFrom:
+        secretKeyRef:
+          name: hindwing-s3-secret
+          key: AWS_ACCESS_KEY_ID
+    - name: AWS_SECRET_ACCESS_KEY
+      valueFrom:
+        secretKeyRef:
+          name: hindwing-s3-secret
+          key: AWS_SECRET_ACCESS_KEY
+  snapshot:
+    cron: "15 */4 * * *"
+    dir: s3://cluster-db-backup/hindwing
+    enableOnMasterOnly: true
   resources:
     requests:
       cpu: 100m
     limits:
       memory: 512Mi
-#  snapshot:
-#    dir: s3://
   serviceSpec:
     type: LoadBalancer
     annotations:

--- a/kubernetes/apps/database/dragonfly/cluster/externalsecret.yaml
+++ b/kubernetes/apps/database/dragonfly/cluster/externalsecret.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: hindwing-s3
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: hindwing-s3-secret
+  data:
+    - secretKey: AWS_ACCESS_KEY_ID
+      remoteRef:
+        key: barman-b2-credentials
+        property: AWS_ACCESS_KEY_ID
+    - secretKey: AWS_SECRET_ACCESS_KEY
+      remoteRef:
+        key: barman-b2-credentials
+        property: AWS_SECRET_ACCESS_KEY

--- a/kubernetes/apps/database/dragonfly/cluster/kustomization.yaml
+++ b/kubernetes/apps/database/dragonfly/cluster/kustomization.yaml
@@ -4,5 +4,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - cluster.yaml
+  - externalsecret.yaml
   - networkpolicy.yaml
   - vmpodscrape.yaml

--- a/kubernetes/apps/database/dragonfly/ks.yaml
+++ b/kubernetes/apps/database/dragonfly/ks.yaml
@@ -33,6 +33,8 @@ spec:
       app.kubernetes.io/name: *app
   dependsOn:
     - name: dragonfly
+    - name: onepassword
+      namespace: external-secrets
     - name: victoria-metrics-operator
       namespace: observability
   path: kubernetes/apps/database/dragonfly/cluster

--- a/kubernetes/apps/downloads/recyclarr/ks.yaml
+++ b/kubernetes/apps/downloads/recyclarr/ks.yaml
@@ -23,7 +23,3 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 5m
-  postBuild:
-    substitute:
-      APP: *app
-      VOLSYNC_CAPACITY: 1Gi

--- a/kubernetes/apps/games/minecraft/atm10/app/helmrelease.yaml
+++ b/kubernetes/apps/games/minecraft/atm10/app/helmrelease.yaml
@@ -29,6 +29,24 @@ spec:
         annotations:
           reloader.stakater.com/auto: "true"
         initContainers:
+          restore-world:
+            image:
+              repository: itzg/mc-backup
+              tag: 2026.5.0
+            command: ["/bin/bash", "/scripts/restore.sh"]
+            envFrom:
+              - secretRef:
+                  name: atm10-restic-secret
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                memory: 256Mi
           init-bluemap-config:
             image:
               repository: busybox
@@ -128,6 +146,35 @@ spec:
                 memory: 1Gi
               limits:
                 memory: 4Gi
+          mc-backup:
+            image:
+              repository: itzg/mc-backup
+              tag: 2026.5.0
+            env:
+              BACKUP_METHOD: restic
+              BACKUP_NAME: *app
+              RESTIC_HOSTNAME: *app
+              BACKUP_INTERVAL: 4h
+              PRUNE_RESTIC_RETENTION: "--keep-hourly 24 --keep-daily 7"
+              RCON_HOST: localhost
+              INITIAL_DELAY: 2m
+              BACKUP_ON_STARTUP: "true"
+              EXCLUDES: "*.jar,cache,logs,*.tmp"
+            envFrom:
+              - secretRef:
+                  name: atm10-restic-secret
+              - secretRef:
+                  name: atm10-secret
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                memory: 256Mi
 
     defaultPodOptions:
       securityContext:
@@ -187,6 +234,11 @@ spec:
             bluemap:
               - path: /data
                 readOnly: true
+            restore-world:
+              - path: /data
+            mc-backup:
+              - path: /data
+                readOnly: true
       bluemap-shared:
         existingClaim: bluemap-shared
         advancedMounts:
@@ -227,3 +279,12 @@ spec:
               - path: /app/config
             bluemap:
               - path: /app/config
+      mc-backup-restore:
+        type: configMap
+        name: mc-backup-restore
+        defaultMode: 0755
+        advancedMounts:
+          atm10:
+            restore-world:
+              - path: /scripts/restore.sh
+                subPath: restore.sh

--- a/kubernetes/apps/games/minecraft/atm10/ks.yaml
+++ b/kubernetes/apps/games/minecraft/atm10/ks.yaml
@@ -11,7 +11,7 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   components:
-    - ../../../../../components/volsync
+    - ../../../../../components/mc-backup
   dependsOn:
     - name: bluemap
       namespace: games
@@ -19,8 +19,6 @@ spec:
       namespace: external-secrets
     - name: rook-ceph-cluster
       namespace: rook-ceph
-    - name: volsync
-      namespace: volsync-system
   path: kubernetes/apps/games/minecraft/atm10/app
   prune: true
   sourceRef:
@@ -34,9 +32,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      VOLSYNC_CAPACITY: 30Gi
-      VOLSYNC_CACHE_CAPACITY: 30Gi
-      VOLSYNC_STORAGECLASS: ceph-filesystem
-      VOLSYNC_ACCESSMODES: ReadWriteMany
-      VOLSYNC_SNAPSHOTCLASS: csi-ceph-filesystem
-      VOLSYNC_SNAP_ACCESSMODES: ReadWriteMany
+      MC_BACKUP_CAPACITY: 30Gi
+      MC_BACKUP_STORAGECLASS: ceph-filesystem
+      MC_BACKUP_ACCESSMODES: ReadWriteMany

--- a/kubernetes/apps/games/minecraft/atmons/app/helmrelease.yaml
+++ b/kubernetes/apps/games/minecraft/atmons/app/helmrelease.yaml
@@ -29,6 +29,24 @@ spec:
         annotations:
           reloader.stakater.com/auto: "true"
         initContainers:
+          restore-world:
+            image:
+              repository: itzg/mc-backup
+              tag: 2026.5.0
+            command: ["/bin/bash", "/scripts/restore.sh"]
+            envFrom:
+              - secretRef:
+                  name: atmons-restic-secret
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                memory: 256Mi
           init-bluemap-config:
             image:
               repository: busybox
@@ -130,6 +148,35 @@ spec:
                 memory: 1Gi
               limits:
                 memory: 4Gi
+          mc-backup:
+            image:
+              repository: itzg/mc-backup
+              tag: 2026.5.0
+            env:
+              BACKUP_METHOD: restic
+              BACKUP_NAME: *app
+              RESTIC_HOSTNAME: *app
+              BACKUP_INTERVAL: 4h
+              PRUNE_RESTIC_RETENTION: "--keep-hourly 24 --keep-daily 7"
+              RCON_HOST: localhost
+              INITIAL_DELAY: 2m
+              BACKUP_ON_STARTUP: "true"
+              EXCLUDES: "*.jar,cache,logs,*.tmp"
+            envFrom:
+              - secretRef:
+                  name: atmons-restic-secret
+              - secretRef:
+                  name: atmons-secret
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                memory: 256Mi
 
     defaultPodOptions:
       securityContext:
@@ -189,6 +236,11 @@ spec:
             bluemap:
               - path: /data
                 readOnly: true
+            restore-world:
+              - path: /data
+            mc-backup:
+              - path: /data
+                readOnly: true
       bluemap-shared:
         existingClaim: bluemap-shared
         advancedMounts:
@@ -229,3 +281,12 @@ spec:
               - path: /app/config
             bluemap:
               - path: /app/config
+      mc-backup-restore:
+        type: configMap
+        name: mc-backup-restore
+        defaultMode: 0755
+        advancedMounts:
+          atmons:
+            restore-world:
+              - path: /scripts/restore.sh
+                subPath: restore.sh

--- a/kubernetes/apps/games/minecraft/atmons/ks.yaml
+++ b/kubernetes/apps/games/minecraft/atmons/ks.yaml
@@ -11,7 +11,7 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   components:
-    - ../../../../../components/volsync
+    - ../../../../../components/mc-backup
   dependsOn:
     - name: bluemap
       namespace: games
@@ -19,8 +19,6 @@ spec:
       namespace: external-secrets
     - name: rook-ceph-cluster
       namespace: rook-ceph
-    - name: volsync
-      namespace: volsync-system
   path: kubernetes/apps/games/minecraft/atmons/app
   prune: true
   sourceRef:
@@ -34,9 +32,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      VOLSYNC_CAPACITY: 30Gi
-      VOLSYNC_CACHE_CAPACITY: 30Gi
-      VOLSYNC_STORAGECLASS: ceph-filesystem
-      VOLSYNC_ACCESSMODES: ReadWriteMany
-      VOLSYNC_SNAPSHOTCLASS: csi-ceph-filesystem
-      VOLSYNC_SNAP_ACCESSMODES: ReadWriteMany
+      MC_BACKUP_CAPACITY: 30Gi
+      MC_BACKUP_STORAGECLASS: ceph-filesystem
+      MC_BACKUP_ACCESSMODES: ReadWriteMany

--- a/kubernetes/apps/games/minecraft/vanilla/app/helmrelease.yaml
+++ b/kubernetes/apps/games/minecraft/vanilla/app/helmrelease.yaml
@@ -18,6 +18,24 @@ spec:
         annotations:
           reloader.stakater.com/auto: "true"
         initContainers:
+          restore-world:
+            image:
+              repository: itzg/mc-backup
+              tag: 2026.5.0
+            command: ["/bin/bash", "/scripts/restore.sh"]
+            envFrom:
+              - secretRef:
+                  name: vanilla-restic-secret
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                memory: 256Mi
           init-bluemap-config:
             image:
               repository: busybox
@@ -117,6 +135,35 @@ spec:
                 memory: 512Mi
               limits:
                 memory: 1536Mi
+          mc-backup:
+            image:
+              repository: itzg/mc-backup
+              tag: 2026.5.0
+            env:
+              BACKUP_METHOD: restic
+              BACKUP_NAME: *app
+              RESTIC_HOSTNAME: *app
+              BACKUP_INTERVAL: 4h
+              PRUNE_RESTIC_RETENTION: "--keep-hourly 24 --keep-daily 7"
+              RCON_HOST: localhost
+              INITIAL_DELAY: 2m
+              BACKUP_ON_STARTUP: "true"
+              EXCLUDES: "*.jar,cache,logs,*.tmp"
+            envFrom:
+              - secretRef:
+                  name: vanilla-restic-secret
+              - secretRef:
+                  name: vanilla-secret
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                memory: 256Mi
 
     defaultPodOptions:
       priorityClassName: best-effort
@@ -173,6 +220,11 @@ spec:
             bluemap:
               - path: /data
                 readOnly: true
+            restore-world:
+              - path: /data
+            mc-backup:
+              - path: /data
+                readOnly: true
       bluemap-shared:
         existingClaim: bluemap-shared
         advancedMounts:
@@ -213,3 +265,12 @@ spec:
               - path: /app/config
             bluemap:
               - path: /app/config
+      mc-backup-restore:
+        type: configMap
+        name: mc-backup-restore
+        defaultMode: 0755
+        advancedMounts:
+          vanilla:
+            restore-world:
+              - path: /scripts/restore.sh
+                subPath: restore.sh

--- a/kubernetes/apps/games/minecraft/vanilla/ks.yaml
+++ b/kubernetes/apps/games/minecraft/vanilla/ks.yaml
@@ -11,7 +11,7 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   components:
-    - ../../../../../components/volsync
+    - ../../../../../components/mc-backup
   dependsOn:
     - name: bluemap
       namespace: games
@@ -19,8 +19,6 @@ spec:
       namespace: external-secrets
     - name: rook-ceph-cluster
       namespace: rook-ceph
-    - name: volsync
-      namespace: volsync-system
   path: kubernetes/apps/games/minecraft/vanilla/app
   prune: true
   sourceRef:
@@ -34,9 +32,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      VOLSYNC_CAPACITY: 10Gi
-      VOLSYNC_CACHE_CAPACITY: 10Gi
-      VOLSYNC_STORAGECLASS: ceph-filesystem
-      VOLSYNC_ACCESSMODES: ReadWriteMany
-      VOLSYNC_SNAPSHOTCLASS: csi-ceph-filesystem
-      VOLSYNC_SNAP_ACCESSMODES: ReadWriteMany
+      MC_BACKUP_CAPACITY: 10Gi
+      MC_BACKUP_STORAGECLASS: ceph-filesystem
+      MC_BACKUP_ACCESSMODES: ReadWriteMany

--- a/kubernetes/apps/media/stash/app/helmrelease.yaml
+++ b/kubernetes/apps/media/stash/app/helmrelease.yaml
@@ -104,6 +104,8 @@ spec:
             subPath: config
           - path: /blobs
             subPath: blobs
+          - path: /metadata
+            subPath: metadata
       cache:
         existingClaim: stash-cache
         globalMounts:
@@ -111,8 +113,6 @@ spec:
             subPath: cache
           - path: /generated
             subPath: generated
-          - path: /metadata
-            subPath: metadata
           - path: /pip-install
             subPath: pip
       media:

--- a/kubernetes/apps/self-hosted/dawarich/app/cluster.yaml
+++ b/kubernetes/apps/self-hosted/dawarich/app/cluster.yaml
@@ -26,3 +26,21 @@ spec:
       memory: 1Gi
   monitoring:
     enablePodMonitor: true
+  backup:
+    retentionPolicy: 30d
+    barmanObjectStore:
+      data:
+        compression: bzip2
+      wal:
+        compression: bzip2
+        maxParallel: 8
+      destinationPath: s3://cluster-db-backup/
+      endpointURL: https://s3.us-west-001.backblazeb2.com
+      serverName: dawarich-db-v1
+      s3Credentials:
+        accessKeyId:
+          name: dawarich-db-secret
+          key: aws-access-key-id
+        secretAccessKey:
+          name: dawarich-db-secret
+          key: aws-secret-access-key

--- a/kubernetes/apps/self-hosted/dawarich/app/externalsecret.yaml
+++ b/kubernetes/apps/self-hosted/dawarich/app/externalsecret.yaml
@@ -18,9 +18,13 @@ spec:
       data:
         username: "{{ .POSTGRES_SUPER_USER }}"
         password: "{{ .POSTGRES_SUPER_PASS }}"
+        aws-access-key-id: "{{ .AWS_ACCESS_KEY_ID }}"
+        aws-secret-access-key: "{{ .AWS_SECRET_ACCESS_KEY }}"
   dataFrom:
     - extract:
         key: dawarich
+    - extract:
+        key: barman-b2-credentials
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
 apiVersion: external-secrets.io/v1

--- a/kubernetes/apps/self-hosted/dawarich/app/kustomization.yaml
+++ b/kubernetes/apps/self-hosted/dawarich/app/kustomization.yaml
@@ -8,5 +8,6 @@ resources:
   - cluster.yaml
   - externalsecret.yaml
   - helmrelease.yaml
+  - scheduledbackup.yaml
   - vmservicescrape.yaml
   - vmrule.yaml

--- a/kubernetes/apps/self-hosted/dawarich/app/scheduledbackup.yaml
+++ b/kubernetes/apps/self-hosted/dawarich/app/scheduledbackup.yaml
@@ -1,0 +1,12 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/postgresql.cnpg.io/scheduledbackup_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: dawarich-db
+spec:
+  schedule: "@daily"
+  immediate: true
+  backupOwnerReference: self
+  cluster:
+    name: dawarich-db

--- a/kubernetes/components/mc-backup/externalsecret.yaml
+++ b/kubernetes/components/mc-backup/externalsecret.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: "${APP}-restic"
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: "${APP}-restic-secret"
+    template:
+      data:
+        RESTIC_REPOSITORY: "s3:{{ .REPOSITORY_TEMPLATE }}/${APP}"
+        RESTIC_PASSWORD: "{{ .RESTIC_PASSWORD }}"
+        AWS_ACCESS_KEY_ID: "{{ .AWS_ACCESS_KEY_ID }}"
+        AWS_SECRET_ACCESS_KEY: "{{ .AWS_SECRET_ACCESS_KEY }}"
+  dataFrom:
+    - extract:
+        key: volsync-restic-template

--- a/kubernetes/components/mc-backup/kustomization.yaml
+++ b/kubernetes/components/mc-backup/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - externalsecret.yaml
+  - pvc.yaml
+  - restore-configmap.yaml

--- a/kubernetes/components/mc-backup/pvc.yaml
+++ b/kubernetes/components/mc-backup/pvc.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: "${APP}"
+spec:
+  accessModes: ["${MC_BACKUP_ACCESSMODES:=ReadWriteOnce}"]
+  resources:
+    requests:
+      storage: "${MC_BACKUP_CAPACITY:=5Gi}"
+  storageClassName: "${MC_BACKUP_STORAGECLASS:=ceph-block}"

--- a/kubernetes/components/mc-backup/restore-configmap.yaml
+++ b/kubernetes/components/mc-backup/restore-configmap.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mc-backup-restore
+data:
+  restore.sh: |
+    #!/bin/bash
+    set -euo pipefail
+
+    if [[ -f /data/eula.txt ]]; then
+      echo "World data present, skipping restic restore"
+      exit 0
+    fi
+
+    echo "Empty world data, restoring latest restic snapshot..."
+    restic snapshots >/dev/null
+    restic restore latest --target /data


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses backup audit findings by adding off-cluster backup for previously unprotected stateful data, replacing Minecraft Volsync with crash-consistent mc-backup, and fixing related config issues.

Rebased on current `main` (2026-07-26). Backup audit notes appended to bead **homelab-l8t** (Cluster teardown/rebuild) via Dolt — not the duplicate jsonl bead.

## Changes

### dawarich-db CNPG backup
- Added `spec.backup.barmanObjectStore` targeting B2 (`serverName: dawarich-db-v1`)
- Added daily `ScheduledBackup`; extended `dawarich-db-secret` with B2 creds

### Dragonfly hindwing backup
- S3 snapshots to `s3://cluster-db-backup/hindwing` every 4h with B2 endpoint + credentials
- Merged with main's networkpolicy/vmpodscrape changes

### Minecraft: Volsync → mc-backup
- New `kubernetes/components/mc-backup` component
- vanilla/atm10/atmons: init restore + mc-backup sidecar (Restic → B2, 4h interval)

### Stash metadata
- Moved `/metadata` from cache PVC to volsync-backed `stash` PVC

### recyclarr cleanup
- Removed orphaned `VOLSYNC_CAPACITY` substitute

## Beads

- **homelab-l8t** — Cluster teardown/rebuild (the correct bead; linked to **homelab-0a4** miroir)
- Audit notes pushed to Dolt remote
- Dropped erroneous **homelab-cdr** jsonl entry (wrong format; main uses Dolt beads)

## Post-merge checklist

- [ ] Copy Stash metadata subpath on live cluster
- [ ] Verify mc-backup RCON backups succeed
- [ ] Verify dawarich-db + hindwing snapshots in B2
- [ ] Run restore drill before homelab-l8t teardown

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f26e9d05-6ee4-4024-ad79-104df5e40be2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f26e9d05-6ee4-4024-ad79-104df5e40be2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

