### PR TITLE
feat(glance): annotate workloads and add category widgets

### DIFF
--- a/docs/architecture/glance-annotations.yaml
+++ b/docs/architecture/glance-annotations.yaml
@@ -1,5 +1,11 @@
 # Canonical glance-k8s annotation registry for homelab workloads.
 # Categories align with Glance Homelab page widgets (namespace-oriented UX).
+#
+# Annotation placement:
+# - Workload (controllers.*.annotations): glance/id, glance/parent, glance/hide
+# - Primary HTTPRoute (route.*.annotations): glance/name, glance/icon, glance/category, glance/url
+# - workload_only: no app-template route; keep display annotations on the workload
+# - upstream_values: third-party charts without HTTPRoute (podAnnotations / podMetadata)
 
 categories:
   - media
@@ -16,6 +22,7 @@ multi_route:
   - downloads/qui
   - media/tautulli
   - media/plex
+  - games/minecraft/router
   - observability/victoria-metrics
 
 app_template:
@@ -27,10 +34,12 @@ app_template:
     icon: si:openai
     url: https://paperless-ai.internal
     category: ai
+    workload_only: true
 
   # AUTH
   - file: kubernetes/apps/auth/pocket-id/app/helmrelease.yaml
     controller: pocket-id
+    route: id
     id: pocket-id
     name: Pocket ID
     icon: si:keycloak
@@ -39,6 +48,7 @@ app_template:
 
   - file: kubernetes/apps/auth/tinyauth/app/helmrelease.yaml
     controller: tinyauth
+    route: external
     id: tinyauth
     name: Tinyauth
     icon: mdi:shield-account
@@ -48,6 +58,7 @@ app_template:
   # DOWNLOADS
   - file: kubernetes/apps/downloads/autobrr/app/helmrelease.yaml
     controller: autobrr
+    route: canonical
     id: autobrr
     name: Autobrr
     icon: mdi:robot
@@ -56,6 +67,7 @@ app_template:
 
   - file: kubernetes/apps/downloads/bazarr/hd/helmrelease.yaml
     controller: bazarr
+    route: canonical
     id: bazarr-hd
     name: Bazarr HD
     icon: si:bazarr
@@ -64,6 +76,7 @@ app_template:
 
   - file: kubernetes/apps/downloads/bazarr/uhd/helmrelease.yaml
     controller: bazarr-uhd
+    route: canonical
     id: bazarr-uhd
     name: Bazarr UHD
     icon: si:bazarr
@@ -72,6 +85,7 @@ app_template:
 
   - file: kubernetes/apps/downloads/lidarr/app/helmrelease.yaml
     controller: lidarr
+    route: canonical
     id: lidarr
     name: Lidarr
     icon: si:lidarr
@@ -80,6 +94,7 @@ app_template:
 
   - file: kubernetes/apps/downloads/openbooks/app/helmrelease.yaml
     controller: openbooks
+    route: canonical
     id: openbooks
     name: OpenBooks
     icon: mdi:book-search
@@ -88,6 +103,7 @@ app_template:
 
   - file: kubernetes/apps/downloads/prowlarr/app/helmrelease.yaml
     controller: prowlarr
+    route: canonical
     id: prowlarr
     name: Prowlarr
     icon: si:prowlarr
@@ -101,17 +117,21 @@ app_template:
     icon: si:qbittorrent
     url: https://qbittorrent.kite-harmonic.ts.net
     category: downloads
+    workload_only: true
 
   - file: kubernetes/apps/downloads/qui/app/helmrelease.yaml
     controller: qui
+    route: canonical
     id: qui
     name: Qui
     icon: si:qbittorrent
     url: https://qui.zebernst.dev
     category: downloads
+    force_url: true
 
   - file: kubernetes/apps/downloads/radarr/app/hd/helmrelease.yaml
     controller: radarr
+    route: canonical
     id: radarr-hd
     name: Radarr HD
     icon: si:radarr
@@ -120,6 +140,7 @@ app_template:
 
   - file: kubernetes/apps/downloads/radarr/app/uhd/helmrelease.yaml
     controller: radarr-uhd
+    route: canonical
     id: radarr-uhd
     name: Radarr UHD
     icon: si:radarr
@@ -128,6 +149,7 @@ app_template:
 
   - file: kubernetes/apps/downloads/sonarr/app/hd/helmrelease.yaml
     controller: sonarr
+    route: canonical
     id: sonarr-hd
     name: Sonarr HD
     icon: si:sonarr
@@ -136,6 +158,7 @@ app_template:
 
   - file: kubernetes/apps/downloads/sonarr/app/uhd/helmrelease.yaml
     controller: sonarr-uhd
+    route: canonical
     id: sonarr-uhd
     name: Sonarr UHD
     icon: si:sonarr
@@ -144,6 +167,7 @@ app_template:
 
   - file: kubernetes/apps/downloads/whisparr/app/helmrelease.yaml
     controller: whisparr
+    route: canonical
     id: whisparr
     name: Whisparr
     icon: si:sonarr
@@ -153,47 +177,34 @@ app_template:
   # GAMES
   - file: kubernetes/apps/games/minecraft/router/app/helmrelease.yaml
     controller: mc-router
+    route: api
     id: minecraft
     name: Minecraft
     icon: si:minecraft
     url: https://worldmap.zebernst.dev
     category: games
+    force_url: true
 
   - file: kubernetes/apps/games/minecraft/bluemap/app/helmrelease.yaml
     controller: bluemap
-    id: bluemap
-    name: BlueMap
-    icon: si:minecraft
     parent: minecraft
-    category: games
 
   - file: kubernetes/apps/games/minecraft/vanilla/app/helmrelease.yaml
     controller: vanilla
-    id: minecraft-vanilla
-    name: Minecraft Vanilla
-    icon: si:minecraft
     parent: minecraft
-    category: games
 
   - file: kubernetes/apps/games/minecraft/atm10/app/helmrelease.yaml
     controller: atm10
-    id: minecraft-atm10
-    name: Minecraft ATM10
-    icon: si:minecraft
     parent: minecraft
-    category: games
 
   - file: kubernetes/apps/games/minecraft/atmons/app/helmrelease.yaml
     controller: atmons
-    id: minecraft-atmons
-    name: Minecraft ATMons
-    icon: si:minecraft
     parent: minecraft
-    category: games
 
   # MEDIA
   - file: kubernetes/apps/media/agregarr/app/helmrelease.yaml
     controller: agregarr
+    route: canonical
     id: agregarr
     name: Agregarr
     icon: si:sonarr
@@ -202,6 +213,7 @@ app_template:
 
   - file: kubernetes/apps/media/booklore/app/helmrelease.yaml
     controller: booklore
+    route: app
     id: booklore
     name: Booklore
     icon: mdi:book-open-variant
@@ -210,6 +222,7 @@ app_template:
 
   - file: kubernetes/apps/media/capacitarr/app/helmrelease.yaml
     controller: capacitarr
+    route: canonical
     id: capacitarr
     name: Capacitarr
     icon: si:sonarr
@@ -218,6 +231,7 @@ app_template:
 
   - file: kubernetes/apps/media/maintainerr/app/helmrelease.yaml
     controller: maintainerr
+    route: canonical
     id: maintainerr
     name: Maintainerr
     icon: mdi:broom
@@ -226,14 +240,17 @@ app_template:
 
   - file: kubernetes/apps/media/plex/app/helmrelease.yaml
     controller: plex
+    route: plex
     id: plex
     name: Plex
     icon: si:plex
     url: https://plex.zebernst.dev
     category: media
+    force_url: true
 
   - file: kubernetes/apps/media/seerr/app/helmrelease.yaml
     controller: seerr
+    route: app
     id: seerr
     name: Seerr
     icon: mdi:movie-open
@@ -242,6 +259,7 @@ app_template:
 
   - file: kubernetes/apps/media/shelfmark/app/helmrelease.yaml
     controller: shelfmark
+    route: canonical
     id: shelfmark
     name: Shelfmark
     icon: mdi:bookmark
@@ -250,6 +268,7 @@ app_template:
 
   - file: kubernetes/apps/media/stash/app/helmrelease.yaml
     controller: stash
+    route: canonical
     id: stash
     name: Stash
     icon: mdi:filmstrip-box
@@ -258,6 +277,7 @@ app_template:
 
   - file: kubernetes/apps/media/steam/app/helmrelease.yaml
     controller: steam
+    route: canonical
     id: steam
     name: Steam Headless
     icon: si:steam
@@ -266,14 +286,17 @@ app_template:
 
   - file: kubernetes/apps/media/tautulli/app/helmrelease.yaml
     controller: tautulli
+    route: canonical
     id: tautulli
     name: Tautulli
     icon: si:plex
     url: https://tautulli.zebernst.dev
     category: media
+    force_url: true
 
   - file: kubernetes/apps/media/wizarr/app/helmrelease.yaml
     controller: wizarr
+    route: app
     id: wizarr
     name: Wizarr
     icon: mdi:account-plus
@@ -281,16 +304,19 @@ app_template:
     category: media
 
   # OBSERVABILITY
-  - file: kubernetes/apps/observability/gatus/app/helmrelease.yaml
+  - file: kubernetes/apps/observability/gatus/private/helmrelease.yaml
     controller: gatus
+    route: canonical
     id: gatus
     name: Gatus
     icon: mdi:heart-pulse
     url: https://status.zebernst.dev
     category: observability
+    force_url: true
 
   - file: kubernetes/apps/observability/karma/app/helmrelease.yaml
     controller: karma
+    route: canonical
     id: karma
     name: Karma
     icon: mdi:alert-circle
@@ -299,6 +325,7 @@ app_template:
 
   - file: kubernetes/apps/observability/kromgo/app/helmrelease.yaml
     controller: kromgo
+    route: app
     id: kromgo
     name: Kromgo
     icon: mdi:message-text
@@ -308,6 +335,7 @@ app_template:
   # SELF-HOSTED
   - file: kubernetes/apps/self-hosted/atuin/app/helmrelease.yaml
     controller: atuin
+    route: canonical
     id: atuin
     name: Atuin
     icon: mdi:history
@@ -316,22 +344,27 @@ app_template:
 
   - file: kubernetes/apps/self-hosted/dawarich/app/helmrelease.yaml
     controller: dawarich
+    route: canonical
     id: dawarich
     name: Dawarich
     icon: mdi:map-marker-path
     url: https://timeline.zebernst.dev
     category: self-hosted
+    force_url: true
 
   - file: kubernetes/apps/self-hosted/glance/app/helmrelease.yaml
     controller: glance
+    route: canonical
     id: glance
     name: Glance
     icon: di:glance
     url: https://glance.zebernst.dev
     category: self-hosted
+    force_url: true
 
   - file: kubernetes/apps/self-hosted/it-tools/app/helmrelease.yaml
     controller: it-tools
+    route: canonical
     id: it-tools
     name: IT-Tools
     icon: mdi:tools
@@ -340,6 +373,7 @@ app_template:
 
   - file: kubernetes/apps/self-hosted/nocodb/app/helmrelease.yaml
     controller: nocodb
+    route: canonical
     id: nocodb
     name: NocoDB
     icon: si:nocodb
@@ -353,9 +387,11 @@ app_template:
     icon: mdi:map-search
     url: https://nominatim.zebernst.dev
     category: self-hosted
+    workload_only: true
 
   - file: kubernetes/apps/self-hosted/paperless/app/helmrelease.yaml
     controller: paperless
+    route: canonical
     id: paperless
     name: Paperless-ngx
     icon: si:readthedocs
@@ -364,6 +400,7 @@ app_template:
 
   - file: kubernetes/apps/self-hosted/rxresume/app/helmrelease.yaml
     controller: rxresume
+    route: app
     id: rxresume
     name: RxResume
     icon: mdi:file-document
@@ -372,11 +409,13 @@ app_template:
 
   - file: kubernetes/apps/self-hosted/unwrapped/app/helmrelease.yaml
     controller: unwrapped
+    route: canonical
     id: unwrapped
     name: Unwrapped
     icon: mdi:gift
     url: https://unwrapped.zebernst.dev
     category: self-hosted
+    force_url: true
 
 hide:
   - file: kubernetes/apps/network/echo-server/app/helmrelease.yaml

