### PR TITLE
feat(nominatim): enable wikipedia and US postcode imports

### DIFF
--- a/kubernetes/apps/self-hosted/nominatim/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/nominatim/app/helmrelease.yaml
@@ -77,6 +77,8 @@ spec:
               # Disable the image's built-in replication loop; updates are managed by CronJob.
               UPDATE_MODE: "none"
               REPLICATION_URL: ""
+              IMPORT_WIKIPEDIA: "true"
+              IMPORT_US_POSTCODES: "true"
               PROJECT_DIR: /nominatim
             envFrom:
               - secretRef:
@@ -288,3 +290,11 @@ spec:
             nominatim:
               - path: /scripts/maintain-regions.sh
                 subPath: maintain-regions.sh
+      dev-shm:
+        type: emptyDir
+        medium: Memory
+        sizeLimit: 4Gi
+        advancedMounts:
+          nominatim:
+            nominatim:
+              - path: /dev/shm

--- a/kubernetes/apps/self-hosted/nominatim/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/nominatim/app/helmrelease.yaml
@@ -58,6 +58,15 @@ spec:
                   exit 1
                 fi
                 export PBF_URL="$${NOMINATIM_DOWNURL:-https://download.geofabrik.de}/$${FIRST_REGION}-latest.osm.pbf"
+                OSMFILE="$${PROJECT_DIR:-/nominatim}/data.osm.pbf"
+                if [ -f "$${OSMFILE}" ]; then
+                  REMOTE_SIZE="$(curl -fsIL "$${PBF_URL}" | awk 'tolower($1)==\"content-length:\" {gsub(\"\\r\",\"\",$2); len=$2} END {print len}')"
+                  LOCAL_SIZE="$(stat -c %s "$${OSMFILE}")"
+                  if [ -n "$${REMOTE_SIZE}" ] && [ "$${LOCAL_SIZE}" -gt "$${REMOTE_SIZE}" ]; then
+                    echo "Removing stale OSM extract ($${LOCAL_SIZE} bytes > remote $${REMOTE_SIZE} bytes): $${OSMFILE}"
+                    rm -f "$${OSMFILE}"
+                  fi
+                fi
                 exec /app/start.sh
             env:
               # Geofabrik region paths (newline, space, or comma separated).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- enable `IMPORT_WIKIPEDIA` for Nominatim bootstrap data enrichment
- enable `IMPORT_US_POSTCODES` to improve US postal-code lookup coverage
- add a memory-backed `/dev/shm` mount with `sizeLimit: 4Gi` for import-time shared memory needs
- add startup preflight logic to remove stale oversized `/nominatim/data.osm.pbf` before the image's `curl -C -` resume step

## Why the stale-file guard

A prior malformed `PBF_URL` left an oversized stale `data.osm.pbf` on the project volume. Upstream `init.sh` always resumes downloads with `-C -`, which then attempted resume from an invalid offset and failed with `curl: (23) Failure writing output to destination`.

The preflight guard compares local file size to remote `Content-Length` and removes the local file when it is larger than upstream, allowing bootstrap download to proceed cleanly.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6b63079c-d91c-470e-be2d-6994348564f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6b63079c-d91c-470e-be2d-6994348564f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

