### PR TITLE
Add Jepsen blog RSS feed to Glance

### DIFF
--- a/kubernetes/apps/self-hosted/glance/app/resources/glance.yml
+++ b/kubernetes/apps/self-hosted/glance/app/resources/glance.yml
@@ -26,13 +26,13 @@ pages:
                 title: selfh.st
                 limit: 4
               - url: https://ciechanow.ski/atom.xml
-                title: ciechanow.ski
+                title: Bartosz Ciechanowski
               - url: https://samwho.dev/rss.xml
-                title: samwho.dev
+                title: Sam Rose
               - url: https://thatshubham.com/rss.xml
-                title: thatshubham.com
+                title: Shubham Bose
               - url: https://jepsen.io/blog.atom
-                title: Jepsen
+                title: Kyle Kingsbury
 
       - size: full
         widgets:

--- a/kubernetes/apps/self-hosted/glance/app/resources/glance.yml
+++ b/kubernetes/apps/self-hosted/glance/app/resources/glance.yml
@@ -28,12 +28,8 @@ pages:
               - url: https://ciechanow.ski/atom.xml
               - url: https://samwho.dev/rss.xml
               - url: https://thatshubham.com/rss.xml
-
-          - type: bookmarks
-            groups:
-              - links:
-                  - title: Jepsen
-                    url: https://jepsen.io/
+              - url: https://jepsen.io/blog.atom
+                title: Jepsen
 
       - size: full
         widgets:

--- a/kubernetes/apps/self-hosted/glance/app/resources/glance.yml
+++ b/kubernetes/apps/self-hosted/glance/app/resources/glance.yml
@@ -26,8 +26,11 @@ pages:
                 title: selfh.st
                 limit: 4
               - url: https://ciechanow.ski/atom.xml
+                title: ciechanow.ski
               - url: https://samwho.dev/rss.xml
+                title: samwho.dev
               - url: https://thatshubham.com/rss.xml
+                title: thatshubham.com
               - url: https://jepsen.io/blog.atom
                 title: Jepsen
 

--- a/kubernetes/apps/self-hosted/glance/app/resources/glance.yml
+++ b/kubernetes/apps/self-hosted/glance/app/resources/glance.yml
@@ -29,6 +29,12 @@ pages:
               - url: https://samwho.dev/rss.xml
               - url: https://thatshubham.com/rss.xml
 
+          - type: bookmarks
+            groups:
+              - links:
+                  - title: Jepsen
+                    url: https://jepsen.io/
+
       - size: full
         widgets:
           - type: group

--- a/kubernetes/apps/self-hosted/glance/app/resources/glance.yml
+++ b/kubernetes/apps/self-hosted/glance/app/resources/glance.yml
@@ -31,8 +31,8 @@ pages:
                 title: Sam Rose
               - url: https://thatshubham.com/rss.xml
                 title: Shubham Bose
-              - url: https://jepsen.io/blog.atom
-                title: Kyle Kingsbury
+              - url: https://jepsen.io/blog.rss
+                title: Jepsen
 
       - size: full
         widgets:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds Jepsen blog to the Glance Home page RSS widget and sets explicit display titles for all feeds in that widget.

## Changes

- Add Jepsen blog Atom feed (`https://jepsen.io/blog.rss`)
- Add titles for ciechanow.ski, samwho.dev, and thatshubham.com (selfh.st and Jepsen already had titles)

## Notes

Flux will apply this change automatically after merge. Glance supports config hot-reload, so no pod restart should be required once the ConfigMap updates.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-38252e1d-b40b-4d11-9477-1236c7956e71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-38252e1d-b40b-4d11-9477-1236c7956e71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