--- a/docs/architecture/glance-annotations.yaml
+++ b/docs/architecture/glance-annotations.yaml
@@ -1,0 +1,396 @@
+# Canonical glance-k8s annotation registry for homelab workloads.
+# Categories align with Glance Homelab page widgets (namespace-oriented UX).
+
+categories:
+  - media
+  - downloads
+  - self-hosted
+  - ai
+  - auth
+  - games
+  - observability
+
+multi_route:
+  - auth/pocket-id
+  - ai/ollama
+  - downloads/qui
+  - media/tautulli
+  - media/plex
+  - observability/victoria-metrics
+
+app_template:
+  # AI
+  - file: kubernetes/apps/ai/paperless-ai/app/helmrelease.yaml
+    controller: paperless-ai
+    id: paperless-ai
+    name: Paperless AI
+    icon: si:openai
+    url: https://paperless-ai.internal
+    category: ai
+
+  # AUTH
+  - file: kubernetes/apps/auth/pocket-id/app/helmrelease.yaml
+    controller: pocket-id
+    id: pocket-id
+    name: Pocket ID
+    icon: si:keycloak
+    url: https://id.zebernst.dev
+    category: auth
+
+  - file: kubernetes/apps/auth/tinyauth/app/helmrelease.yaml
+    controller: tinyauth
+    id: tinyauth
+    name: Tinyauth
+    icon: mdi:shield-account
+    url: https://auth.zebernst.dev
+    category: auth
+
+  # DOWNLOADS
+  - file: kubernetes/apps/downloads/autobrr/app/helmrelease.yaml
+    controller: autobrr
+    id: autobrr
+    name: Autobrr
+    icon: mdi:robot
+    url: https://autobrr.kite-harmonic.ts.net
+    category: downloads
+
+  - file: kubernetes/apps/downloads/bazarr/hd/helmrelease.yaml
+    controller: bazarr
+    id: bazarr-hd
+    name: Bazarr HD
+    icon: si:bazarr
+    url: https://bazarr.kite-harmonic.ts.net
+    category: downloads
+
+  - file: kubernetes/apps/downloads/bazarr/uhd/helmrelease.yaml
+    controller: bazarr-uhd
+    id: bazarr-uhd
+    name: Bazarr UHD
+    icon: si:bazarr
+    url: https://bazarr-uhd.kite-harmonic.ts.net
+    category: downloads
+
+  - file: kubernetes/apps/downloads/lidarr/app/helmrelease.yaml
+    controller: lidarr
+    id: lidarr
+    name: Lidarr
+    icon: si:lidarr
+    url: https://lidarr.kite-harmonic.ts.net
+    category: downloads
+
+  - file: kubernetes/apps/downloads/openbooks/app/helmrelease.yaml
+    controller: openbooks
+    id: openbooks
+    name: OpenBooks
+    icon: mdi:book-search
+    url: https://openbooks.kite-harmonic.ts.net
+    category: downloads
+
+  - file: kubernetes/apps/downloads/prowlarr/app/helmrelease.yaml
+    controller: prowlarr
+    id: prowlarr
+    name: Prowlarr
+    icon: si:prowlarr
+    url: https://prowlarr.kite-harmonic.ts.net
+    category: downloads
+
+  - file: kubernetes/apps/downloads/qbittorrent/app/helmrelease.yaml
+    controller: qbittorrent
+    id: qbittorrent
+    name: qBittorrent
+    icon: si:qbittorrent
+    url: https://qbittorrent.kite-harmonic.ts.net
+    category: downloads
+
+  - file: kubernetes/apps/downloads/qui/app/helmrelease.yaml
+    controller: qui
+    id: qui
+    name: Qui
+    icon: si:qbittorrent
+    url: https://qui.zebernst.dev
+    category: downloads
+
+  - file: kubernetes/apps/downloads/radarr/app/hd/helmrelease.yaml
+    controller: radarr
+    id: radarr-hd
+    name: Radarr HD
+    icon: si:radarr
+    url: https://radarr.kite-harmonic.ts.net
+    category: downloads
+
+  - file: kubernetes/apps/downloads/radarr/app/uhd/helmrelease.yaml
+    controller: radarr-uhd
+    id: radarr-uhd
+    name: Radarr UHD
+    icon: si:radarr
+    url: https://radarr-uhd.kite-harmonic.ts.net
+    category: downloads
+
+  - file: kubernetes/apps/downloads/sonarr/app/hd/helmrelease.yaml
+    controller: sonarr
+    id: sonarr-hd
+    name: Sonarr HD
+    icon: si:sonarr
+    url: https://sonarr.kite-harmonic.ts.net
+    category: downloads
+
+  - file: kubernetes/apps/downloads/sonarr/app/uhd/helmrelease.yaml
+    controller: sonarr-uhd
+    id: sonarr-uhd
+    name: Sonarr UHD
+    icon: si:sonarr
+    url: https://sonarr-uhd.kite-harmonic.ts.net
+    category: downloads
+
+  - file: kubernetes/apps/downloads/whisparr/app/helmrelease.yaml
+    controller: whisparr
+    id: whisparr
+    name: Whisparr
+    icon: si:sonarr
+    url: https://whisparr.kite-harmonic.ts.net
+    category: downloads
+
+  # GAMES
+  - file: kubernetes/apps/games/minecraft/router/app/helmrelease.yaml
+    controller: mc-router
+    id: minecraft
+    name: Minecraft
+    icon: si:minecraft
+    url: https://worldmap.zebernst.dev
+    category: games
+
+  - file: kubernetes/apps/games/minecraft/bluemap/app/helmrelease.yaml
+    controller: bluemap
+    id: bluemap
+    name: BlueMap
+    icon: si:minecraft
+    parent: minecraft
+    category: games
+
+  - file: kubernetes/apps/games/minecraft/vanilla/app/helmrelease.yaml
+    controller: vanilla
+    id: minecraft-vanilla
+    name: Minecraft Vanilla
+    icon: si:minecraft
+    parent: minecraft
+    category: games
+
+  - file: kubernetes/apps/games/minecraft/atm10/app/helmrelease.yaml
+    controller: atm10
+    id: minecraft-atm10
+    name: Minecraft ATM10
+    icon: si:minecraft
+    parent: minecraft
+    category: games
+
+  - file: kubernetes/apps/games/minecraft/atmons/app/helmrelease.yaml
+    controller: atmons
+    id: minecraft-atmons
+    name: Minecraft ATMons
+    icon: si:minecraft
+    parent: minecraft
+    category: games
+
+  # MEDIA
+  - file: kubernetes/apps/media/agregarr/app/helmrelease.yaml
+    controller: agregarr
+    id: agregarr
+    name: Agregarr
+    icon: si:sonarr
+    url: https://agregarr.zebernst.dev
+    category: media
+
+  - file: kubernetes/apps/media/booklore/app/helmrelease.yaml
+    controller: booklore
+    id: booklore
+    name: Booklore
+    icon: mdi:book-open-variant
+    url: https://booklore.zebernst.dev
+    category: media
+
+  - file: kubernetes/apps/media/capacitarr/app/helmrelease.yaml
+    controller: capacitarr
+    id: capacitarr
+    name: Capacitarr
+    icon: si:sonarr
+    url: https://capacitarr.zebernst.dev
+    category: media
+
+  - file: kubernetes/apps/media/maintainerr/app/helmrelease.yaml
+    controller: maintainerr
+    id: maintainerr
+    name: Maintainerr
+    icon: mdi:broom
+    url: https://maintainerr.kite-harmonic.ts.net
+    category: media
+
+  - file: kubernetes/apps/media/plex/app/helmrelease.yaml
+    controller: plex
+    id: plex
+    name: Plex
+    icon: si:plex
+    url: https://plex.zebernst.dev
+    category: media
+
+  - file: kubernetes/apps/media/seerr/app/helmrelease.yaml
+    controller: seerr
+    id: seerr
+    name: Seerr
+    icon: mdi:movie-open
+    url: https://requests.zebernst.dev
+    category: media
+
+  - file: kubernetes/apps/media/shelfmark/app/helmrelease.yaml
+    controller: shelfmark
+    id: shelfmark
+    name: Shelfmark
+    icon: mdi:bookmark
+    url: https://shelfmark.zebernst.dev
+    category: media
+
+  - file: kubernetes/apps/media/stash/app/helmrelease.yaml
+    controller: stash
+    id: stash
+    name: Stash
+    icon: mdi:filmstrip-box
+    url: https://stash.kite-harmonic.ts.net
+    category: media
+
+  - file: kubernetes/apps/media/steam/app/helmrelease.yaml
+    controller: steam
+    id: steam
+    name: Steam Headless
+    icon: si:steam
+    url: https://steam.kite-harmonic.ts.net
+    category: media
+
+  - file: kubernetes/apps/media/tautulli/app/helmrelease.yaml
+    controller: tautulli
+    id: tautulli
+    name: Tautulli
+    icon: si:plex
+    url: https://tautulli.zebernst.dev
+    category: media
+
+  - file: kubernetes/apps/media/wizarr/app/helmrelease.yaml
+    controller: wizarr
+    id: wizarr
+    name: Wizarr
+    icon: mdi:account-plus
+    url: https://join.zebernst.dev
+    category: media
+
+  # OBSERVABILITY
+  - file: kubernetes/apps/observability/gatus/app/helmrelease.yaml
+    controller: gatus
+    id: gatus
+    name: Gatus
+    icon: mdi:heart-pulse
+    url: https://status.zebernst.dev
+    category: observability
+
+  - file: kubernetes/apps/observability/karma/app/helmrelease.yaml
+    controller: karma
+    id: karma
+    name: Karma
+    icon: mdi:alert-circle
+    url: https://karma.kite-harmonic.ts.net
+    category: observability
+
+  - file: kubernetes/apps/observability/kromgo/app/helmrelease.yaml
+    controller: kromgo
+    id: kromgo
+    name: Kromgo
+    icon: mdi:message-text
+    url: https://kromgo.zebernst.dev
+    category: observability
+
+  # SELF-HOSTED
+  - file: kubernetes/apps/self-hosted/atuin/app/helmrelease.yaml
+    controller: atuin
+    id: atuin
+    name: Atuin
+    icon: mdi:history
+    url: https://atuin.kite-harmonic.ts.net
+    category: self-hosted
+
+  - file: kubernetes/apps/self-hosted/dawarich/app/helmrelease.yaml
+    controller: dawarich
+    id: dawarich
+    name: Dawarich
+    icon: mdi:map-marker-path
+    url: https://timeline.zebernst.dev
+    category: self-hosted
+
+  - file: kubernetes/apps/self-hosted/glance/app/helmrelease.yaml
+    controller: glance
+    id: glance
+    name: Glance
+    icon: di:glance
+    url: https://glance.zebernst.dev
+    category: self-hosted
+
+  - file: kubernetes/apps/self-hosted/it-tools/app/helmrelease.yaml
+    controller: it-tools
+    id: it-tools
+    name: IT-Tools
+    icon: mdi:tools
+    url: https://it-tools.kite-harmonic.ts.net
+    category: self-hosted
+
+  - file: kubernetes/apps/self-hosted/nocodb/app/helmrelease.yaml
+    controller: nocodb
+    id: nocodb
+    name: NocoDB
+    icon: si:nocodb
+    url: https://nocodb.kite-harmonic.ts.net
+    category: self-hosted
+
+  - file: kubernetes/apps/self-hosted/nominatim/app/helmrelease.yaml
+    controller: nominatim
+    id: nominatim
+    name: Nominatim
+    icon: mdi:map-search
+    url: https://nominatim.zebernst.dev
+    category: self-hosted
+
+  - file: kubernetes/apps/self-hosted/paperless/app/helmrelease.yaml
+    controller: paperless
+    id: paperless
+    name: Paperless-ngx
+    icon: si:readthedocs
+    url: https://paperless.kite-harmonic.ts.net
+    category: self-hosted
+
+  - file: kubernetes/apps/self-hosted/rxresume/app/helmrelease.yaml
+    controller: rxresume
+    id: rxresume
+    name: RxResume
+    icon: mdi:file-document
+    url: https://rxresume.zebernst.dev
+    category: self-hosted
+
+  - file: kubernetes/apps/self-hosted/unwrapped/app/helmrelease.yaml
+    controller: unwrapped
+    id: unwrapped
+    name: Unwrapped
+    icon: mdi:gift
+    url: https://unwrapped.zebernst.dev
+    category: self-hosted
+
+hide:
+  - file: kubernetes/apps/network/echo-server/app/helmrelease.yaml
+    controller: echo-server
+
+  - file: kubernetes/apps/downloads/flaresolverr/app/helmrelease.yaml
+    controller: flaresolverr
+
+  - file: kubernetes/apps/downloads/cross-seed/app/helmrelease.yaml
+    controller: cross-seed
+
+  - file: kubernetes/apps/downloads/omegabrr/app/helmrelease.yaml
+    controller: omegabrr
+
+upstream_values:
+  # Upstream chart annotations are applied manually in HelmRelease values to preserve formatting.
+  # See ollama, open-webui, grafana, hajimari, victoria-metrics, victoria-logs helmreleases.

--- a/kubernetes/apps/ai/ollama/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/ollama/app/helmrelease.yaml
@@ -42,3 +42,9 @@ spec:
       - key: nvidia.com/gpu
         operator: Exists
         effect: NoSchedule
+    podAnnotations:
+      glance/id: ollama
+      glance/name: Ollama
+      glance/icon: si:ollama
+      glance/url: https://ollama.internal
+      glance/category: ai

--- a/kubernetes/apps/ai/open-webui/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/open-webui/app/helmrelease.yaml
@@ -32,3 +32,9 @@ spec:
     persistence:
       enabled: true
       existingClaim: open-webui
+    podAnnotations:
+      glance/id: open-webui
+      glance/name: Open WebUI
+      glance/icon: si:openai
+      glance/url: https://open-webui.internal
+      glance/category: ai

--- a/kubernetes/apps/ai/paperless-ai/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/paperless-ai/app/helmrelease.yaml
@@ -16,6 +16,11 @@ spec:
       paperless-ai:
         annotations:
           reloader.stakater.com/auto: "true"
+          glance/id: paperless-ai
+          glance/name: Paperless AI
+          glance/icon: si:openai
+          glance/category: ai
+          glance/url: https://paperless-ai.internal
         containers:
           app:
             image:

--- a/kubernetes/apps/auth/pocket-id/app/helmrelease.yaml
+++ b/kubernetes/apps/auth/pocket-id/app/helmrelease.yaml
@@ -16,6 +16,11 @@ spec:
       pocket-id:
         annotations:
           reloader.stakater.com/auto: "true"
+          glance/id: pocket-id
+          glance/name: Pocket ID
+          glance/icon: si:keycloak
+          glance/category: auth
+          glance/url: https://id.zebernst.dev
 
         initContainers:
           init-db:

--- a/kubernetes/apps/auth/pocket-id/app/helmrelease.yaml
+++ b/kubernetes/apps/auth/pocket-id/app/helmrelease.yaml
@@ -17,10 +17,6 @@ spec:
         annotations:
           reloader.stakater.com/auto: "true"
           glance/id: pocket-id
-          glance/name: Pocket ID
-          glance/icon: si:keycloak
-          glance/category: auth
-          glance/url: https://id.zebernst.dev
 
         initContainers:
           init-db:
@@ -118,6 +114,10 @@ spec:
           gatus.home-operations.com/endpoint: |
             name: "{{ .Release.Name }}"
             group: "{{ .Release.Namespace }}"
+          glance/name: Pocket ID
+          glance/icon: si:keycloak
+          glance/category: auth
+          glance/url: https://id.zebernst.dev
         hostnames:
           - id.zebernst.dev
         parentRefs:

--- a/kubernetes/apps/auth/tinyauth/app/helmrelease.yaml
+++ b/kubernetes/apps/auth/tinyauth/app/helmrelease.yaml
@@ -16,6 +16,11 @@ spec:
       tinyauth:
         annotations:
           reloader.stakater.com/auto: "true"
+          glance/id: tinyauth
+          glance/name: Tinyauth
+          glance/icon: mdi:shield-account
+          glance/category: auth
+          glance/url: https://auth.zebernst.dev
 
         containers:
           tinyauth:

--- a/kubernetes/apps/auth/tinyauth/app/helmrelease.yaml
+++ b/kubernetes/apps/auth/tinyauth/app/helmrelease.yaml
@@ -17,10 +17,6 @@ spec:
         annotations:
           reloader.stakater.com/auto: "true"
           glance/id: tinyauth
