### PR TITLE
fix(nominatim): run update CronJob without shell in kubectl image

### DIFF
--- a/kubernetes/apps/self-hosted/nominatim/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/nominatim/app/helmrelease.yaml
@@ -27,6 +27,9 @@ spec:
         replication:
           type: Role
           rules:
+            - apiGroups: ["apps"]
+              resources: ["deployments"]
+              verbs: ["get"]
             - apiGroups: [""]
               resources: ["pods"]
               verbs: ["get", "list"]
@@ -137,15 +140,15 @@ spec:
             image:
               repository: registry.k8s.io/kubectl
               tag: v1.34.5
-            command: ["/bin/sh", "-ec"]
+            command: ["/kubectl"]
             args:
-              - |
-                POD_NAME="$(kubectl get pods -l app.kubernetes.io/name=nominatim -o jsonpath='{.items[0].metadata.name}')"
-                if [ -z "$${POD_NAME}" ]; then
-                  echo "nominatim pod not found"
-                  exit 1
-                fi
-                kubectl exec "$${POD_NAME}" -c nominatim -- /bin/bash /scripts/maintain-regions.sh
+              - exec
+              - deploy/nominatim
+              - -c
+              - nominatim
+              - --
+              - /bin/bash
+              - /scripts/maintain-regions.sh
             resources:
               requests:
                 cpu: 10m


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The `nominatim-update-osm-db` CronJob fails immediately on pod start:

```
exec: "/bin/sh": stat /bin/sh: no such file or directory
```

`registry.k8s.io/kubectl:v1.34.5` is a distroless image and does not include a shell.

## Fix

- Replace the `/bin/sh -ec` wrapper with a direct `/kubectl exec deploy/nominatim ...` invocation.
- Add `deployments/get` to the replication Role so kubectl can resolve the deployment to a pod.

## Verification

After Flux reconciles, trigger a manual CronJob run or wait for the next schedule and confirm the job pod starts and exec succeeds into the nominatim container.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6b63079c-d91c-470e-be2d-6994348564f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6b63079c-d91c-470e-be2d-6994348564f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

