### PR TITLE
fix(observability): descriptive alert job labels and VMRule wiring

### DIFF
--- a/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
@@ -47,7 +47,8 @@ spec:
         spec:
           keep_firing_for: 90s
           labels:
-            job: '{{ $labels.namespace | default "cluster" }}'
+            # vmalert/VMRule webhook only allows $labels/$value/$expr — not Helm's `default`
+            job: '{{ if $labels.namespace }}{{ $labels.namespace }}{{ else }}cluster{{ end }}'
 
     extraRules:
       dockerhub-rules:
@@ -69,7 +70,7 @@ spec:
         groups:
           - name: oom
             labels:
-              job: '{{ $labels.namespace | default "cluster" }}'
+              job: '{{ if $labels.namespace }}{{ $labels.namespace }}{{ else }}cluster{{ end }}'
             rules:
               - alert: OomKilled
                 annotations:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Rebased on `main` after #1128 merged. This PR adds the follow-up fix for Victoria Metrics stack VMRule admission failures.

## Changes

- Replace Helm `default` in `defaultRules` / `extraRules` group `job` labels with vmalert-compatible `if`/`else` templates so the VM operator webhook accepts the rules.

## Verification

- [ ] `flux reconcile helmrelease victoria-metrics -n observability` succeeds
- [ ] No `function "default" not defined` errors on `vmks-*` VMRules
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ec042059-0e95-4128-9b63-d90c83e80a75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ec042059-0e95-4128-9b63-d90c83e80a75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

