### PR TITLE
fix(scanopy): set daemon name from Kubernetes node hostname

### DIFF
--- a/kubernetes/apps/observability/scanopy/app/daemon-helmrelease.yaml
+++ b/kubernetes/apps/observability/scanopy/app/daemon-helmrelease.yaml
@@ -24,6 +24,11 @@ spec:
               TZ: America/Chicago
               SCANOPY_LOG_LEVEL: info
               SCANOPY_SERVER_URL: http://scanopy.observability.svc.cluster.local:60072
+              SCANOPY_ENABLE_LOCAL_DOCKER_SOCKET: "false"
+              SCANOPY_NAME:
+                valueFrom:
+                  fieldRef:
+                    fieldPath: spec.nodeName
             envFrom:
               - secretRef:
                   name: scanopy-secret


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Restores dynamic Scanopy daemon names that were implemented on the deploy branch but did not land in #1092.

Each daemon pod now sets `SCANOPY_NAME` from the Kubernetes downward API (`spec.nodeName`), so daemons register in Scanopy as their Talos node hostname (e.g. `redspot`, `blue`) instead of a generic default.

Also sets `SCANOPY_ENABLE_LOCAL_DOCKER_SOCKET: "false"` to match the intended daemon config from the original deploy work.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-86b08b12-1a91-4707-b513-e659fbee76d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-86b08b12-1a91-4707-b513-e659fbee76d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

