### PR TITLE
fix(observability): raise vmsingle memory limit to 4Gi

### DIFF
--- a/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
@@ -134,11 +134,13 @@ spec:
         priorityClassName: control-plane-critical
         extraArgs:
           search.maxQueryDuration: 120s
+          memory.allowedPercent: "80"
         resources:
           requests:
             cpu: 100m
+            memory: 4Gi
           limits:
-            memory: 2000Mi
+            memory: 4Gi
         storage:
           accessModes:
             - ReadWriteOnce


### PR DESCRIPTION
## Summary

- Raise `vmsingle` memory requests and limits from 2Gi to 4Gi after repeated OOMKills during background merges.
- Add `memory.allowedPercent: "80"` so VictoriaMetrics respects the cgroup memory limit.

## Context

`vmsingle-vmks` on `ganymede` had 77 restarts with `OOMKilled` while holding ~27B rows (~2.3GB on disk). Steady usage was ~1.6Gi but compaction merges spiked above the 2Gi cap.

## Test plan

- [ ] Flux reconciles `victoria-metrics` HelmRelease
- [ ] `vmsingle` pod restarts with 4Gi limit and stays Ready
- [ ] `kubectl top pod -n observability -l app.kubernetes.io/name=vmsingle` stays below limit under normal load
- [ ] No new OOMKilled events over 24h


Made with [Cursor](https://cursor.com)