### PR TITLE
fix(gatus): map buddy pushover secrets to existing 1Password keys

### DIFF
--- a/kubernetes/apps/observability/gatus/app/externalsecret.yaml
+++ b/kubernetes/apps/observability/gatus/app/externalsecret.yaml
@@ -15,8 +15,8 @@ spec:
       data:
         BUDDY_DDNS_HOSTNAME: "{{ .BUDDY_DDNS_HOSTNAME }}"
         BUDDY_HEARTBEAT_TOKEN: "{{ .BUDDY_HEARTBEAT_TOKEN }}"
-        BUDDY_PUSHOVER_TOKEN: "{{ .BUDDY_PUSHOVER_TOKEN }}"
-        BUDDY_PUSHOVER_USER_KEY: "{{ .BUDDY_PUSHOVER_USER_KEY }}"
+        BUDDY_PUSHOVER_TOKEN: "{{ .GATUS_PUSHOVER_TOKEN }}"
+        BUDDY_PUSHOVER_USER_KEY: "{{ .PUSHOVER_USER_KEY }}"
         BUDDY_STATUS_HOSTNAME: "{{ .BUDDY_STATUS_HOSTNAME }}"
         FLUX_WEBHOOK_PATH: '/hook/{{ sha256sum (printf "%s%s%s" .FLUX_GITHUB_WEBHOOK_TOKEN "github-receiver" "flux-system") }}'
         INIT_POSTGRES_DBNAME: gatus
@@ -29,5 +29,7 @@ spec:
         key: cloudnative-pg
     - extract:
         key: flux
+    - extract:
+        key: pushover
     - extract:
         key: gatus

--- a/kubernetes/apps/observability/gatus/app/externalsecret.yaml
+++ b/kubernetes/apps/observability/gatus/app/externalsecret.yaml
@@ -15,7 +15,7 @@ spec:
       data:
         BUDDY_DDNS_HOSTNAME: "{{ .BUDDY_DDNS_HOSTNAME }}"
         BUDDY_HEARTBEAT_TOKEN: "{{ .BUDDY_HEARTBEAT_TOKEN }}"
-        BUDDY_PUSHOVER_TOKEN: "{{ .BUDDY_PUSHOVER_KEY }}"
+        BUDDY_PUSHOVER_TOKEN: "{{ .BUDDY_PUSHOVER_TOKEN }}"
         BUDDY_PUSHOVER_USER_KEY: "{{ .PUSHOVER_USER_KEY }}"
         BUDDY_STATUS_HOSTNAME: "{{ .BUDDY_STATUS_HOSTNAME }}"
         FLUX_WEBHOOK_PATH: '/hook/{{ sha256sum (printf "%s%s%s" .FLUX_GITHUB_WEBHOOK_TOKEN "github-receiver" "flux-system") }}'

--- a/kubernetes/apps/observability/gatus/app/externalsecret.yaml
+++ b/kubernetes/apps/observability/gatus/app/externalsecret.yaml
@@ -15,7 +15,7 @@ spec:
       data:
         BUDDY_DDNS_HOSTNAME: "{{ .BUDDY_DDNS_HOSTNAME }}"
         BUDDY_HEARTBEAT_TOKEN: "{{ .BUDDY_HEARTBEAT_TOKEN }}"
-        BUDDY_PUSHOVER_TOKEN: "{{ .GATUS_PUSHOVER_TOKEN }}"
+        BUDDY_PUSHOVER_TOKEN: "{{ .BUDDY_PUSHOVER_KEY }}"
         BUDDY_PUSHOVER_USER_KEY: "{{ .PUSHOVER_USER_KEY }}"
         BUDDY_STATUS_HOSTNAME: "{{ .BUDDY_STATUS_HOSTNAME }}"
         FLUX_WEBHOOK_PATH: '/hook/{{ sha256sum (printf "%s%s%s" .FLUX_GITHUB_WEBHOOK_TOKEN "github-receiver" "flux-system") }}'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Gatus is crash-looping because `gatus-secret` fails to sync:

```
unable to execute template at key BUDDY_PUSHOVER_USER_KEY: map has no entry for key "BUDDY_PUSHOVER_USER_KEY"
```

The buddy pattern (#1127) referenced a `BUDDY_PUSHOVER_USER_KEY` field that doesn't exist in 1Password. With the secret stuck, Gatus starts with empty env vars and panics on the `buddy_heartbeat` external endpoint.

## Fix

Only the user key mapping needed correction — `BUDDY_PUSHOVER_TOKEN` already matches the 1Password field name:

| Secret env var | 1Password source | Item |
|---|---|---|
| `BUDDY_PUSHOVER_TOKEN` | `BUDDY_PUSHOVER_TOKEN` | gatus |
| `BUDDY_PUSHOVER_USER_KEY` | `PUSHOVER_USER_KEY` | pushover |

Also re-adds the `pushover` `dataFrom` extract so `PUSHOVER_USER_KEY` is available to the template.

## After merge

```bash
kubectl -n observability get externalsecret gatus
kubectl -n observability logs deploy/gatus -c gatus --tail=20
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-edd684ab-3ad8-43dc-981d-de03fca55033"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-edd684ab-3ad8-43dc-981d-de03fca55033"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

