### PR TITLE
fix(observability): atuin v18 server cmd, vmalert OOM, health rule

### DIFF
--- a/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
@@ -103,8 +103,9 @@ spec:
         resources:
           requests:
             cpu: 100m
+            memory: 256Mi
           limits:
-            memory: 512Mi
+            memory: 1Gi
 
     vmsingle:
       enabled: true
@@ -152,6 +153,12 @@ spec:
         evaluationInterval: 30s
         externalLabels:
           cluster: jupiter
+        resources:
+          requests:
+            cpu: 50m
+            memory: 128Mi
+          limits:
+            memory: 512Mi
 
     prometheus-node-exporter:
       fullnameOverride: node-exporter

--- a/kubernetes/apps/observability/vmalert/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/vmalert/app/helmrelease.yaml
@@ -32,8 +32,9 @@ spec:
             resources: &resources
               requests:
                 cpu: 10m
+                memory: 64Mi
               limits:
-                memory: 128Mi
+                memory: 512Mi
         containers:
           vmalert:
             image:

--- a/kubernetes/apps/observability/vmalert/app/vmrule.yaml
+++ b/kubernetes/apps/observability/vmalert/app/vmrule.yaml
@@ -10,7 +10,7 @@ spec:
       rules:
         - alert: VmalertDown
           expr: |
-            absent(up{job=~".*vmalert.*"})
+            absent(up{instance=~".*:8880"})
           for: 5m
           labels:
             severity: critical

--- a/kubernetes/apps/self-hosted/atuin/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/atuin/app/helmrelease.yaml
@@ -39,7 +39,7 @@ spec:
               ATUIN_METRICS__PORT: &metricsPort 8080
               ATUIN_TLS__ENABLE: "false"
             envFrom: *envFrom
-            args: ["server", "start"]
+            args: ["start"]
             probes:
               liveness: &probe
                 enabled: true


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes three related issues from the VictoriaMetrics migration and Atuin image bump.

### Atuin crash loop
Atuin **v18.12.0** split the server into a separate `atuin-server` binary. The image entrypoint no longer accepts `server start` — only `start`.

### VM component OOMKills
- **standalone `vmalert`** (Victoria Logs): 128Mi → **512Mi** — watches ConfigMaps across all namespaces + sidecar
- **`vmalert-vmks`** (metrics stack): added **512Mi** limit (was unset)
- **`vmagent-vmks`**: 512Mi → **1Gi**

### Duplicate vmalert confusion
Two vmalert instances are **intentional**, not duplicates:
| Deployment | Purpose | Datasource | Port |
|---|---|---|---|
| `vmalert` | Victoria **Logs** alerts (`vmalert.io/rule` ConfigMaps) | victoria-logs:9428 | 8880 |
| `vmalert-vmks` | Prometheus/**metrics** alerts (VMRule CRs + defaultRules) | vmsingle:8428 | 8080 |

Both notify the same Alertmanager (`vmalertmanager-vmks`). You will see two `up` series and similar `vmalert_*` internal metrics — filter by `instance` port or job name.

Also fixed `VmalertDown` VMRule: it previously used `absent(up{job=~".*vmalert.*"})` which would **never fire** while `vmalert-vmks` was healthy. Now scoped to the logs vmalert via `instance=~".*:8880"`.

## Test plan
- [ ] Flux reconciles `atuin` — pod starts, probes pass
- [ ] `vmalert` and `vmalert-vmks` pods stable (no OOMKilled restarts)
- [ ] Confirm two vmalert scrape targets in VMUI with distinct instances/ports
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9824cc84-690f-4f38-85e4-64b3a26ea8d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9824cc84-690f-4f38-85e4-64b3a26ea8d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

