### PR TITLE
fix(observability): simplify snmp-exporter config templating

### DIFF
--- a/kubernetes/apps/observability/snmp-exporter/app/externalsecret.yaml
+++ b/kubernetes/apps/observability/snmp-exporter/app/externalsecret.yaml
@@ -16,26 +16,10 @@ spec:
       templateFrom:
         - target: Data
           configMap:
-            name: snmp-exporter-modules
+            name: snmp-exporter-config-tpl
             items:
-              - key: modules.yaml
+              - key: snmp.yaml
                 templateAs: Values
-      data:
-        snmp.yaml: |
-          auths:
-            public_v1:
-              community: {{ .UNIFI_SNMP_COMMUNITY | quote }}
-              security_level: noAuthNoPriv
-              auth_protocol: MD5
-              priv_protocol: DES
-              version: 1
-            public_v2:
-              community: {{ .UNIFI_SNMP_COMMUNITY | quote }}
-              security_level: noAuthNoPriv
-              auth_protocol: MD5
-              priv_protocol: DES
-              version: 2
-          {{ .modules_yaml }}
   dataFrom:
     - extract:
         key: scanopy

--- a/kubernetes/apps/observability/snmp-exporter/app/kustomization.yaml
+++ b/kubernetes/apps/observability/snmp-exporter/app/kustomization.yaml
@@ -2,14 +2,15 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: observability
 resources:
   - externalsecret.yaml
   - helmrelease.yaml
   - vmrule.yaml
 configMapGenerator:
-  - name: snmp-exporter-modules
+  - name: snmp-exporter-config-tpl
     files:
-      - modules.yaml=resources/modules.yml
+      - snmp.yaml=resources/snmp.yaml.tpl
 generatorOptions:
   disableNameSuffixHash: true
 labels:

--- a/kubernetes/apps/observability/snmp-exporter/app/resources/generator.yml
+++ b/kubernetes/apps/observability/snmp-exporter/app/resources/generator.yml
@@ -5,9 +5,9 @@ auths:
   public_v2:
     version: 2
 
-# Regenerate modules.yml after editing this file:
+# Regenerate snmp.yaml.tpl after editing modules in this file:
 #   generator generate -g generator.yml -o /tmp/snmp.yml   # requires MIBs; see generator README
-#   tail -n +17 /tmp/snmp.yml > modules.yml
+#   { head -n 13 snmp.yaml.tpl; tail -n +17 /tmp/snmp.yml; } > /tmp/snmp.yaml.tpl && mv /tmp/snmp.yaml.tpl snmp.yaml.tpl
 
 modules:
   # Synology

--- a/kubernetes/apps/observability/snmp-exporter/app/resources/snmp.yaml.tpl
+++ b/kubernetes/apps/observability/snmp-exporter/app/resources/snmp.yaml.tpl
@@ -1,3 +1,16 @@
+auths:
+  public_v1:
+    community: {{ .UNIFI_SNMP_COMMUNITY | quote }}
+    security_level: noAuthNoPriv
+    auth_protocol: MD5
+    priv_protocol: DES
+    version: 1
+  public_v2:
+    community: {{ .UNIFI_SNMP_COMMUNITY | quote }}
+    security_level: noAuthNoPriv
+    auth_protocol: MD5
+    priv_protocol: DES
+    version: 2
 modules:
   synology:
     walk:


### PR DESCRIPTION
## Summary
- Fix snmp-exporter ExternalSecret sync failure caused by an invalid `modules_yaml` template key and a duplicate `modules.yaml` secret entry
- Consolidate config into a single `snmp.yaml.tpl` template (templated auths + generated modules) rendered once via `templateFrom`
- Set `namespace: observability` on the snmp-exporter kustomization to avoid accidental default-namespace applies

## Test plan
- [x] ExternalSecret reports `Ready=True` in `observability`
- [x] `snmp-exporter-config` secret contains only the `snmp.yaml` key
- [ ] snmp-exporter pod mounts config and scrapes NAS/UPS targets successfully after merge


Made with [Cursor](https://cursor.com)