-          glance/name: Tinyauth
-          glance/icon: mdi:shield-account
-          glance/category: auth
-          glance/url: https://auth.zebernst.dev
 
         containers:
           tinyauth:
@@ -72,6 +68,9 @@ spec:
           gatus.home-operations.com/endpoint: |
             name: "{{ .Release.Name }}"
             group: "{{ .Release.Namespace }}"
+          glance/name: Tinyauth
+          glance/icon: mdi:shield-account
+          glance/category: auth
         hostnames:
           - auth.zebernst.dev
         parentRefs:

--- a/kubernetes/apps/downloads/autobrr/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/autobrr/app/helmrelease.yaml
@@ -16,6 +16,11 @@ spec:
       autobrr:
         annotations:
           reloader.stakater.com/auto: "true"
+          glance/id: autobrr
+          glance/name: Autobrr
+          glance/icon: mdi:robot
+          glance/category: downloads
+          glance/url: https://autobrr.kite-harmonic.ts.net
         initContainers:
           init-db:
             image:

--- a/kubernetes/apps/downloads/autobrr/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/autobrr/app/helmrelease.yaml
@@ -17,10 +17,6 @@ spec:
         annotations:
           reloader.stakater.com/auto: "true"
           glance/id: autobrr
-          glance/name: Autobrr
-          glance/icon: mdi:robot
-          glance/category: downloads
-          glance/url: https://autobrr.kite-harmonic.ts.net
         initContainers:
           init-db:
             image:
@@ -85,6 +81,10 @@ spec:
           gatus.home-operations.com/endpoint: |
             name: "{{ .Release.Name }}"
             group: "{{ .Release.Namespace }}"
+          glance/name: Autobrr
+          glance/icon: mdi:robot
+          glance/category: downloads
+          glance/url: https://autobrr.kite-harmonic.ts.net
         hostnames:
           - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/downloads/bazarr/hd/helmrelease.yaml
+++ b/kubernetes/apps/downloads/bazarr/hd/helmrelease.yaml
@@ -16,6 +16,11 @@ spec:
       bazarr:
         annotations:
           reloader.stakater.com/auto: "true"
+          glance/id: bazarr-hd
+          glance/name: Bazarr HD
+          glance/icon: si:bazarr
+          glance/category: downloads
+          glance/url: https://bazarr.kite-harmonic.ts.net
         containers:
           bazarr:
             image:

--- a/kubernetes/apps/downloads/bazarr/hd/helmrelease.yaml
+++ b/kubernetes/apps/downloads/bazarr/hd/helmrelease.yaml
@@ -17,10 +17,6 @@ spec:
         annotations:
           reloader.stakater.com/auto: "true"
           glance/id: bazarr-hd
-          glance/name: Bazarr HD
-          glance/icon: si:bazarr
-          glance/category: downloads
-          glance/url: https://bazarr.kite-harmonic.ts.net
         containers:
           bazarr:
             image:
@@ -120,6 +116,10 @@ spec:
           gatus.home-operations.com/endpoint: |
             name: "{{ .Release.Name }}"
             group: "{{ .Release.Namespace }}"
+          glance/name: Bazarr HD
+          glance/icon: si:bazarr
+          glance/category: downloads
+          glance/url: https://bazarr.kite-harmonic.ts.net
         hostnames:
           - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/downloads/bazarr/uhd/helmrelease.yaml
+++ b/kubernetes/apps/downloads/bazarr/uhd/helmrelease.yaml
@@ -16,6 +16,11 @@ spec:
       bazarr-uhd:
         annotations:
           reloader.stakater.com/auto: "true"
+          glance/id: bazarr-uhd
+          glance/name: Bazarr UHD
+          glance/icon: si:bazarr
+          glance/category: downloads
+          glance/url: https://bazarr-uhd.kite-harmonic.ts.net
         containers:
           bazarr-uhd:
             image:

--- a/kubernetes/apps/downloads/bazarr/uhd/helmrelease.yaml
+++ b/kubernetes/apps/downloads/bazarr/uhd/helmrelease.yaml
@@ -17,10 +17,6 @@ spec:
         annotations:
           reloader.stakater.com/auto: "true"
           glance/id: bazarr-uhd
-          glance/name: Bazarr UHD
-          glance/icon: si:bazarr
-          glance/category: downloads
-          glance/url: https://bazarr-uhd.kite-harmonic.ts.net
         containers:
           bazarr-uhd:
             image:
@@ -120,6 +116,10 @@ spec:
           gatus.home-operations.com/endpoint: |
             name: "{{ .Release.Name }}"
             group: "{{ .Release.Namespace }}"
+          glance/name: Bazarr UHD
+          glance/icon: si:bazarr
+          glance/category: downloads
+          glance/url: https://bazarr-uhd.kite-harmonic.ts.net
         hostnames:
           - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/downloads/cross-seed/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/cross-seed/app/helmrelease.yaml
@@ -19,6 +19,7 @@ spec:
       cross-seed:
         annotations:
           reloader.stakater.com/auto: "true"
+          glance/hide: "true"
 
         containers:
           cross-seed:

--- a/kubernetes/apps/downloads/flaresolverr/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/flaresolverr/app/helmrelease.yaml
@@ -15,11 +15,10 @@ spec:
     controllers:
       flaresolverr:
         annotations:
+          reloader.stakater.com/auto: "true"
           glance/hide: "true"
         replicas: 2
         strategy: RollingUpdate
-        annotations:
-          reloader.stakater.com/auto: "true"
         containers:
           flaresolverr:
             image:

--- a/kubernetes/apps/downloads/flaresolverr/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/flaresolverr/app/helmrelease.yaml
@@ -14,6 +14,8 @@ spec:
   values:
     controllers:
       flaresolverr:
+        annotations:
+          glance/hide: "true"
         replicas: 2
         strategy: RollingUpdate
         annotations:

--- a/kubernetes/apps/downloads/lidarr/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/lidarr/app/helmrelease.yaml
@@ -16,6 +16,11 @@ spec:
       lidarr:
         annotations:
           reloader.stakater.com/auto: "true"
+          glance/id: lidarr
+          glance/name: Lidarr
+          glance/icon: si:lidarr
+          glance/category: downloads
+          glance/url: https://lidarr.kite-harmonic.ts.net
         initContainers:
           init-db:
             image:

--- a/kubernetes/apps/downloads/lidarr/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/lidarr/app/helmrelease.yaml
@@ -17,10 +17,6 @@ spec:
         annotations:
           reloader.stakater.com/auto: "true"
           glance/id: lidarr
-          glance/name: Lidarr
-          glance/icon: si:lidarr
-          glance/category: downloads
-          glance/url: https://lidarr.kite-harmonic.ts.net
         initContainers:
           init-db:
             image:
@@ -120,6 +116,10 @@ spec:
           gatus.home-operations.com/endpoint: |
             name: "{{ .Release.Name }}"
             group: "{{ .Release.Namespace }}"
+          glance/name: Lidarr
+          glance/icon: si:lidarr
+          glance/category: downloads
+          glance/url: https://lidarr.kite-harmonic.ts.net
         hostnames:
           - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/downloads/omegabrr/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/omegabrr/app/helmrelease.yaml
@@ -19,6 +19,7 @@ spec:
       omegabrr:
         annotations:
           reloader.stakater.com/auto: "true"
+          glance/hide: "true"
         containers:
           omegabrr:
             image:

--- a/kubernetes/apps/downloads/openbooks/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/openbooks/app/helmrelease.yaml
@@ -16,6 +16,11 @@ spec:
       openbooks:
         annotations:
           reloader.stakater.com/auto: "true"
+          glance/id: openbooks
+          glance/name: OpenBooks
+          glance/icon: mdi:book-search
+          glance/category: downloads
+          glance/url: https://openbooks.kite-harmonic.ts.net
         containers:
           openbooks:
             image:

--- a/kubernetes/apps/downloads/openbooks/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/openbooks/app/helmrelease.yaml
@@ -17,10 +17,6 @@ spec:
         annotations:
           reloader.stakater.com/auto: "true"
           glance/id: openbooks
-          glance/name: OpenBooks
-          glance/icon: mdi:book-search
-          glance/category: downloads
-          glance/url: https://openbooks.kite-harmonic.ts.net
         containers:
           openbooks:
             image:
@@ -59,6 +55,10 @@ spec:
           gatus.home-operations.com/endpoint: |
             name: "{{ .Release.Name }}"
             group: "{{ .Release.Namespace }}"
+          glance/name: OpenBooks
+          glance/icon: mdi:book-search
+          glance/category: downloads
+          glance/url: https://openbooks.kite-harmonic.ts.net
         hostnames:
           - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/downloads/prowlarr/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/prowlarr/app/helmrelease.yaml
@@ -16,6 +16,11 @@ spec:
       prowlarr:
         annotations:
           reloader.stakater.com/auto: "true"
+          glance/id: prowlarr
+          glance/name: Prowlarr
+          glance/icon: si:prowlarr
+          glance/category: downloads
+          glance/url: https://prowlarr.kite-harmonic.ts.net
         initContainers:
           init-db:
             image:

--- a/kubernetes/apps/downloads/prowlarr/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/prowlarr/app/helmrelease.yaml
@@ -17,10 +17,6 @@ spec:
         annotations:
           reloader.stakater.com/auto: "true"
           glance/id: prowlarr
-          glance/name: Prowlarr
-          glance/icon: si:prowlarr
-          glance/category: downloads
-          glance/url: https://prowlarr.kite-harmonic.ts.net
         initContainers:
           init-db:
             image:
@@ -118,6 +114,10 @@ spec:
           gatus.home-operations.com/endpoint: |
             name: "{{ .Release.Name }}"
             group: "{{ .Release.Namespace }}"
+          glance/name: Prowlarr
+          glance/icon: si:prowlarr
+          glance/category: downloads
+          glance/url: https://prowlarr.kite-harmonic.ts.net
         hostnames:
           - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/downloads/qbittorrent/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/qbittorrent/app/helmrelease.yaml
@@ -16,6 +16,11 @@ spec:
       qbittorrent:
         annotations:
           reloader.stakater.com/auto: "true"
+          glance/id: qbittorrent
+          glance/name: qBittorrent
+          glance/icon: si:qbittorrent
+          glance/category: downloads
+          glance/url: https://qbittorrent.kite-harmonic.ts.net
         containers:
           qbittorrent:
             image:

--- a/kubernetes/apps/downloads/qui/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/qui/app/helmrelease.yaml
@@ -16,6 +16,11 @@ spec:
       qui:
         annotations:
           reloader.stakater.com/auto: "true"
+          glance/id: qui
+          glance/name: Qui
+          glance/icon: si:qbittorrent
+          glance/category: downloads
+          glance/url: https://qui.zebernst.dev
         containers:
           qui:
             image:

--- a/kubernetes/apps/downloads/qui/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/qui/app/helmrelease.yaml
@@ -17,10 +17,6 @@ spec:
         annotations:
           reloader.stakater.com/auto: "true"
           glance/id: qui
-          glance/name: Qui
-          glance/icon: si:qbittorrent
-          glance/category: downloads
-          glance/url: https://qui.zebernst.dev
         containers:
           qui:
             image:
@@ -103,6 +99,10 @@ spec:
           gatus.home-operations.com/endpoint: |
             name: "{{ .Release.Name }}"
             group: "{{ .Release.Namespace }}"
+          glance/name: Qui
+          glance/icon: si:qbittorrent
+          glance/category: downloads
+          glance/url: https://qui.zebernst.dev
         hostnames:
           - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/downloads/radarr/app/hd/helmrelease.yaml
+++ b/kubernetes/apps/downloads/radarr/app/hd/helmrelease.yaml
@@ -16,6 +16,11 @@ spec:
       radarr:
         annotations:
           reloader.stakater.com/auto: "true"
+          glance/id: radarr-hd
+          glance/name: Radarr HD
+          glance/icon: si:radarr
+          glance/category: downloads
+          glance/url: https://radarr.kite-harmonic.ts.net
         initContainers:
           init-db:
             image:

--- a/kubernetes/apps/downloads/radarr/app/hd/helmrelease.yaml
+++ b/kubernetes/apps/downloads/radarr/app/hd/helmrelease.yaml
@@ -17,10 +17,6 @@ spec:
         annotations:
           reloader.stakater.com/auto: "true"
           glance/id: radarr-hd
-          glance/name: Radarr HD
-          glance/icon: si:radarr
-          glance/category: downloads
-          glance/url: https://radarr.kite-harmonic.ts.net
         initContainers:
           init-db:
             image:
@@ -121,6 +117,10 @@ spec:
           gatus.home-operations.com/endpoint: |
             name: "{{ .Release.Name }}"
             group: "{{ .Release.Namespace }}"
+          glance/name: Radarr HD
+          glance/icon: si:radarr
+          glance/category: downloads
+          glance/url: https://radarr.kite-harmonic.ts.net
         hostnames:
           - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/downloads/radarr/app/uhd/helmrelease.yaml
+++ b/kubernetes/apps/downloads/radarr/app/uhd/helmrelease.yaml
@@ -16,6 +16,11 @@ spec:
       radarr-uhd:
         annotations:
           reloader.stakater.com/auto: "true"
+          glance/id: radarr-uhd
+          glance/name: Radarr UHD
+          glance/icon: si:radarr
+          glance/category: downloads
+          glance/url: https://radarr-uhd.kite-harmonic.ts.net
         initContainers:
           init-db:
             image:

--- a/kubernetes/apps/downloads/radarr/app/uhd/helmrelease.yaml
+++ b/kubernetes/apps/downloads/radarr/app/uhd/helmrelease.yaml
@@ -17,10 +17,6 @@ spec:
         annotations:
           reloader.stakater.com/auto: "true"
           glance/id: radarr-uhd
-          glance/name: Radarr UHD
-          glance/icon: si:radarr
-          glance/category: downloads
-          glance/url: https://radarr-uhd.kite-harmonic.ts.net
         initContainers:
           init-db:
             image:
@@ -121,6 +117,10 @@ spec:
           gatus.home-operations.com/endpoint: |
             name: "{{ .Release.Name }}"
             group: "{{ .Release.Namespace }}"
+          glance/name: Radarr UHD
+          glance/icon: si:radarr
+          glance/category: downloads
+          glance/url: https://radarr-uhd.kite-harmonic.ts.net
         hostnames:
           - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/downloads/sonarr/app/hd/helmrelease.yaml
