### PR TITLE
fix(nominatim): disable HelmRelease wait during long import

### DIFF
--- a/kubernetes/apps/self-hosted/nominatim/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/nominatim/app/helmrelease.yaml
@@ -11,6 +11,11 @@ spec:
     name: app-template
     namespace: flux-system
 
+  install:
+    disableWait: true
+  upgrade:
+    disableWait: true
+
   values:
     serviceAccount:
       app:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- disable Helm install/upgrade wait for Nominatim so Flux does not roll back during multi-hour bootstrap imports

## Why

Nominatim initial imports can take ~30h. The HelmRelease default wait window is 5m, which causes failed upgrades/rollbacks while the pod is still importing even though startup probes are configured for long bootstrap.

The Flux Kustomization already has `wait: false`; this change addresses HelmRelease-level waiting instead.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6b63079c-d91c-470e-be2d-6994348564f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6b63079c-d91c-470e-be2d-6994348564f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

