### PR TITLE
fix(nominatim): use kubectl image entrypoint for OSM update cronjob

### DIFF
--- a/kubernetes/apps/self-hosted/nominatim/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/nominatim/app/helmrelease.yaml
@@ -142,7 +142,6 @@ spec:
             image:
               repository: registry.k8s.io/kubectl
               tag: v1.34.5
-            command: ["/kubectl"]
             args:
               - exec
               - deploy/nominatim


### PR DESCRIPTION
## Summary

The `nominatim-update-osm-db` CronJob was failing immediately with `StartError: exec: "/kubectl": no such file or directory`, so daily OSM region maintenance never ran. Removing the incorrect `command` override lets the official `registry.k8s.io/kubectl` image use its built-in `/bin/kubectl` entrypoint.

## Test plan

- [ ] After Flux reconciles, manually trigger the CronJob and confirm the pod starts
- [ ] Verify the job execs into `deploy/nominatim` and runs `/scripts/maintain-regions.sh`