+++ b/kubernetes/apps/downloads/sonarr/app/hd/helmrelease.yaml
@@ -16,6 +16,11 @@ spec:
       sonarr:
         annotations:
           reloader.stakater.com/auto: "true"
+          glance/id: sonarr-hd
+          glance/name: Sonarr HD
+          glance/icon: si:sonarr
+          glance/category: downloads
+          glance/url: https://sonarr.kite-harmonic.ts.net
         initContainers:
           init-db:
             image:

--- a/kubernetes/apps/downloads/sonarr/app/hd/helmrelease.yaml
+++ b/kubernetes/apps/downloads/sonarr/app/hd/helmrelease.yaml
@@ -17,10 +17,6 @@ spec:
         annotations:
           reloader.stakater.com/auto: "true"
           glance/id: sonarr-hd
-          glance/name: Sonarr HD
-          glance/icon: si:sonarr
-          glance/category: downloads
-          glance/url: https://sonarr.kite-harmonic.ts.net
         initContainers:
           init-db:
             image:
@@ -119,6 +115,10 @@ spec:
           gatus.home-operations.com/endpoint: |
             name: "{{ .Release.Name }}"
             group: "{{ .Release.Namespace }}"
+          glance/name: Sonarr HD
+          glance/icon: si:sonarr
+          glance/category: downloads
+          glance/url: https://sonarr.kite-harmonic.ts.net
         hostnames:
           - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/downloads/sonarr/app/uhd/helmrelease.yaml
+++ b/kubernetes/apps/downloads/sonarr/app/uhd/helmrelease.yaml
@@ -16,6 +16,11 @@ spec:
       sonarr-uhd:
         annotations:
           reloader.stakater.com/auto: "true"
+          glance/id: sonarr-uhd
+          glance/name: Sonarr UHD
+          glance/icon: si:sonarr
+          glance/category: downloads
+          glance/url: https://sonarr-uhd.kite-harmonic.ts.net
         initContainers:
           init-db:
             image:

--- a/kubernetes/apps/downloads/sonarr/app/uhd/helmrelease.yaml
+++ b/kubernetes/apps/downloads/sonarr/app/uhd/helmrelease.yaml
@@ -17,10 +17,6 @@ spec:
         annotations:
           reloader.stakater.com/auto: "true"
           glance/id: sonarr-uhd
-          glance/name: Sonarr UHD
-          glance/icon: si:sonarr
-          glance/category: downloads
-          glance/url: https://sonarr-uhd.kite-harmonic.ts.net
         initContainers:
           init-db:
             image:
@@ -119,6 +115,10 @@ spec:
           gatus.home-operations.com/endpoint: |
             name: "{{ .Release.Name }}"
             group: "{{ .Release.Namespace }}"
+          glance/name: Sonarr UHD
+          glance/icon: si:sonarr
+          glance/category: downloads
+          glance/url: https://sonarr-uhd.kite-harmonic.ts.net
         hostnames:
           - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/downloads/whisparr/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/whisparr/app/helmrelease.yaml
@@ -16,6 +16,11 @@ spec:
       whisparr:
         annotations:
           reloader.stakater.com/auto: "true"
+          glance/id: whisparr
+          glance/name: Whisparr
+          glance/icon: si:sonarr
+          glance/category: downloads
+          glance/url: https://whisparr.kite-harmonic.ts.net
         initContainers:
           init-db:
             image:

--- a/kubernetes/apps/downloads/whisparr/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/whisparr/app/helmrelease.yaml
@@ -17,10 +17,6 @@ spec:
         annotations:
           reloader.stakater.com/auto: "true"
           glance/id: whisparr
-          glance/name: Whisparr
-          glance/icon: si:sonarr
-          glance/category: downloads
-          glance/url: https://whisparr.kite-harmonic.ts.net
         initContainers:
           init-db:
             image:
@@ -84,6 +80,10 @@ spec:
           gatus.home-operations.com/endpoint: |
             name: "{{ .Release.Name }}"
             group: "{{ .Release.Namespace }}"
+          glance/name: Whisparr
+          glance/icon: si:sonarr
+          glance/category: downloads
+          glance/url: https://whisparr.kite-harmonic.ts.net
         hostnames:
           - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/games/minecraft/atm10/app/helmrelease.yaml
+++ b/kubernetes/apps/games/minecraft/atm10/app/helmrelease.yaml
@@ -25,6 +25,12 @@ spec:
   values:
     controllers:
       atm10:
+        annotations:
+          glance/id: minecraft-atm10
+          glance/name: Minecraft ATM10
+          glance/icon: si:minecraft
+          glance/category: games
+          glance/parent: minecraft
         type: statefulset
         annotations:
           reloader.stakater.com/auto: "true"

--- a/kubernetes/apps/games/minecraft/atm10/app/helmrelease.yaml
+++ b/kubernetes/apps/games/minecraft/atm10/app/helmrelease.yaml
@@ -28,10 +28,6 @@ spec:
         type: statefulset
         annotations:
           reloader.stakater.com/auto: "true"
-          glance/id: minecraft-atm10
-          glance/name: Minecraft ATM10
-          glance/icon: si:minecraft
-          glance/category: games
           glance/parent: minecraft
         initContainers:
           init-bluemap-config:

--- a/kubernetes/apps/games/minecraft/atm10/app/helmrelease.yaml
+++ b/kubernetes/apps/games/minecraft/atm10/app/helmrelease.yaml
@@ -25,15 +25,14 @@ spec:
   values:
     controllers:
       atm10:
+        type: statefulset
         annotations:
+          reloader.stakater.com/auto: "true"
           glance/id: minecraft-atm10
           glance/name: Minecraft ATM10
           glance/icon: si:minecraft
           glance/category: games
           glance/parent: minecraft
-        type: statefulset
-        annotations:
-          reloader.stakater.com/auto: "true"
         initContainers:
           init-bluemap-config:
             image:

--- a/kubernetes/apps/games/minecraft/atmons/app/helmrelease.yaml
+++ b/kubernetes/apps/games/minecraft/atmons/app/helmrelease.yaml
@@ -25,6 +25,12 @@ spec:
   values:
     controllers:
       atmons:
+        annotations:
+          glance/id: minecraft-atmons
+          glance/name: Minecraft ATMons
+          glance/icon: si:minecraft
+          glance/category: games
+          glance/parent: minecraft
         type: statefulset
         annotations:
           reloader.stakater.com/auto: "true"

--- a/kubernetes/apps/games/minecraft/atmons/app/helmrelease.yaml
+++ b/kubernetes/apps/games/minecraft/atmons/app/helmrelease.yaml
@@ -28,10 +28,6 @@ spec:
         type: statefulset
         annotations:
           reloader.stakater.com/auto: "true"
-          glance/id: minecraft-atmons
-          glance/name: Minecraft ATMons
-          glance/icon: si:minecraft
-          glance/category: games
           glance/parent: minecraft
         initContainers:
           init-bluemap-config:

--- a/kubernetes/apps/games/minecraft/atmons/app/helmrelease.yaml
+++ b/kubernetes/apps/games/minecraft/atmons/app/helmrelease.yaml
@@ -25,15 +25,14 @@ spec:
   values:
     controllers:
       atmons:
+        type: statefulset
         annotations:
+          reloader.stakater.com/auto: "true"
           glance/id: minecraft-atmons
           glance/name: Minecraft ATMons
           glance/icon: si:minecraft
           glance/category: games
           glance/parent: minecraft
-        type: statefulset
-        annotations:
-          reloader.stakater.com/auto: "true"
         initContainers:
           init-bluemap-config:
             image:

--- a/kubernetes/apps/games/minecraft/bluemap/app/helmrelease.yaml
+++ b/kubernetes/apps/games/minecraft/bluemap/app/helmrelease.yaml
@@ -16,6 +16,11 @@ spec:
       bluemap:
         annotations:
           reloader.stakater.com/auto: "true"
+          glance/id: bluemap
+          glance/name: BlueMap
+          glance/icon: si:minecraft
+          glance/category: games
+          glance/parent: minecraft
         initContainers:
           init-config:
             image:

--- a/kubernetes/apps/games/minecraft/bluemap/app/helmrelease.yaml
+++ b/kubernetes/apps/games/minecraft/bluemap/app/helmrelease.yaml
@@ -16,10 +16,6 @@ spec:
       bluemap:
         annotations:
           reloader.stakater.com/auto: "true"
-          glance/id: bluemap
-          glance/name: BlueMap
-          glance/icon: si:minecraft
-          glance/category: games
           glance/parent: minecraft
         initContainers:
           init-config:

--- a/kubernetes/apps/games/minecraft/router/app/helmrelease.yaml
+++ b/kubernetes/apps/games/minecraft/router/app/helmrelease.yaml
@@ -47,6 +47,11 @@ spec:
       mc-router:
         annotations:
           reloader.stakater.com/auto: "true"
+          glance/id: minecraft
+          glance/name: Minecraft
+          glance/icon: si:minecraft
+          glance/category: games
+          glance/url: https://worldmap.zebernst.dev
         containers:
           mc-router:
             image:

--- a/kubernetes/apps/games/minecraft/router/app/helmrelease.yaml
+++ b/kubernetes/apps/games/minecraft/router/app/helmrelease.yaml
@@ -48,10 +48,6 @@ spec:
         annotations:
           reloader.stakater.com/auto: "true"
           glance/id: minecraft
-          glance/name: Minecraft
-          glance/icon: si:minecraft
-          glance/category: games
-          glance/url: https://worldmap.zebernst.dev
         containers:
           mc-router:
             image:
@@ -125,6 +121,10 @@ spec:
         annotations:
           # Health is on the Service above; don't also probe via the HTTPRoute
           gatus.home-operations.com/enabled: "false"
+          glance/name: Minecraft
+          glance/icon: si:minecraft
+          glance/category: games
+          glance/url: https://worldmap.zebernst.dev
         hostnames: ["mc-api.zebernst.dev"]
         parentRefs:
           - name: lan

--- a/kubernetes/apps/games/minecraft/vanilla/app/helmrelease.yaml
+++ b/kubernetes/apps/games/minecraft/vanilla/app/helmrelease.yaml
@@ -14,15 +14,14 @@ spec:
   values:
     controllers:
       vanilla:
+        type: statefulset
         annotations:
+          reloader.stakater.com/auto: "true"
           glance/id: minecraft-vanilla
           glance/name: Minecraft Vanilla
           glance/icon: si:minecraft
           glance/category: games
           glance/parent: minecraft
-        type: statefulset
-        annotations:
-          reloader.stakater.com/auto: "true"
         initContainers:
           init-bluemap-config:
             image:

--- a/kubernetes/apps/games/minecraft/vanilla/app/helmrelease.yaml
+++ b/kubernetes/apps/games/minecraft/vanilla/app/helmrelease.yaml
@@ -14,6 +14,12 @@ spec:
   values:
     controllers:
       vanilla:
+        annotations:
+          glance/id: minecraft-vanilla
+          glance/name: Minecraft Vanilla
+          glance/icon: si:minecraft
+          glance/category: games
+          glance/parent: minecraft
         type: statefulset
         annotations:
           reloader.stakater.com/auto: "true"

--- a/kubernetes/apps/games/minecraft/vanilla/app/helmrelease.yaml
+++ b/kubernetes/apps/games/minecraft/vanilla/app/helmrelease.yaml
@@ -17,10 +17,6 @@ spec:
         type: statefulset
         annotations:
           reloader.stakater.com/auto: "true"
-          glance/id: minecraft-vanilla
-          glance/name: Minecraft Vanilla
-          glance/icon: si:minecraft
-          glance/category: games
           glance/parent: minecraft
         initContainers:
           init-bluemap-config:

--- a/kubernetes/apps/media/agregarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/agregarr/app/helmrelease.yaml
@@ -14,6 +14,12 @@ spec:
   values:
     controllers:
       agregarr:
+        annotations:
+          glance/id: agregarr
+          glance/name: Agregarr
+          glance/icon: si:sonarr
+          glance/category: media
+          glance/url: https://agregarr.zebernst.dev
         containers:
           agregarr:
             image:

--- a/kubernetes/apps/media/agregarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/agregarr/app/helmrelease.yaml
@@ -14,12 +14,6 @@ spec:
   values:
     controllers:
       agregarr:
-        annotations:
-          glance/id: agregarr
-          glance/name: Agregarr
-          glance/icon: si:sonarr
-          glance/category: media
-          glance/url: https://agregarr.zebernst.dev
         containers:
           agregarr:
             image:
@@ -74,6 +68,11 @@ spec:
           gatus.home-operations.com/endpoint: |
             name: "{{ .Release.Name }}"
             group: "{{ .Release.Namespace }}"
+          glance/id: agregarr
+          glance/name: Agregarr
+          glance/icon: si:sonarr
+          glance/category: media
+          glance/url: https://agregarr.zebernst.dev
         hostnames:
           - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/media/booklore/app/helmrelease.yaml
+++ b/kubernetes/apps/media/booklore/app/helmrelease.yaml
@@ -14,6 +14,12 @@ spec:
   values:
     controllers:
       booklore:
+        annotations:
+          glance/id: booklore
+          glance/name: Booklore
+          glance/icon: mdi:book-open-variant
+          glance/category: media
+          glance/url: https://booklore.zebernst.dev
         containers:
           booklore:
             image:

--- a/kubernetes/apps/media/booklore/app/helmrelease.yaml
+++ b/kubernetes/apps/media/booklore/app/helmrelease.yaml
@@ -14,12 +14,6 @@ spec:
   values:
     controllers:
       booklore:
-        annotations:
-          glance/id: booklore
-          glance/name: Booklore
-          glance/icon: mdi:book-open-variant
-          glance/category: media
-          glance/url: https://booklore.zebernst.dev
         containers:
           booklore:
             image:
@@ -74,6 +68,11 @@ spec:
           gatus.home-operations.com/endpoint: |
             name: "{{ .Release.Name }}"
             group: "{{ .Release.Namespace }}"
+          glance/id: booklore
+          glance/name: Booklore
+          glance/icon: mdi:book-open-variant
+          glance/category: media
+          glance/url: https://booklore.zebernst.dev
         hostnames:
           - "{{ .Release.Name }}.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/media/capacitarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/capacitarr/app/helmrelease.yaml
@@ -16,6 +16,11 @@ spec:
       capacitarr:
         annotations:
           reloader.stakater.com/auto: "true"
