### PR TITLE
fix(observability): smartctl node labels and silence-operator Helm failure

### DIFF
--- a/kubernetes/apps/observability/silence-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/silence-operator/app/helmrelease.yaml
@@ -10,7 +10,7 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 0.20.0
+    tag: 0.19.0
   url: oci://ghcr.io/home-operations/charts-mirror/silence-operator
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2

--- a/kubernetes/apps/observability/smartctl-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/smartctl-exporter/app/helmrelease.yaml
@@ -30,5 +30,9 @@ spec:
     serviceMonitor:
       enabled: true
       relabelings:
-        - action: labeldrop
-          regex: (pod)
+        - action: replace
+          sourceLabels: ["__meta_kubernetes_pod_node_name"]
+          targetLabel: node
+        - action: replace
+          sourceLabels: ["__meta_kubernetes_pod_host_ip"]
+          targetLabel: node_ip

--- a/kubernetes/apps/observability/smartctl-exporter/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/smartctl-exporter/app/prometheusrule.yaml
@@ -13,7 +13,7 @@ spec:
           for: 5m
           annotations:
             summary: >-
-              Mounted drive {{ $labels.device }} on device {{ $labels.instance }} has a temperature higher than {{ $value }}°C
+              Mounted drive {{ $labels.device }} on node {{ $labels.node }} ({{ $labels.node_ip }}) has a temperature higher than {{ $value }}°C
           labels:
             severity: critical
 
@@ -23,7 +23,7 @@ spec:
           for: 5m
           annotations:
             summary: >-
-              Mounted drive {{ $labels.device }} on device {{ $labels.instance }} did not pass its SMART test
+              Mounted drive {{ $labels.device }} on node {{ $labels.node }} ({{ $labels.node_ip }}) did not pass its SMART test
           labels:
             severity: critical
 
@@ -33,7 +33,7 @@ spec:
           for: 5m
           annotations:
             summary: >-
-              Mounted drive {{ $labels.device }} on device {{ $labels.instance }} is in a critical state
+              Mounted drive {{ $labels.device }} on node {{ $labels.node }} ({{ $labels.node_ip }}) is in a critical state
           labels:
             severity: critical
 
@@ -43,7 +43,7 @@ spec:
           for: 5m
           annotations:
             summary: >-
-              Mounted drive {{ $labels.device }} on device {{ $labels.instance }} has media errors
+              Mounted drive {{ $labels.device }} on node {{ $labels.node }} ({{ $labels.node_ip }}) has media errors
           labels:
             severity: critical
 
@@ -53,7 +53,7 @@ spec:
           for: 5m
           annotations:
             summary: >-
-              Device {{ $labels.device }} on instance {{ $labels.instance }} is under available spare threshold
+              Device {{ $labels.device }} on node {{ $labels.node }} ({{ $labels.node_ip }}) is under available spare threshold
           labels:
             severity: critical
 
@@ -62,7 +62,7 @@ spec:
             smartctl_device_interface_speed{speed_type="current"} != on(device, instance, namespace, pod) smartctl_device_interface_speed{speed_type="max"}
           annotations:
             summary: >-
-              Device {{ $labels.device }} on instance {{ $labels.instance }} interface is slower then it should be
+              Device {{ $labels.device }} on node {{ $labels.node }} ({{ $labels.node_ip }}) interface is slower then it should be
           for: 5m
           labels:
             severity: critical


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes two observability alerts from the screenshot:

1. **SmartDeviceHighTemperature** — notifications now show the physical node hostname and host IP instead of the pod scrape address (`10.244.x.x:9633`).
2. **FluxKustomizationHealthcheckfailed (silence-operator)** — reverts the chart to `0.19.0` so Helm can pull a published image again.

## Smartctl exporter

The alert summary used `{{ $labels.instance }}`, which is the Prometheus scrape target (pod IP:port). ServiceMonitor relabelings now copy:

- `__meta_kubernetes_pod_node_name` → `node`
- `__meta_kubernetes_pod_host_ip` → `node_ip`

PrometheusRule summaries were updated to reference those labels, e.g. `on node talos-worker-01 (192.168.1.42)`.

**Note:** Existing firing alerts will keep old labels until metrics are re-scraped with the new relabel config (after Flux reconciles).

## Silence-operator

Renovate bumped the chart `0.19.0` → `0.20.0`. Chart `0.20.0` sets the container image tag from `Chart.Version` (`0.20.0`), but `quay.io/giantswarm/silence-operator:0.20.0` is not published yet (only `0.19.0` and older exist). That causes `ImagePullBackOff` and the Flux `HelmRelease` health check failure.

Pinning the chart back to `0.19.0` restores the last known-good image tag. When `0.20.0` is available on Quay, we can bump to chart `0.20.1` (which uses `Chart.AppVersion` for the image tag).

## Test plan

- [ ] Flux reconciles `smartctl-exporter` and `silence-operator` Kustomizations successfully
- [ ] `kubectl get helmrelease silence-operator -n observability` shows Ready
- [ ] `kubectl get pods -n observability -l app.kubernetes.io/name=silence-operator` is Running
- [ ] Fire or inspect a `SmartDeviceHighTemperature` alert and confirm `node` / `node_ip` in the notification
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-206210c6-f931-40e9-8487-0efec59e14b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-206210c6-f931-40e9-8487-0efec59e14b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

