### PR TITLE
fix(nominatim): cap gunicorn workers and api db pool size

### DIFF
--- a/kubernetes/apps/self-hosted/nominatim/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/nominatim/app/helmrelease.yaml
@@ -81,6 +81,8 @@ spec:
               POSTGRES_MAINTENANCE_WORK_MEM: 4GB
               POSTGRES_AUTOVACUUM_WORK_MEM: 1GB
               POSTGRES_EFFECTIVE_CACHE_SIZE: 12GB
+              GUNICORN_WORKERS: "4"
+              NOMINATIM_API_POOL_SIZE: "5"
             envFrom:
               - secretRef:
                   name: nominatim-secret


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- cap Nominatim API concurrency to stay within Postgres connection limits
- set `GUNICORN_WORKERS=4` and `NOMINATIM_API_POOL_SIZE=5` (max ~20 DB connections from API workers)

## Why

The mediagis image defaults workers to `nproc` with `NOMINATIM_API_POOL_SIZE=10`, which can exceed Postgres `max_connections` during steady-state API use.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6b63079c-d91c-470e-be2d-6994348564f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6b63079c-d91c-470e-be2d-6994348564f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