+          glance/id: capacitarr
+          glance/name: Capacitarr
+          glance/icon: si:sonarr
+          glance/category: media
+          glance/url: https://capacitarr.zebernst.dev
         containers:
           capacitarr:
             image:

--- a/kubernetes/apps/media/capacitarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/capacitarr/app/helmrelease.yaml
@@ -17,10 +17,6 @@ spec:
         annotations:
           reloader.stakater.com/auto: "true"
           glance/id: capacitarr
-          glance/name: Capacitarr
-          glance/icon: si:sonarr
-          glance/category: media
-          glance/url: https://capacitarr.zebernst.dev
         containers:
           capacitarr:
             image:
@@ -74,6 +70,10 @@ spec:
             name: "{{ .Release.Name }}"
             group: "{{ .Release.Namespace }}"
             path: /api/v1/health
+          glance/name: Capacitarr
+          glance/icon: si:sonarr
+          glance/category: media
+          glance/url: https://capacitarr.zebernst.dev
         hostnames:
           - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/media/maintainerr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/maintainerr/app/helmrelease.yaml
@@ -16,6 +16,11 @@ spec:
       maintainerr:
         annotations:
           reloader.stakater.com/auto: "true"
+          glance/id: maintainerr
+          glance/name: Maintainerr
+          glance/icon: mdi:broom
+          glance/category: media
+          glance/url: https://maintainerr.kite-harmonic.ts.net
         containers:
           maintainerr:
             image:

--- a/kubernetes/apps/media/maintainerr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/maintainerr/app/helmrelease.yaml
@@ -17,10 +17,6 @@ spec:
         annotations:
           reloader.stakater.com/auto: "true"
           glance/id: maintainerr
-          glance/name: Maintainerr
-          glance/icon: mdi:broom
-          glance/category: media
-          glance/url: https://maintainerr.kite-harmonic.ts.net
         containers:
           maintainerr:
             image:
@@ -64,6 +60,10 @@ spec:
           gatus.home-operations.com/endpoint: |
             name: "{{ .Release.Name }}"
             group: "{{ .Release.Namespace }}"
+          glance/name: Maintainerr
+          glance/icon: mdi:broom
+          glance/category: media
+          glance/url: https://maintainerr.kite-harmonic.ts.net
         hostnames:
           - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/media/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/media/plex/app/helmrelease.yaml
@@ -19,6 +19,11 @@ spec:
       plex:
         annotations:
           reloader.stakater.com/auto: "true"
+          glance/id: plex
+          glance/name: Plex
+          glance/icon: si:plex
+          glance/category: media
+          glance/url: https://plex.zebernst.dev
         containers:
           plex:
             image:

--- a/kubernetes/apps/media/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/media/plex/app/helmrelease.yaml
@@ -20,10 +20,6 @@ spec:
         annotations:
           reloader.stakater.com/auto: "true"
           glance/id: plex
-          glance/name: Plex
-          glance/icon: si:plex
-          glance/category: media
-          glance/url: https://plex.zebernst.dev
         containers:
           plex:
             image:
@@ -97,6 +93,10 @@ spec:
             name: "{{ .Release.Name }}"
             group: "{{ .Release.Namespace }}"
             path: /web/index.html
+          glance/name: Plex
+          glance/icon: si:plex
+          glance/category: media
+          glance/url: https://plex.zebernst.dev
         hostnames:
           - "{{ .Release.Name }}.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/media/seerr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/seerr/app/helmrelease.yaml
@@ -16,6 +16,11 @@ spec:
       seerr:
         annotations:
           reloader.stakater.com/auto: "true"
+          glance/id: seerr
+          glance/name: Seerr
+          glance/icon: mdi:movie-open
+          glance/category: media
+          glance/url: https://requests.zebernst.dev
         containers:
           seerr:
             image:

--- a/kubernetes/apps/media/seerr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/seerr/app/helmrelease.yaml
@@ -17,10 +17,6 @@ spec:
         annotations:
           reloader.stakater.com/auto: "true"
           glance/id: seerr
-          glance/name: Seerr
-          glance/icon: mdi:movie-open
-          glance/category: media
-          glance/url: https://requests.zebernst.dev
         containers:
           seerr:
             image:
@@ -75,6 +71,9 @@ spec:
             name: "{{ .Release.Name }}"
             group: "{{ .Release.Namespace }}"
             path: /api/v1/status
+          glance/name: Seerr
+          glance/icon: mdi:movie-open
+          glance/category: media
         hostnames:
           - "requests.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/media/shelfmark/app/helmrelease.yaml
+++ b/kubernetes/apps/media/shelfmark/app/helmrelease.yaml
@@ -14,6 +14,12 @@ spec:
   values:
     controllers:
       shelfmark:
+        annotations:
+          glance/id: shelfmark
+          glance/name: Shelfmark
+          glance/icon: mdi:bookmark
+          glance/category: media
+          glance/url: https://shelfmark.zebernst.dev
         containers:
           shelfmark:
             image:

--- a/kubernetes/apps/media/shelfmark/app/helmrelease.yaml
+++ b/kubernetes/apps/media/shelfmark/app/helmrelease.yaml
@@ -14,12 +14,6 @@ spec:
   values:
     controllers:
       shelfmark:
-        annotations:
-          glance/id: shelfmark
-          glance/name: Shelfmark
-          glance/icon: mdi:bookmark
-          glance/category: media
-          glance/url: https://shelfmark.zebernst.dev
         containers:
           shelfmark:
             image:
@@ -65,6 +59,11 @@ spec:
           gatus.home-operations.com/endpoint: |
             name: "{{ .Release.Name }}"
             group: "{{ .Release.Namespace }}"
+          glance/id: shelfmark
+          glance/name: Shelfmark
+          glance/icon: mdi:bookmark
+          glance/category: media
+          glance/url: https://shelfmark.zebernst.dev
         hostnames:
           - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/media/stash/app/helmrelease.yaml
+++ b/kubernetes/apps/media/stash/app/helmrelease.yaml
@@ -16,6 +16,11 @@ spec:
       stash:
         annotations:
           reloader.stakater.com/auto: "true"
+          glance/id: stash
+          glance/name: Stash
+          glance/icon: mdi:filmstrip-box
+          glance/category: media
+          glance/url: https://stash.kite-harmonic.ts.net
         containers:
           stash:
             image:

--- a/kubernetes/apps/media/stash/app/helmrelease.yaml
+++ b/kubernetes/apps/media/stash/app/helmrelease.yaml
@@ -17,10 +17,6 @@ spec:
         annotations:
           reloader.stakater.com/auto: "true"
           glance/id: stash
-          glance/name: Stash
-          glance/icon: mdi:filmstrip-box
-          glance/category: media
-          glance/url: https://stash.kite-harmonic.ts.net
         containers:
           stash:
             image:
@@ -95,6 +91,10 @@ spec:
           gatus.home-operations.com/endpoint: |
             name: "{{ .Release.Name }}"
             group: "{{ .Release.Namespace }}"
+          glance/name: Stash
+          glance/icon: mdi:filmstrip-box
+          glance/category: media
+          glance/url: https://stash.kite-harmonic.ts.net
         hostnames:
           - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/media/steam/app/helmrelease.yaml
+++ b/kubernetes/apps/media/steam/app/helmrelease.yaml
@@ -16,6 +16,11 @@ spec:
       steam:
         annotations:
           reloader.stakater.com/auto: "true"
+          glance/id: steam
+          glance/name: Steam Headless
+          glance/icon: si:steam
+          glance/category: media
+          glance/url: https://steam.kite-harmonic.ts.net
         containers:
           steam:
             image:

--- a/kubernetes/apps/media/steam/app/helmrelease.yaml
+++ b/kubernetes/apps/media/steam/app/helmrelease.yaml
@@ -17,10 +17,6 @@ spec:
         annotations:
           reloader.stakater.com/auto: "true"
           glance/id: steam
-          glance/name: Steam Headless
-          glance/icon: si:steam
-          glance/category: media
-          glance/url: https://steam.kite-harmonic.ts.net
         containers:
           steam:
             image:
@@ -103,6 +99,10 @@ spec:
           gatus.home-operations.com/endpoint: |
             name: "{{ .Release.Name }}"
             group: "{{ .Release.Namespace }}"
+          glance/name: Steam Headless
+          glance/icon: si:steam
+          glance/category: media
+          glance/url: https://steam.kite-harmonic.ts.net
         hostnames:
           - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/media/tautulli/app/helmrelease.yaml
+++ b/kubernetes/apps/media/tautulli/app/helmrelease.yaml
@@ -16,6 +16,11 @@ spec:
       tautulli:
         annotations:
           reloader.stakater.com/auto: "true"
+          glance/id: tautulli
+          glance/name: Tautulli
+          glance/icon: si:plex
+          glance/category: media
+          glance/url: https://tautulli.zebernst.dev
         containers:
           tautulli:
             image:

--- a/kubernetes/apps/media/tautulli/app/helmrelease.yaml
+++ b/kubernetes/apps/media/tautulli/app/helmrelease.yaml
@@ -17,10 +17,6 @@ spec:
         annotations:
           reloader.stakater.com/auto: "true"
           glance/id: tautulli
-          glance/name: Tautulli
-          glance/icon: si:plex
-          glance/category: media
-          glance/url: https://tautulli.zebernst.dev
         containers:
           tautulli:
             image:
@@ -76,6 +72,10 @@ spec:
           gatus.home-operations.com/endpoint: |
             name: "{{ .Release.Name }}"
             group: "{{ .Release.Namespace }}"
+          glance/name: Tautulli
+          glance/icon: si:plex
+          glance/category: media
+          glance/url: https://tautulli.zebernst.dev
         hostnames:
           - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/media/wizarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/wizarr/app/helmrelease.yaml
@@ -19,6 +19,11 @@ spec:
       wizarr:
         annotations:
           reloader.stakater.com/auto: "true"
+          glance/id: wizarr
+          glance/name: Wizarr
+          glance/icon: mdi:account-plus
+          glance/category: media
+          glance/url: https://join.zebernst.dev
         containers:
           wizarr:
             image:

--- a/kubernetes/apps/media/wizarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/wizarr/app/helmrelease.yaml
@@ -20,10 +20,6 @@ spec:
         annotations:
           reloader.stakater.com/auto: "true"
           glance/id: wizarr
-          glance/name: Wizarr
-          glance/icon: mdi:account-plus
-          glance/category: media
-          glance/url: https://join.zebernst.dev
         containers:
           wizarr:
             image:
@@ -59,6 +55,9 @@ spec:
           gatus.home-operations.com/endpoint: |
             name: "{{ .Release.Name }}"
             group: "{{ .Release.Namespace }}"
+          glance/name: Wizarr
+          glance/icon: mdi:account-plus
+          glance/category: media
         hostnames:
           - "join.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/network/echo-server/app/helmrelease.yaml
+++ b/kubernetes/apps/network/echo-server/app/helmrelease.yaml
@@ -14,6 +14,8 @@ spec:
   values:
     controllers:
       echo-server:
+        annotations:
+          glance/hide: "true"
         strategy: RollingUpdate
         containers:
           echo-server:

--- a/kubernetes/apps/observability/gatus/private/helmrelease.yaml
+++ b/kubernetes/apps/observability/gatus/private/helmrelease.yaml
@@ -16,6 +16,11 @@ spec:
       gatus:
         annotations:
           reloader.stakater.com/auto: "true"
+          glance/id: gatus
+          glance/name: Gatus
+          glance/icon: mdi:heart-pulse
+          glance/category: observability
+          glance/url: https://status.zebernst.dev
         initContainers:
           init-db:
             image:

--- a/kubernetes/apps/observability/gatus/private/helmrelease.yaml
+++ b/kubernetes/apps/observability/gatus/private/helmrelease.yaml
@@ -17,10 +17,6 @@ spec:
         annotations:
           reloader.stakater.com/auto: "true"
           glance/id: gatus
-          glance/name: Gatus
-          glance/icon: mdi:heart-pulse
-          glance/category: observability
-          glance/url: https://status.zebernst.dev
         initContainers:
           init-db:
             image:
@@ -93,6 +89,10 @@ spec:
       canonical:
         annotations:
           gatus.home-operations.com/enabled: "false"
+          glance/name: Gatus
+          glance/icon: mdi:heart-pulse
+          glance/category: observability
+          glance/url: https://status.zebernst.dev
         hostnames:
           - gatus.jptr.zebernst.dev
         parentRefs:

--- a/kubernetes/apps/observability/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/grafana/app/helmrelease.yaml
@@ -531,6 +531,12 @@ spec:
       - victoriametrics-logs-datasource
     serviceMonitor:
       enabled: true
+    podAnnotations:
+      glance/id: grafana
+      glance/name: Grafana
+      glance/icon: si:grafana
+      glance/url: https://grafana.kite-harmonic.ts.net
+      glance/category: observability
     ingress:
       enabled: false
     persistence:

--- a/kubernetes/apps/observability/karma/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/karma/app/helmrelease.yaml
@@ -14,6 +14,12 @@ spec:
   values:
     controllers:
       karma:
+        annotations:
+          glance/id: karma
+          glance/name: Karma
+          glance/icon: mdi:alert-circle
+          glance/category: observability
+          glance/url: https://karma.kite-harmonic.ts.net
         replicas: 2
         strategy: RollingUpdate
         containers:

--- a/kubernetes/apps/observability/karma/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/karma/app/helmrelease.yaml
@@ -14,12 +14,6 @@ spec:
   values:
     controllers:
       karma:
-        annotations:
-          glance/id: karma
-          glance/name: Karma
-          glance/icon: mdi:alert-circle
-          glance/category: observability
-          glance/url: https://karma.kite-harmonic.ts.net
         replicas: 2
         strategy: RollingUpdate
         containers:
@@ -62,6 +56,11 @@ spec:
           gatus.home-operations.com/endpoint: |
             name: "{{ .Release.Name }}"
             group: "{{ .Release.Namespace }}"
+          glance/id: karma
+          glance/name: Karma
+          glance/icon: mdi:alert-circle
+          glance/category: observability
+          glance/url: https://karma.kite-harmonic.ts.net
         hostnames:
           - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/observability/kromgo/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kromgo/app/helmrelease.yaml
@@ -15,6 +15,7 @@ spec:
     controllers:
       kromgo:
         annotations:
+          reloader.stakater.com/auto: "true"
           glance/id: kromgo
           glance/name: Kromgo
           glance/icon: mdi:message-text
