### PR TITLE
fix(nominatim): stage bootstrap downloads on ephemeral storage

### DIFF
--- a/kubernetes/apps/self-hosted/nominatim/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/nominatim/app/helmrelease.yaml
@@ -58,7 +58,31 @@ spec:
                   exit 1
                 fi
                 export PBF_URL="$${NOMINATIM_DOWNURL:-https://download.geofabrik.de}/$${FIRST_REGION}-latest.osm.pbf"
-                OSMFILE="$${PROJECT_DIR:-/nominatim}/data.osm.pbf"
+                STAGING_DIR="/import-staging"
+                PROJECT_DIR="$${PROJECT_DIR:-/nominatim}"
+                mkdir -p "$${STAGING_DIR}"
+
+                link_staging() {
+                  local name="$1"
+                  local link="$${PROJECT_DIR}/$${name}"
+                  local target="$${STAGING_DIR}/$${name}"
+
+                  if [ -e "$${link}" ] && [ ! -L "$${link}" ]; then
+                    echo "Removing stale import artifact from project volume: $${link}"
+                    rm -f "$${link}"
+                  fi
+
+                  ln -sfn "$${target}" "$${link}"
+                }
+
+                link_staging "data.osm.pbf"
+                link_staging "wikimedia-importance.csv.gz"
+                link_staging "us_postcodes.csv.gz"
+                link_staging "secondary_importance.sql.gz"
+                link_staging "gb_postcodes.csv.gz"
+                link_staging "tiger-nominatim-preprocessed.csv.tar.gz"
+
+                OSMFILE="$${STAGING_DIR}/data.osm.pbf"
                 if [ -f "$${OSMFILE}" ]; then
                   REMOTE_SIZE="$(curl -fsIL "$${PBF_URL}" | grep -Fi 'content-length:' | tail -n1 | sed 's/.*:[[:space:]]*//' | tr -d '\r')"
                   LOCAL_SIZE="$(stat -c %s "$${OSMFILE}")"
@@ -299,6 +323,12 @@ spec:
             nominatim:
               - path: /scripts/maintain-regions.sh
                 subPath: maintain-regions.sh
+      import-staging:
+        type: emptyDir
+        advancedMounts:
+          nominatim:
+            nominatim:
+              - path: /import-staging
       dev-shm:
         type: emptyDir
         medium: Memory

--- a/kubernetes/apps/self-hosted/nominatim/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/nominatim/app/helmrelease.yaml
@@ -79,8 +79,6 @@ spec:
                 link_staging "wikimedia-importance.csv.gz"
                 link_staging "us_postcodes.csv.gz"
                 link_staging "secondary_importance.sql.gz"
-                link_staging "gb_postcodes.csv.gz"
-                link_staging "tiger-nominatim-preprocessed.csv.tar.gz"
 
                 OSMFILE="$${STAGING_DIR}/data.osm.pbf"
                 if [ -f "$${OSMFILE}" ]; then
@@ -111,6 +109,7 @@ spec:
               UPDATE_MODE: "none"
               REPLICATION_URL: ""
               IMPORT_WIKIPEDIA: "true"
+              IMPORT_SECONDARY_WIKIPEDIA: "true"
               IMPORT_US_POSTCODES: "true"
               PROJECT_DIR: /nominatim
             envFrom:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- route bootstrap import downloads (PBF, Wikipedia importance, US postcodes, secondary Wikipedia importance) to pod-ephemeral storage instead of the 10Gi project PVC
- add `/import-staging` `emptyDir` and symlink expected `${PROJECT_DIR}` download paths into it before `/app/start.sh`
- remove stale non-symlink import artifacts from the project PVC when present
- enable `IMPORT_SECONDARY_WIKIPEDIA` for improved ranking coverage

## Why

Upstream `init.sh` downloads transient import files into `${PROJECT_DIR}` (`/nominatim`). In this deployment that path is backed by the `nominatim-project` PVC (10Gi via VolSync), which is too small for multi-GB bootstrap artifacts.

Project PVC should retain Nominatim project state only; bootstrap downloads should be ephemeral.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6b63079c-d91c-470e-be2d-6994348564f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6b63079c-d91c-470e-be2d-6994348564f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

