### PR TITLE
fix(nominatim): repair stale extract guard parsing

### DIFF
--- a/kubernetes/apps/self-hosted/nominatim/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/nominatim/app/helmrelease.yaml
@@ -60,7 +60,7 @@ spec:
                 export PBF_URL="$${NOMINATIM_DOWNURL:-https://download.geofabrik.de}/$${FIRST_REGION}-latest.osm.pbf"
                 OSMFILE="$${PROJECT_DIR:-/nominatim}/data.osm.pbf"
                 if [ -f "$${OSMFILE}" ]; then
-                  REMOTE_SIZE="$(curl -fsIL "$${PBF_URL}" | awk 'tolower($1)==\"content-length:\" {gsub(\"\\r\",\"\",$2); len=$2} END {print len}')"
+                  REMOTE_SIZE="$(curl -fsIL "$${PBF_URL}" | grep -Fi 'content-length:' | tail -n1 | sed 's/.*:[[:space:]]*//' | tr -d '\r')"
                   LOCAL_SIZE="$(stat -c %s "$${OSMFILE}")"
                   if [ -n "$${REMOTE_SIZE}" ] && [ "$${LOCAL_SIZE}" -gt "$${REMOTE_SIZE}" ]; then
                     echo "Removing stale OSM extract ($${LOCAL_SIZE} bytes > remote $${REMOTE_SIZE} bytes): $${OSMFILE}"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- fix startup preflight parsing for stale `/nominatim/data.osm.pbf` cleanup
- replace broken awk quoting with `grep`/`sed` header parsing

## Problem

The stale extract guard used awk with escaped quotes that rendered incorrectly at runtime:

- `awk: 1: unexpected character '\'`
- `awk: line 1: runaway string constant "content-le ...`

## Result

Startup no longer fails in the preflight step; stale-file removal still runs only when remote `Content-Length` is available and local size exceeds it.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6b63079c-d91c-470e-be2d-6994348564f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6b63079c-d91c-470e-be2d-6994348564f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