@@ -22,8 +23,6 @@ spec:
           glance/url: https://kromgo.zebernst.dev
         replicas: 2
         strategy: RollingUpdate
-        annotations:
-          reloader.stakater.com/auto: "true"
         containers:
           kromgo:
             image:

--- a/kubernetes/apps/observability/kromgo/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kromgo/app/helmrelease.yaml
@@ -14,6 +14,12 @@ spec:
   values:
     controllers:
       kromgo:
+        annotations:
+          glance/id: kromgo
+          glance/name: Kromgo
+          glance/icon: mdi:message-text
+          glance/category: observability
+          glance/url: https://kromgo.zebernst.dev
         replicas: 2
         strategy: RollingUpdate
         annotations:

--- a/kubernetes/apps/observability/kromgo/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kromgo/app/helmrelease.yaml
@@ -17,10 +17,6 @@ spec:
         annotations:
           reloader.stakater.com/auto: "true"
           glance/id: kromgo
-          glance/name: Kromgo
-          glance/icon: mdi:message-text
-          glance/category: observability
-          glance/url: https://kromgo.zebernst.dev
         replicas: 2
         strategy: RollingUpdate
         containers:
@@ -76,6 +72,10 @@ spec:
             name: "{{ .Release.Name }}"
             group: "{{ .Release.Namespace }}"
             path: /talos_version
+          glance/name: Kromgo
+          glance/icon: mdi:message-text
+          glance/category: observability
+          glance/url: https://kromgo.zebernst.dev
         hostnames:
           - "{{ .Release.Name }}.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/observability/victoria-logs/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-logs/app/helmrelease.yaml
@@ -34,3 +34,9 @@ spec:
       serviceMonitor:
         enabled: true
       retentionPeriod: 90d
+      podAnnotations:
+        glance/id: victoria-logs
+        glance/name: VictoriaLogs
+        glance/icon: si:victoriametrics
+        glance/url: https://logs.zebernst.dev
+        glance/category: observability

--- a/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
@@ -109,6 +109,9 @@ spec:
         # to multiple receivers (e.g. blackhole + pushover).
         disableRouteContinueEnforce: true
         externalURL: https://alertmanager.jptr.zebernst.dev
+        podMetadata:
+          annotations:
+            glance/hide: "true"
         storage:
           volumeClaimTemplate:
             spec:
@@ -343,6 +346,13 @@ spec:
         retentionPeriod: "90d"
         replicaCount: 1
         priorityClassName: control-plane-critical
+        podMetadata:
+          annotations:
+            glance/id: victoria-metrics
+            glance/name: VictoriaMetrics
+            glance/icon: si:victoriametrics
+            glance/url: https://victoria-metrics.zebernst.dev
+            glance/category: observability
         extraArgs:
           search.maxQueryDuration: 120s
           memory.allowedPercent: "80"

--- a/kubernetes/apps/self-hosted/atuin/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/atuin/app/helmrelease.yaml
@@ -14,6 +14,12 @@ spec:
   values:
     controllers:
       atuin:
+        annotations:
+          glance/id: atuin
+          glance/name: Atuin
+          glance/icon: mdi:history
+          glance/category: self-hosted
+          glance/url: https://atuin.kite-harmonic.ts.net
         strategy: RollingUpdate
         annotations:
           reloader.stakater.com/auto: "true"

--- a/kubernetes/apps/self-hosted/atuin/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/atuin/app/helmrelease.yaml
@@ -15,14 +15,13 @@ spec:
     controllers:
       atuin:
         annotations:
+          reloader.stakater.com/auto: "true"
           glance/id: atuin
           glance/name: Atuin
           glance/icon: mdi:history
           glance/category: self-hosted
           glance/url: https://atuin.kite-harmonic.ts.net
         strategy: RollingUpdate
-        annotations:
-          reloader.stakater.com/auto: "true"
         initContainers:
           init-db:
             image:

--- a/kubernetes/apps/self-hosted/atuin/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/atuin/app/helmrelease.yaml
@@ -17,10 +17,6 @@ spec:
         annotations:
           reloader.stakater.com/auto: "true"
           glance/id: atuin
-          glance/name: Atuin
-          glance/icon: mdi:history
-          glance/category: self-hosted
-          glance/url: https://atuin.kite-harmonic.ts.net
         strategy: RollingUpdate
         initContainers:
           init-db:
@@ -88,6 +84,10 @@ spec:
           gatus.home-operations.com/endpoint: |
             name: "{{ .Release.Name }}"
             group: "{{ .Release.Namespace }}"
+          glance/name: Atuin
+          glance/icon: mdi:history
+          glance/category: self-hosted
+          glance/url: https://atuin.kite-harmonic.ts.net
         hostnames:
           - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/self-hosted/dawarich/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/dawarich/app/helmrelease.yaml
@@ -16,6 +16,11 @@ spec:
       dawarich:
         annotations:
           reloader.stakater.com/auto: "true"
+          glance/id: dawarich
+          glance/name: Dawarich
+          glance/icon: mdi:map-marker-path
+          glance/category: self-hosted
+          glance/url: https://timeline.zebernst.dev
         containers:
           web:
             image:

--- a/kubernetes/apps/self-hosted/dawarich/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/dawarich/app/helmrelease.yaml
@@ -17,10 +17,6 @@ spec:
         annotations:
           reloader.stakater.com/auto: "true"
           glance/id: dawarich
-          glance/name: Dawarich
-          glance/icon: mdi:map-marker-path
-          glance/category: self-hosted
-          glance/url: https://timeline.zebernst.dev
         containers:
           web:
             image:
@@ -153,6 +149,10 @@ spec:
           gatus.home-operations.com/endpoint: |
             name: "{{ .Release.Name }}"
             group: "{{ .Release.Namespace }}"
+          glance/name: Dawarich
+          glance/icon: mdi:map-marker-path
+          glance/category: self-hosted
+          glance/url: https://timeline.zebernst.dev
         hostnames:
           - timeline.jptr.zebernst.dev
         parentRefs:

--- a/kubernetes/apps/self-hosted/glance/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/glance/app/helmrelease.yaml
@@ -16,6 +16,11 @@ spec:
       glance:
         annotations:
           reloader.stakater.com/auto: "true"
+          glance/id: glance
+          glance/name: Glance
+          glance/icon: di:glance
+          glance/category: self-hosted
+          glance/url: https://glance.zebernst.dev
         containers:
           glance:
             image:
@@ -133,8 +138,11 @@ spec:
             - apiGroups: [""]
               resources: ["services"]
               verbs: ["list"]
-            - apiGroups: ["networking.k8s.io"] # networking.k8s.io/v1
-              resources: ["ingresses", "ingressclasses"]
+            - apiGroups: ["networking.k8s.io"]
+              resources: ["ingresses"]
+              verbs: ["list"]
+            - apiGroups: ["gateway.networking.k8s.io"]
+              resources: ["httproutes"]
               verbs: ["list"]
             - apiGroups: ["apps"]
               resources: ["deployments", "statefulsets", "daemonsets"]

--- a/kubernetes/apps/self-hosted/glance/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/glance/app/helmrelease.yaml
@@ -17,10 +17,6 @@ spec:
         annotations:
           reloader.stakater.com/auto: "true"
           glance/id: glance
-          glance/name: Glance
-          glance/icon: di:glance
-          glance/category: self-hosted
-          glance/url: https://glance.zebernst.dev
         containers:
           glance:
             image:
@@ -101,6 +97,10 @@ spec:
           gatus.home-operations.com/endpoint: |
             name: "{{ .Release.Name }}"
             group: "{{ .Release.Namespace }}"
+          glance/name: Glance
+          glance/icon: di:glance
+          glance/category: self-hosted
+          glance/url: https://glance.zebernst.dev
         hostnames:
           - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/self-hosted/glance/app/resources/glance.yml
+++ b/kubernetes/apps/self-hosted/glance/app/resources/glance.yml
@@ -117,7 +117,7 @@ pages:
 
       - size: full
         widgets:
-          - title: Apps
+          - title: Media
             type: extension
             url: http://localhost:8080/extension/apps
             allow-potentially-dangerous-html: true
@@ -125,4 +125,71 @@ pages:
             parameters:
               show-if: |
                 namespace != "kube-system" and
-                ("glance/hide" not in annotations || annotations["glance/hide"] != "true")
+                ("glance/hide" not in annotations || annotations["glance/hide"] != "true") and
+                annotations["glance/category"] == "media"
+
+          - title: Downloads
+            type: extension
+            url: http://localhost:8080/extension/apps
+            allow-potentially-dangerous-html: true
+            cache: 1s
+            parameters:
+              show-if: |
+                namespace != "kube-system" and
+                ("glance/hide" not in annotations || annotations["glance/hide"] != "true") and
+                annotations["glance/category"] == "downloads"
+
+          - title: Self-Hosted
+            type: extension
+            url: http://localhost:8080/extension/apps
+            allow-potentially-dangerous-html: true
+            cache: 1s
+            parameters:
+              show-if: |
+                namespace != "kube-system" and
+                ("glance/hide" not in annotations || annotations["glance/hide"] != "true") and
+                annotations["glance/category"] == "self-hosted"
+
+          - title: AI
+            type: extension
+            url: http://localhost:8080/extension/apps
+            allow-potentially-dangerous-html: true
+            cache: 1s
+            parameters:
+              show-if: |
+                namespace != "kube-system" and
+                ("glance/hide" not in annotations || annotations["glance/hide"] != "true") and
+                annotations["glance/category"] == "ai"
+
+          - title: Auth
+            type: extension
+            url: http://localhost:8080/extension/apps
+            allow-potentially-dangerous-html: true
+            cache: 1s
+            parameters:
+              show-if: |
+                namespace != "kube-system" and
+                ("glance/hide" not in annotations || annotations["glance/hide"] != "true") and
+                annotations["glance/category"] == "auth"
+
+          - title: Games
+            type: extension
+            url: http://localhost:8080/extension/apps
+            allow-potentially-dangerous-html: true
+            cache: 1s
+            parameters:
+              show-if: |
+                namespace != "kube-system" and
+                ("glance/hide" not in annotations || annotations["glance/hide"] != "true") and
+                annotations["glance/category"] == "games"
+
+          - title: Observability
+            type: extension
+            url: http://localhost:8080/extension/apps
+            allow-potentially-dangerous-html: true
+            cache: 1s
+            parameters:
+              show-if: |
+                namespace != "kube-system" and
+                ("glance/hide" not in annotations || annotations["glance/hide"] != "true") and
+                annotations["glance/category"] == "observability"

--- a/kubernetes/apps/self-hosted/hajimari/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/hajimari/app/helmrelease.yaml
@@ -36,6 +36,11 @@ spec:
         any: true
     podAnnotations:
       configmap.reloader.stakater.com/reload: hajimari-settings
+      glance/id: hajimari
+      glance/name: Hajimari
+      glance/icon: mdi:view-dashboard
+      glance/url: https://hajimari.kite-harmonic.ts.net
+      glance/category: self-hosted
     persistence:
       data:
         type: emptyDir

--- a/kubernetes/apps/self-hosted/it-tools/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/it-tools/app/helmrelease.yaml
@@ -16,6 +16,11 @@ spec:
       it-tools:
         annotations:
           reloader.stakater.com/auto: "true"
+          glance/id: it-tools
+          glance/name: IT-Tools
+          glance/icon: mdi:tools
+          glance/category: self-hosted
+          glance/url: https://it-tools.kite-harmonic.ts.net
         containers:
           it-tools:
             image:

--- a/kubernetes/apps/self-hosted/it-tools/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/it-tools/app/helmrelease.yaml
@@ -17,10 +17,6 @@ spec:
         annotations:
           reloader.stakater.com/auto: "true"
           glance/id: it-tools
-          glance/name: IT-Tools
-          glance/icon: mdi:tools
-          glance/category: self-hosted
-          glance/url: https://it-tools.kite-harmonic.ts.net
         containers:
           it-tools:
             image:
@@ -54,6 +50,10 @@ spec:
           gatus.home-operations.com/endpoint: |
             name: "{{ .Release.Name }}"
             group: "{{ .Release.Namespace }}"
+          glance/name: IT-Tools
+          glance/icon: mdi:tools
+          glance/category: self-hosted
+          glance/url: https://it-tools.kite-harmonic.ts.net
         hostnames:
           - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/self-hosted/nocodb/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/nocodb/app/helmrelease.yaml
@@ -16,6 +16,11 @@ spec:
       nocodb:
         annotations:
           reloader.stakater.com/auto: "true"
+          glance/id: nocodb
+          glance/name: NocoDB
+          glance/icon: si:nocodb
+          glance/category: self-hosted
+          glance/url: https://nocodb.kite-harmonic.ts.net
         initContainers:
           init-db:
             image:

--- a/kubernetes/apps/self-hosted/nocodb/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/nocodb/app/helmrelease.yaml
@@ -17,10 +17,6 @@ spec:
         annotations:
           reloader.stakater.com/auto: "true"
           glance/id: nocodb
-          glance/name: NocoDB
-          glance/icon: si:nocodb
-          glance/category: self-hosted
-          glance/url: https://nocodb.kite-harmonic.ts.net
         initContainers:
           init-db:
             image:
@@ -66,6 +62,10 @@ spec:
           gatus.home-operations.com/endpoint: |
             name: "{{ .Release.Name }}"
             group: "{{ .Release.Namespace }}"
+          glance/name: NocoDB
+          glance/icon: si:nocodb
+          glance/category: self-hosted
+          glance/url: https://nocodb.kite-harmonic.ts.net
         hostnames:
           - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/self-hosted/nominatim/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/nominatim/app/helmrelease.yaml
@@ -49,6 +49,11 @@ spec:
       nominatim:
         annotations:
           reloader.stakater.com/auto: "true"
+          glance/id: nominatim
+          glance/name: Nominatim
+          glance/icon: mdi:map-search
+          glance/category: self-hosted
+          glance/url: https://nominatim.zebernst.dev
         serviceAccount:
           identifier: app
         containers:

--- a/kubernetes/apps/self-hosted/paperless/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/paperless/app/helmrelease.yaml
@@ -17,6 +17,11 @@ spec:
 
         annotations:
           reloader.stakater.com/auto: "true"
+          glance/id: paperless
+          glance/name: Paperless-ngx
+          glance/icon: si:readthedocs
+          glance/category: self-hosted
+          glance/url: https://paperless.kite-harmonic.ts.net
 
         initContainers:
           init-db:

