### PR TITLE
fix(nominatim): parse single base region for PBF_URL

### DIFF
--- a/kubernetes/apps/self-hosted/nominatim/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/nominatim/app/helmrelease.yaml
@@ -52,7 +52,7 @@ spec:
             command: ["/bin/bash", "-ec"]
             args:
               - |
-                FIRST_REGION="$(echo "$${NOMINATIM_REGIONS}" | tr ',' ' ' | awk '{print $1}')"
+                FIRST_REGION="$(printf '%s\n' "$${NOMINATIM_REGIONS}" | tr ',[:space:]' '\n' | sed '/^[[:space:]]*$/d' | awk 'NR==1 { print; exit }')"
                 if [ -z "$${FIRST_REGION}" ]; then
                   echo "NOMINATIM_REGIONS must include at least one region"
                   exit 1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- fix startup region parsing in the Nominatim HelmRelease command
- derive `FIRST_REGION` from the first non-empty token across comma/space/newline-separated `NOMINATIM_REGIONS`
- prevent multiline region lists from producing malformed `PBF_URL` values

## Problem

When `NOMINATIM_REGIONS` is configured as a multiline YAML string, the previous logic (`awk '{print $1}'`) emitted the first token from every line. That produced a multiline `PBF_URL` and curl failed with `URL rejected: Malformed input to a URL function`.

## Result

`PBF_URL` now always points to exactly one extract URL for bootstrap import.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6b63079c-d91c-470e-be2d-6994348564f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6b63079c-d91c-470e-be2d-6994348564f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

