### PR TITLE
fix(self-hosted): fix dawarich metrics scrape 403 errors

### DIFF
--- a/kubernetes/apps/self-hosted/dawarich/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/dawarich/app/helmrelease.yaml
@@ -155,24 +155,6 @@ spec:
               - name: *app
                 port: 3000
 
-
-    serviceMonitor:
-      app:
-        serviceName: *app
-        endpoints:
-          - port: http
-            scheme: http
-            path: /metrics
-            interval: 1m
-            scrapeTimeout: 10s
-            basicAuth:
-              username:
-                name: dawarich-secret
-                key: METRICS_USERNAME
-              password:
-                name: dawarich-secret
-                key: METRICS_PASSWORD
-
     persistence:
       data:
         existingClaim: *app

--- a/kubernetes/apps/self-hosted/dawarich/app/kustomization.yaml
+++ b/kubernetes/apps/self-hosted/dawarich/app/kustomization.yaml
@@ -6,4 +6,5 @@ resources:
   - cluster.yaml
   - externalsecret.yaml
   - helmrelease.yaml
+  - vmservicescrape.yaml
   - vmrule.yaml

--- a/kubernetes/apps/self-hosted/dawarich/app/vmservicescrape.yaml
+++ b/kubernetes/apps/self-hosted/dawarich/app/vmservicescrape.yaml
@@ -1,0 +1,29 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/operator.victoriametrics.com/vmservicescrape_v1beta1.json
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMServiceScrape
+metadata:
+  name: dawarich
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: dawarich
+      app.kubernetes.io/name: dawarich
+      app.kubernetes.io/service: dawarich
+  endpoints:
+    - port: http
+      path: /metrics
+      scheme: http
+      interval: 1m
+      scrapeTimeout: 10s
+      basicAuth:
+        username:
+          name: dawarich-secret
+          key: METRICS_USERNAME
+        password:
+          name: dawarich-secret
+          key: METRICS_PASSWORD
+      vm_scrape_params:
+        headers:
+          - "X-Forwarded-Proto: https"
+          - "Host: localhost"


### PR DESCRIPTION
## Summary
- Replace the helm-managed ServiceMonitor with a dedicated `VMServiceScrape`
- Keep `basicAuth` against `dawarich-secret` (`METRICS_USERNAME` / `METRICS_PASSWORD`)
- Add `vm_scrape_params.headers` for `X-Forwarded-Proto: https` and `Host: localhost`, which Dawarich requires when `APPLICATION_PROTOCOL=https`

Prometheus Operator `Endpoint` supports `basicAuth` but not custom scrape headers, so the ServiceMonitor could not satisfy Rails' HTTPS expectation on in-cluster HTTP scrapes.

## Test plan
- [ ] Flux reconciles `dawarich` kustomization in `self-hosted`
- [ ] Old helm `ServiceMonitor` is removed and only the new `VMServiceScrape` remains
- [ ] vmagent target for `job=dawarich` on `:3000/metrics` reports healthy
- [ ] `rails_requests_total` and related Dawarich metrics appear in VictoriaMetrics


Made with [Cursor](https://cursor.com)