--- a/kubernetes/apps/self-hosted/paperless/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/paperless/app/helmrelease.yaml
@@ -14,14 +14,9 @@ spec:
   values:
     controllers:
       paperless:
-
         annotations:
           reloader.stakater.com/auto: "true"
           glance/id: paperless
-          glance/name: Paperless-ngx
-          glance/icon: si:readthedocs
-          glance/category: self-hosted
-          glance/url: https://paperless.kite-harmonic.ts.net
 
         initContainers:
           init-db:
@@ -139,6 +134,10 @@ spec:
           gatus.home-operations.com/endpoint: |
             name: "{{ .Release.Name }}"
             group: "{{ .Release.Namespace }}"
+          glance/name: Paperless-ngx
+          glance/icon: si:readthedocs
+          glance/category: self-hosted
+          glance/url: https://paperless.kite-harmonic.ts.net
         hostnames:
           - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/self-hosted/rxresume/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/rxresume/app/helmrelease.yaml
@@ -16,6 +16,11 @@ spec:
       rxresume:
         annotations:
           reloader.stakater.com/auto: "true"
+          glance/id: rxresume
+          glance/name: RxResume
+          glance/icon: mdi:file-document
+          glance/category: self-hosted
+          glance/url: https://rxresume.zebernst.dev
         initContainers:
           init-db:
             image:

--- a/kubernetes/apps/self-hosted/rxresume/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/rxresume/app/helmrelease.yaml
@@ -17,10 +17,6 @@ spec:
         annotations:
           reloader.stakater.com/auto: "true"
           glance/id: rxresume
-          glance/name: RxResume
-          glance/icon: mdi:file-document
-          glance/category: self-hosted
-          glance/url: https://rxresume.zebernst.dev
         initContainers:
           init-db:
             image:
@@ -103,6 +99,10 @@ spec:
           gatus.home-operations.com/endpoint: |
             name: "{{ .Release.Name }}"
             group: "{{ .Release.Namespace }}"
+          glance/name: RxResume
+          glance/icon: mdi:file-document
+          glance/category: self-hosted
+          glance/url: https://rxresume.zebernst.dev
         hostnames:
           - "{{ .Release.Name }}.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/self-hosted/unwrapped/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/unwrapped/app/helmrelease.yaml
@@ -16,6 +16,11 @@ spec:
       unwrapped:
         annotations:
           reloader.stakater.com/auto: "true"
+          glance/id: unwrapped
+          glance/name: Unwrapped
+          glance/icon: mdi:gift
+          glance/category: self-hosted
+          glance/url: https://unwrapped.zebernst.dev
         containers:
           unwrapped:
             image:

--- a/kubernetes/apps/self-hosted/unwrapped/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/unwrapped/app/helmrelease.yaml
@@ -17,10 +17,6 @@ spec:
         annotations:
           reloader.stakater.com/auto: "true"
           glance/id: unwrapped
-          glance/name: Unwrapped
-          glance/icon: mdi:gift
-          glance/category: self-hosted
-          glance/url: https://unwrapped.zebernst.dev
         containers:
           unwrapped:
             image:
@@ -76,6 +72,10 @@ spec:
           gatus.home-operations.com/endpoint: |
             name: "{{ .Release.Name }}"
             group: "{{ .Release.Namespace }}"
+          glance/name: Unwrapped
+          glance/icon: mdi:gift
+          glance/category: self-hosted
+          glance/url: https://unwrapped.zebernst.dev
         hostnames:
           - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:

