### PR TITLE
fix(ai): align holmesgpt Cilium network policies with chart labels

### DIFF
--- a/kubernetes/apps/ai/holmesgpt/app/ciliumnetworkpolicy.yaml
+++ b/kubernetes/apps/ai/holmesgpt/app/ciliumnetworkpolicy.yaml
@@ -1,16 +1,30 @@
 # yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/cilium.io/ciliumnetworkpolicy_v2.json
 ---
-# Holmes core pod (server + operator): cluster-internal only, no internet.
+# Holmes server + operator: cluster-internal only, no internet.
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
   name: holmesgpt
 spec:
   endpointSelector:
-    matchLabels:
-      app.kubernetes.io/name: holmes
+    matchExpressions:
+      - key: app
+        operator: In
+        values:
+          - holmes
+          - holmes-operator
   egress:
     # DNS
+    - toServices:
+        - k8sService:
+            serviceName: kube-dns
+            namespace: kube-system
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
     - toEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: kube-system
@@ -60,17 +74,17 @@ spec:
         - ports:
             - port: "9428"
               protocol: TCP
-    # GitHub MCP sidecar (in-namespace, chart-managed port 8000)
+    # GitHub MCP server (in-namespace, chart-managed port 8000)
     - toEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: ai
-            app.kubernetes.io/component: github-mcp
+            app.kubernetes.io/name: github-mcp-server
       toPorts:
         - ports:
             - port: "8000"
               protocol: TCP
 ---
-# GitHub MCP sidecar: only allowed to reach api.github.com.
+# GitHub MCP server: only allowed to reach api.github.com.
 # All other internet egress is denied.
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
@@ -79,9 +93,19 @@ metadata:
 spec:
   endpointSelector:
     matchLabels:
-      app.kubernetes.io/component: github-mcp
+      app.kubernetes.io/name: github-mcp-server
   egress:
     # DNS (required to resolve api.github.com)
+    - toServices:
+        - k8sService:
+            serviceName: kube-dns
+            namespace: kube-system
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
     - toEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: kube-system


### PR DESCRIPTION
## Summary

- Fix `holmesgpt` CiliumNetworkPolicy selectors to match the Holmes server (`app: holmes`) and operator (`app: holmes-operator`) deployments instead of the stale `app.kubernetes.io/name: holmes` label
- Fix GitHub MCP policy targeting to use `app.kubernetes.io/name: github-mcp-server`, matching the chart's separate MCP deployment (replacing the old `component: github-mcp` sidecar label)
- Allow Holmes → GitHub MCP egress on port 8000 using the same corrected label
- Add explicit `toServices` rules for `kube-dns` so DNS works via the ClusterIP (`10.245.0.10:53`) when egress enforcement is active

## Context

The GitHub MCP pod was failing to resolve `api.github.com` because the egress-restricting CNP never matched the running pod. During troubleshooting we also found the kube-dns ClusterIP path needed an explicit service allow rule alongside the existing CoreDNS endpoint rule.

## Test plan

- [ ] Flux reconciles `holmesgpt` Kustomization in `ai` namespace
- [ ] `kubectl get ciliumnetworkpolicy -n ai holmesgpt-github-mcp -o yaml` shows `app.kubernetes.io/name: github-mcp-server` selector
- [ ] `kubectl exec -n ai deploy/holmesgpt-github-mcp-server -- wget -S -O /dev/null --timeout=5 https://api.github.com/zen` returns HTTP 200
- [ ] Holmes health checks / scheduled checks that use GitHub MCP still pass
- [ ] Delete stray CNPs in `default` namespace if present from manual debugging: `holmesgpt`, `holmesgpt-github-mcp`


Made with [Cursor](https://cursor.com)