### PR TITLE
fix(dawarich): enable Nominatim geocoding in Sidekiq

### DIFF
--- a/kubernetes/apps/self-hosted/dawarich/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/dawarich/app/helmrelease.yaml
@@ -46,8 +46,8 @@ spec:
               OIDC_REDIRECT_URI: https://timeline.zebernst.dev/users/auth/openid_connect/callback
               OIDC_AUTO_REGISTER: "true"
               ALLOW_EMAIL_PASSWORD_REGISTRATION: "false"
-              NOMINATIM_API_HOST: nominatim.self-hosted.svc.cluster.local
-              NOMINATIM_API_USE_HTTPS: "false"
+              NOMINATIM_API_HOST: &nominatimApiHost nominatim.self-hosted.svc.cluster.local
+              NOMINATIM_API_USE_HTTPS: &nominatimApiUseHttps "false"
               SMTP_SERVER: smtp-relay.network.svc.cluster.local
               SMTP_PORT: "25"
               SMTP_DOMAIN: zebernst.dev
@@ -103,6 +103,8 @@ spec:
               RAILS_LOG_TO_STDOUT: "true"
               SELF_HOSTED: "true"
               STORE_GEODATA: "true"
+              NOMINATIM_API_HOST: *nominatimApiHost
+              NOMINATIM_API_USE_HTTPS: *nominatimApiUseHttps
               TIME_ZONE: America/Chicago
               BACKGROUND_PROCESSING_CONCURRENCY: "5"
               PROMETHEUS_EXPORTER_ENABLED: "true"


### PR DESCRIPTION
## Summary

- Propagate `NOMINATIM_API_HOST` and `NOMINATIM_API_USE_HTTPS` to the Sidekiq container so reverse geocoding jobs can reach the self-hosted Nominatim instance.
- Use YAML anchors so web and Sidekiq stay aligned on the same Nominatim endpoint.

The web container already had Nominatim configured when #1067 landed; background geocoding runs in Sidekiq and was missing those env vars.

## Test plan

- [ ] Flux reconciles the Dawarich HelmRelease
- [ ] Confirm Sidekiq env: `kubectl -n self-hosted exec deploy/dawarich -c sidekiq -- printenv | grep NOMINATIM`
- [ ] Trigger reverse geocoding from Dawarich UI and verify points get geodata
- [ ] Confirm Sidekiq can reach Nominatim: `kubectl -n self-hosted exec deploy/dawarich -c sidekiq -- curl -sf http://nominatim.self-hosted.svc.cluster.local/status`