--- a/scripts/apply-glance-annotations.py
+++ b/scripts/apply-glance-annotations.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Apply glance/* annotations from docs/architecture/glance-annotations.yaml."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+CATALOG = ROOT / "docs/architecture/glance-annotations.yaml"
+
+
+def glance_lines(entry: dict, *, hide: bool = False) -> list[str]:
+    indent = "          "
+    if hide:
+        return [f'{indent}glance/hide: "true"']
+
+    lines = [
+        f"{indent}glance/id: {entry['id']}",
+        f"{indent}glance/name: {entry['name']}",
+        f"{indent}glance/icon: {entry['icon']}",
+        f"{indent}glance/category: {entry['category']}",
+    ]
+    if entry.get("url"):
+        lines.append(f'{indent}glance/url: {entry["url"]}')
+    if entry.get("parent"):
+        lines.append(f"{indent}glance/parent: {entry['parent']}")
+    return lines
+
+
+def already_has_glance(text: str) -> bool:
+    return "glance/id:" in text or 'glance/hide: "true"' in text
+
+
+def apply_app_template(path: Path, controller: str, lines: list[str]) -> bool:
+    text = path.read_text()
+    if already_has_glance(text):
+        return False
+
+    controller_re = re.compile(rf"^      {re.escape(controller)}:\n", re.MULTILINE)
+    match = controller_re.search(text)
+    if not match:
+        print(f"WARN: controller {controller} not found in {path}", file=sys.stderr)
+        return False
+
+    after = text[match.end() :]
+    ann_match = re.search(r"        annotations:\n((?:          .+\n)*)", after)
+    if ann_match:
+        insert_at = match.end() + ann_match.end(1)
+        text = text[:insert_at] + "".join(line + "\n" for line in lines) + text[insert_at:]
+        path.write_text(text)
+        return True
+
+    child_match = re.search(
+        r"        (?:(?:replicas|strategy|initContainers|containers|type):)",
+        after,
+    )
+    if not child_match:
+        print(f"WARN: no insertion point for {controller} in {path}", file=sys.stderr)
+        return False
+
+    insert_at = match.end()
+    ann_block = "        annotations:\n" + "".join(line + "\n" for line in lines)
+    text = text[:insert_at] + ann_block + text[insert_at:]
+    path.write_text(text)
+    return True
+
+
+def set_nested(values: dict, path: str, annotations: dict) -> None:
+    parts = path.split(".")
+    cur = values
+    for part in parts[:-1]:
+        cur = cur.setdefault(part, {})
+    key = parts[-1]
+    cur.setdefault(key, {})
+    cur[key].update(annotations)
+
+
+def apply_upstream(path: Path, entry: dict) -> bool:
+    documents = list(yaml.safe_load_all(path.read_text()))
+    changed = False
+    annotations = {
+        "glance/id": entry["id"],
+        "glance/name": entry["name"],
+        "glance/icon": entry["icon"],
+        "glance/category": entry["category"],
+    }
+    if entry.get("url"):
+        annotations["glance/url"] = entry["url"]
+    if entry.get("hide"):
+        annotations = {"glance/hide": "true"}
+
+    for doc in documents:
+        if not isinstance(doc, dict) or doc.get("kind") != "HelmRelease":
+            continue
+        values = doc.setdefault("spec", {}).setdefault("values", {})
+        if entry.get("hide"):
+            set_nested(values, entry["values_path"], annotations)
+            changed = True
+            continue
+        target = values
+        for part in entry["values_path"].split("."):
+            target = target.setdefault(part, {}) if isinstance(target, dict) else target
+        if isinstance(target, dict):
+            if target.get("glance/id"):
+                continue
+            target.update(annotations)
+            changed = True
+
+    if changed:
+        path.write_text("---\n".join(yaml.dump(doc, sort_keys=False) for doc in documents))
+    return changed
+
+
+def main() -> int:
+    catalog = yaml.safe_load(CATALOG.read_text())
+    updated = 0
+
+    for entry in catalog.get("app_template", []):
+        path = ROOT / entry["file"]
+        if apply_app_template(path, entry["controller"], glance_lines(entry)):
+            updated += 1
+            print(f"updated {path}")
+
+    for entry in catalog.get("hide", []):
+        path = ROOT / entry["file"]
+        if apply_app_template(path, entry["controller"], glance_lines(entry, hide=True)):
+            updated += 1
+            print(f"hidden {path}")
+
+    for entry in catalog.get("upstream_values", []):
+        path = ROOT / entry["file"]
+        if apply_upstream(path, entry):
+            updated += 1
+            print(f"upstream {path} ({entry['values_path']})")
+
+    print(f"Done. {updated} files updated.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/apply-glance-annotations.py
+++ b/scripts/apply-glance-annotations.py
@@ -35,6 +35,19 @@ def already_has_glance(text: str) -> bool:
     return "glance/id:" in text or 'glance/hide: "true"' in text
 
 
+def controller_block_end(text: str, start: int) -> int:
+    """Return index after the controller block starting at `start`."""
+    lines = text[start:].splitlines(keepends=True)
+    consumed = 0
+    for line in lines[1:]:
+        if line.startswith("      ") and not line.startswith("        ") and line.strip():
+            break
+        if line.startswith("    ") and not line.startswith("      ") and line.strip():
+            break
+        consumed += len(line)
+    return start + consumed
+
+
 def apply_app_template(path: Path, controller: str, lines: list[str]) -> bool:
     text = path.read_text()
     if already_has_glance(text):
@@ -46,23 +59,26 @@ def apply_app_template(path: Path, controller: str, lines: list[str]) -> bool:
         print(f"WARN: controller {controller} not found in {path}", file=sys.stderr)
         return False
 
-    after = text[match.end() :]
-    ann_match = re.search(r"        annotations:\n((?:          .+\n)*)", after)
-    if ann_match:
-        insert_at = match.end() + ann_match.end(1)
+    block_end = controller_block_end(text, match.start())
+    block = text[match.start() : block_end]
+    ann_matches = list(re.finditer(r"^        annotations:\n((?:          .+\n)*)", block, re.MULTILINE))
+    if ann_matches:
+        ann_match = ann_matches[0]
+        insert_at = match.start() + ann_match.end(1)
         text = text[:insert_at] + "".join(line + "\n" for line in lines) + text[insert_at:]
         path.write_text(text)
         return True
 
     child_match = re.search(
-        r"        (?:(?:replicas|strategy|initContainers|containers|type):)",
-        after,
+        r"^        (?:(?:replicas|strategy|initContainers|containers|type):)",
+        block,
+        re.MULTILINE,
     )
     if not child_match:
         print(f"WARN: no insertion point for {controller} in {path}", file=sys.stderr)
         return False
 
-    insert_at = match.end()
+    insert_at = match.start() + child_match.start()
     ann_block = "        annotations:\n" + "".join(line + "\n" for line in lines)
     text = text[:insert_at] + ann_block + text[insert_at:]
     path.write_text(text)

--- a/scripts/apply-glance-annotations.py
+++ b/scripts/apply-glance-annotations.py
@@ -11,32 +11,60 @@ import yaml
 
 ROOT = Path(__file__).resolve().parents[1]
 CATALOG = ROOT / "docs/architecture/glance-annotations.yaml"
+ROUTE_PRIORITY = ("app", "id", "plex", "external", "api", "cv")
 
 
-def glance_lines(entry: dict, *, hide: bool = False) -> list[str]:
+def route_keys(text: str) -> list[str]:
+    if "    route:" not in text:
+        return []
+    block = text.split("    route:", 1)[1]
+    m = re.match(r"(.*?)(?=^    \w|\Z)", block, re.MULTILINE | re.DOTALL)
+    if not m:
+        return []
+    return re.findall(r"^      (\S+):", m.group(1), re.MULTILINE)
+
+
+def pick_route(text: str, entry: dict) -> str | None:
+    if entry.get("route"):
+        return entry["route"]
+    keys = route_keys(text)
+    if not keys:
+        return None
+    for key in ROUTE_PRIORITY:
+        if key in keys:
+            return key
+    non_canonical = [k for k in keys if k != "canonical"]
+    return non_canonical[0] if non_canonical else keys[0]
+
+
+def display_lines(entry: dict, *, include_url: bool) -> list[str]:
     indent = "          "
-    if hide:
-        return [f'{indent}glance/hide: "true"']
-
     lines = [
-        f"{indent}glance/id: {entry['id']}",
         f"{indent}glance/name: {entry['name']}",
         f"{indent}glance/icon: {entry['icon']}",
         f"{indent}glance/category: {entry['category']}",
     ]
-    if entry.get("url"):
-        lines.append(f'{indent}glance/url: {entry["url"]}')
-    if entry.get("parent"):
-        lines.append(f"{indent}glance/parent: {entry['parent']}")
+    if include_url and entry.get("url"):
+        lines.append(f"{indent}glance/url: {entry['url']}")
     return lines
 
 
+def workload_lines(entry: dict, *, hide: bool = False) -> list[str]:
+    indent = "          "
+    if hide:
+        return [f'{indent}glance/hide: "true"']
+    if entry.get("parent"):
+        return [f"{indent}glance/parent: {entry['parent']}"]
+    if entry.get("id"):
+        return [f"{indent}glance/id: {entry['id']}"]
+    return []
+
+
 def already_has_glance(text: str) -> bool:
-    return "glance/id:" in text or 'glance/hide: "true"' in text
+    return "glance/id:" in text or 'glance/hide: "true"' in text or "glance/parent:" in text
 
 
 def controller_block_end(text: str, start: int) -> int:
-    """Return index after the controller block starting at `start`."""
     lines = text[start:].splitlines(keepends=True)
     consumed = 0
     for line in lines[1:]:
@@ -48,39 +76,90 @@ def controller_block_end(text: str, start: int) -> int:
     return start + consumed
 
 
-def apply_app_template(path: Path, controller: str, lines: list[str]) -> bool:
+def merge_annotations(text: str, anchor_re: re.Pattern[str], lines: list[str]) -> str:
+    match = anchor_re.search(text)
+    if not match:
+        return text
+    block_end = controller_block_end(text, match.start()) if "      " in anchor_re.pattern else len(text)
+    block = text[match.start() : block_end]
+    ann_match = re.search(r"^        annotations:\n((?:          .+\n)*)", block, re.MULTILINE)
+    if ann_match:
+        insert_at = match.start() + ann_match.end(1)
+        payload = "".join(line + "\n" for line in lines)
+        return text[:insert_at] + payload + text[insert_at:]
+    insert_at = match.end()
+    payload = "        annotations:\n" + "".join(line + "\n" for line in lines)
+    return text[:insert_at] + payload + text[insert_at:]
+
+
+def should_include_url(entry: dict, text: str, route: str | None) -> bool:
+    if not entry.get("url"):
+        return False
+    if entry.get("force_url"):
+        return True
+    if not route:
+        return True
+    host = entry["url"].split("://", 1)[-1].split("/", 1)[0]
+    route_start = text.find("    route:")
+    if route_start == -1:
+        return True
+    route_block = text[route_start:]
+    route_section = re.search(
+        rf"      {re.escape(route)}:(.*?)(?=^      \S|\Z)",
+        route_block,
+        re.DOTALL | re.MULTILINE,
+    )
+    if route_section and host in route_section.group(1):
+        return False
+    return True
+
+
+def apply_app_template(path: Path, entry: dict, *, hide: bool = False) -> bool:
     text = path.read_text()
     if already_has_glance(text):
         return False
 
+    controller = entry["controller"]
     controller_re = re.compile(rf"^      {re.escape(controller)}:\n", re.MULTILINE)
-    match = controller_re.search(text)
-    if not match:
+    if not controller_re.search(text):
         print(f"WARN: controller {controller} not found in {path}", file=sys.stderr)
         return False
 
-    block_end = controller_block_end(text, match.start())
-    block = text[match.start() : block_end]
-    ann_matches = list(re.finditer(r"^        annotations:\n((?:          .+\n)*)", block, re.MULTILINE))
-    if ann_matches:
-        ann_match = ann_matches[0]
-        insert_at = match.start() + ann_match.end(1)
-        text = text[:insert_at] + "".join(line + "\n" for line in lines) + text[insert_at:]
+    text = merge_annotations(text, controller_re, workload_lines(entry, hide=hide))
+
+    if hide or entry.get("parent"):
         path.write_text(text)
         return True
 
-    child_match = re.search(
-        r"^        (?:(?:replicas|strategy|initContainers|containers|type):)",
-        block,
-        re.MULTILINE,
-    )
-    if not child_match:
-        print(f"WARN: no insertion point for {controller} in {path}", file=sys.stderr)
-        return False
+    if entry.get("workload_only"):
+        text = merge_annotations(
+            text,
+            controller_re,
+            display_lines(entry, include_url=should_include_url(entry, text, None)),
+        )
+        path.write_text(text)
+        return True
 
-    insert_at = match.start() + child_match.start()
-    ann_block = "        annotations:\n" + "".join(line + "\n" for line in lines)
-    text = text[:insert_at] + ann_block + text[insert_at:]
+    route = pick_route(text, entry)
+    if route:
+        route_re = re.compile(rf"^      {re.escape(route)}:\n", re.MULTILINE)
+        route_start = text.find("    route:")
+        route_block = text[route_start:]
+        if route_re.search(route_block):
+            abs_route_re = re.compile(rf"(?m)^      {re.escape(route)}:\n")
+            text = merge_annotations(
+                text,
+                abs_route_re,
+                display_lines(entry, include_url=should_include_url(entry, text, route)),
+            )
+            path.write_text(text)
+            return True
+
+    text = merge_annotations(
+        text,
+        controller_re,
+        display_lines(entry, include_url=should_include_url(entry, text, None)),
+    )
     path.write_text(text)
     return True
 
@@ -137,13 +216,13 @@ def main() -> int:
 
     for entry in catalog.get("app_template", []):
         path = ROOT / entry["file"]
-        if apply_app_template(path, entry["controller"], glance_lines(entry)):
+        if apply_app_template(path, entry):
             updated += 1
             print(f"updated {path}")
 
     for entry in catalog.get("hide", []):
         path = ROOT / entry["file"]
-        if apply_app_template(path, entry["controller"], glance_lines(entry, hide=True)):
+        if apply_app_template(path, entry, hide=True):
             updated += 1
             print(f"hidden {path}")
 

--- a/scripts/migrate-glance-to-routes.py
+++ b/scripts/migrate-glance-to-routes.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+"""Move glance display annotations from workloads to primary HTTPRoutes."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+CATALOG = ROOT / "docs/architecture/glance-annotations.yaml"
+
+DISPLAY_KEYS = ("glance/name", "glance/icon", "glance/category", "glance/url")
+WORKLOAD_GLANCE_KEYS = ("glance/id", "glance/parent", "glance/hide")
+ROUTE_PRIORITY = ("app", "id", "plex", "external", "api", "cv")
+
+
+def route_keys(text: str) -> list[str]:
+    if "    route:" not in text:
+        return []
+    block = text.split("    route:", 1)[1]
+    m = re.match(r"(.*?)(?=^    \w|\Z)", block, re.MULTILINE | re.DOTALL)
+    if not m:
+        return []
+    return re.findall(r"^      (\S+):", m.group(1), re.MULTILINE)
+
+
+def pick_route(text: str, entry: dict) -> str | None:
+    if entry.get("route"):
+        return entry["route"]
+    keys = route_keys(text)
+    if not keys:
+        return None
+    for key in ROUTE_PRIORITY:
+        if key in keys:
+            return key
+    non_canonical = [k for k in keys if k != "canonical"]
+    return non_canonical[0] if non_canonical else keys[0]
+
+
+def display_lines(entry: dict, *, include_url: bool) -> list[str]:
+    indent = "          "
+    lines = [
+        f"{indent}glance/name: {entry['name']}",
+        f"{indent}glance/icon: {entry['icon']}",
+        f"{indent}glance/category: {entry['category']}",
+    ]
+    if include_url and entry.get("url"):
+        lines.append(f"{indent}glance/url: {entry['url']}")
+    return lines
+
+
+def workload_lines(entry: dict) -> list[str]:
+    indent = "          "
+    lines: list[str] = []
+    if entry.get("parent"):
+        lines.append(f"{indent}glance/parent: {entry['parent']}")
+    elif entry.get("id"):
+        lines.append(f"{indent}glance/id: {entry['id']}")
+    return lines
+
+
+def strip_glance_from_controller(text: str, controller: str) -> str:
+    controller_re = re.compile(
+        rf"(^      {re.escape(controller)}:\n(?:        .+\n|\n)*?)(        annotations:\n(?:          .+\n)*)",
+        re.MULTILINE,
+    )
+
+    def repl(match: re.Match[str]) -> str:
+        prefix, ann_block = match.group(1), match.group(2)
+        kept = []
+        for line in ann_block.splitlines(keepends=True):
+            if any(key in line for key in DISPLAY_KEYS + WORKLOAD_GLANCE_KEYS):
+                continue
+            kept.append(line)
+        if not kept or kept == ["        annotations:\n"]:
+            return prefix
+        return prefix + "".join(kept)
+
+    return controller_re.sub(repl, text, count=1)
+
+
+def ensure_controller_workload_annotations(text: str, controller: str, lines: list[str]) -> str:
+    if not lines:
+        return text
+
+    controller_re = re.compile(rf"^      {re.escape(controller)}:\n", re.MULTILINE)
+    match = controller_re.search(text)
+    if not match:
+        print(f"WARN: controller {controller} not found", file=sys.stderr)
+        return text
+
+    after = text[match.end() :]
+    ann_match = re.search(r"^        annotations:\n((?:          .+\n)*)", after, re.MULTILINE)
+    if ann_match:
+        insert_at = match.end() + ann_match.end(1)
+        block = "".join(line + "\n" for line in lines)
+        return text[:insert_at] + block + text[insert_at:]
+
+    child_match = re.search(
+        r"^        (?:(?:replicas|strategy|initContainers|containers|type|serviceAccount):)",
+        after,
+        re.MULTILINE,
+    )
+    insert_at = match.end() + (child_match.start() if child_match else 0)
+    block = "        annotations:\n" + "".join(line + "\n" for line in lines)
+    return text[:insert_at] + block + text[insert_at:]
+
+
+def ensure_route_display_annotations(text: str, route: str, lines: list[str]) -> str:
+    if not lines:
+        return text
+
+    route_re = re.compile(rf"^      {re.escape(route)}:\n", re.MULTILINE)
+    route_start = text.find("    route:")
+    if route_start == -1:
+        return text
+    route_block = text[route_start:]
+    match = route_re.search(route_block)
+    if not match:
+        print(f"WARN: route {route} not found", file=sys.stderr)
+        return text
+
+    abs_start = route_start + match.start()
+    after = route_block[match.end() :]
+    ann_match = re.search(r"^        annotations:\n((?:          .+\n)*)", after, re.MULTILINE)
+    if ann_match:
+        insert_at = route_start + match.end() + ann_match.end(1)
+        block = "".join(line + "\n" for line in lines)
+        return text[:insert_at] + block + text[insert_at:]
+
+    insert_at = route_start + match.end()
+    block = "        annotations:\n" + "".join(line + "\n" for line in lines)
+    return text[:insert_at] + block + text[insert_at:]
+
+
+def strip_glance_from_route(text: str, route: str) -> str:
+    route_start = text.find("    route:")
+    if route_start == -1:
+        return text
+    route_block = text[route_start:]
+    route_re = re.compile(
+        rf"(^      {re.escape(route)}:\n(?:        .+\n)*?)(        annotations:\n(?:          .+\n)*)",
+        re.MULTILINE,
+    )
+
+    def repl(match: re.Match[str]) -> str:
+        prefix, ann_block = match.group(1), match.group(2)
+        kept = []
+        for line in ann_block.splitlines(keepends=True):
+            if any(key in line for key in DISPLAY_KEYS):
+                continue
+            kept.append(line)
+        if not kept or kept == ["        annotations:\n"]:
+            return prefix.rstrip("\n") + "\n"
+        return prefix + "".join(kept)
+
+    updated = route_re.sub(repl, route_block, count=1)
+    return text[:route_start] + updated
+
+
+def should_include_url(entry: dict, text: str, route: str | None) -> bool:
+    if not entry.get("url"):
+        return False
+    if entry.get("force_url"):
+        return True
+    rel = entry["file"].replace("\\", "/")
+    if rel in MULTI_ROUTE_FILES:
+        return True
+    if not route:
+        return True
+    host = entry["url"].split("://", 1)[-1].split("/", 1)[0]
+    route_start = text.find("    route:")
+    if route_start == -1:
+        return True
+    route_block = text[route_start:]
+    route_section = re.search(
+        rf"      {re.escape(route)}:(.*?)(?=^      \S|\Z)",
+        route_block,
+        re.DOTALL | re.MULTILINE,
+    )
+    if route_section and host in route_section.group(1):
+        return False
+    return True
+
+
+def migrate_app_template(path: Path, entry: dict) -> bool:
+    text = path.read_text()
+    controller = entry["controller"]
+    original = text
+
+    text = strip_glance_from_controller(text, controller)
+    for route_name in route_keys(text):
+        text = strip_glance_from_route(text, route_name)
+
+    text = ensure_controller_workload_annotations(text, controller, workload_lines(entry))
+
+    if entry.get("parent"):
+        pass
+    elif entry.get("workload_only"):
+        include_url = should_include_url(entry, text, None)
+        text = ensure_controller_workload_annotations(
+            text, controller, display_lines(entry, include_url=include_url)
+        )
+    else:
+        route = pick_route(text, entry)
+        if route:
+            include_url = should_include_url(entry, text, route)
+            text = ensure_route_display_annotations(
+                text, route, display_lines(entry, include_url=include_url)
+            )
+        else:
+            include_url = should_include_url(entry, text, None)
+            text = ensure_controller_workload_annotations(
+                text, controller, display_lines(entry, include_url=include_url)
+            )
+
+    if text != original:
+        path.write_text(text)
+        return True
+    return False
+
+
+def migrate_hide(path: Path, entry: dict) -> bool:
+    text = path.read_text()
+    controller = entry["controller"]
+    original = text
+
+    text = strip_glance_from_controller(text, controller)
+    for route in route_keys(text):
+        text = strip_glance_from_route(text, route)
+
+    hide_line = '          glance/hide: "true"'
+    text = ensure_controller_workload_annotations(text, controller, [hide_line])
+
+    if text != original:
+        path.write_text(text)
+        return True
+    return False
+
+
+MULTI_ROUTE_FILES: set[str] = set()
+
+
+def main() -> int:
+    catalog = yaml.safe_load(CATALOG.read_text())
+    MULTI_ROUTE_FILES.update(
+        f"kubernetes/apps/{item.replace('/', '/app/')}/helmrelease.yaml" if "/" in item else item
+        for item in catalog.get("multi_route", [])
+    )
+    # normalize multi_route paths
+    MULTI_ROUTE_FILES.clear()
+    for item in catalog.get("multi_route", []):
+        ns, app = item.split("/", 1)
+        if ns == "games" and app.startswith("minecraft/"):
+            MULTI_ROUTE_FILES.add(f"kubernetes/apps/{ns}/{app.split('/', 1)[1]}/app/helmrelease.yaml")
+        else:
+            MULTI_ROUTE_FILES.add(f"kubernetes/apps/{ns}/{app}/app/helmrelease.yaml")
+
+    changed = 0
+    for entry in catalog.get("app_template", []):
+        path = ROOT / entry["file"]
+        if migrate_app_template(path, entry):
+            changed += 1
+            print(f"migrated {path}")
+
+    for entry in catalog.get("hide", []):
+        path = ROOT / entry["file"]
+        if migrate_hide(path, entry):
+            changed += 1
+            print(f"hide {path}")
+
+    print(f"Done. {changed} files migrated.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `glance/*` Kubernetes annotations across homelab apps so glance-k8s can discover apps with correct names, icons, categories, and grouping. Replaces the legacy single Apps widget with category-filtered widgets.

## Annotation placement

| Key | Where | Why |
|---|---|---|
| `glance/id`, `glance/parent`, `glance/hide` | Workload (`controllers.*.annotations`) | glance-k8s reads these for app grouping |
| `glance/name`, `glance/icon`, `glance/category`, `glance/url` | Primary HTTPRoute (`route.*.annotations`) | Co-located with hostname; merged by glance-k8s at discovery time |
| Display on workload | Apps without routes (`workload_only`) or upstream charts | No app-template HTTPRoute to attach to |

## Key changes

- `docs/architecture/glance-annotations.yaml` — catalog with per-app `route:` targets
- `scripts/apply-glance-annotations.py` — applies workload vs route split
- `scripts/migrate-glance-to-routes.py` — one-shot migration helper
- Category widgets in `kubernetes/apps/self-hosted/glance/app/resources/glance.yml`
- HTTPRoute RBAC on Glance HelmRelease

## Commits

1. feat: annotations + category widgets
2. fix: merge duplicate controller annotations (CI)
3. refactor: move display annotations to HTTPRoutes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5cd1a3b8-da08-43bd-9371-c50bac25c40f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5cd1a3b8-da08-43bd-9371-c50bac25c40f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

