### PR TITLE
fix(stash): expand stash-cache PVC from 100Gi to 250Gi

### DIFF
--- a/kubernetes/apps/media/stash/app/pvc.yaml
+++ b/kubernetes/apps/media/stash/app/pvc.yaml
@@ -7,5 +7,5 @@ spec:
   accessModes: ["ReadWriteOnce"]
   resources:
     requests:
-      storage: 100Gi
+      storage: 250Gi
   storageClassName: ceph-block


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The `stash-cache` PersistentVolumeClaim in the `media` namespace is critically low on space (~0.05% free on a 100Gi `ceph-block` volume). This PVC backs Stash's cache, generated content (thumbnails, sprites, previews), metadata, and pip install directories.

## Solution

Increase the PVC storage request from **100Gi** to **250Gi** in GitOps. The `ceph-block` StorageClass has `allowVolumeExpansion: true`, so Flux reconciliation will trigger online volume expansion without recreating the PVC.

## After merge

Once Flux applies the change, verify expansion completed:

```bash
kubectl get pvc stash-cache -n media
kubectl describe pvc stash-cache -n media
```

The PVC status should show the new capacity and `FileSystemResizePending` / `Resizing` conditions should clear once the filesystem is expanded.

## Notes

- No pod restart is required for RBD online expansion.
- If growth continues, consider a further bump (plex-cache uses 500Gi for a similar workload).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9f44d8cc-22cc-4f14-ab4c-dac0b1cbf45c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9f44d8cc-22cc-4f14-ab4c-dac0b1cbf45c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

