### PR TITLE
fix(nominatim): suspend OSM maintenance CronJob during bootstrap

### DIFF
--- a/kubernetes/apps/self-hosted/nominatim/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/nominatim/app/helmrelease.yaml
@@ -178,6 +178,8 @@ spec:
       update-osm-db:
         type: cronjob
         cronjob:
+          # Re-enable (suspend: false) after bootstrap / flatnode re-import completes.
+          suspend: true
           schedule: "@daily"
           concurrencyPolicy: Forbid
           successfulJobsHistory: 1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Suspends the `nominatim-update-osm-db` CronJob while the database is bootstrapping (e.g. flatnode re-import). Avoids the daily job exec'ing `maintain-regions.sh` into a pod that is still importing or unstable.

## Change

- `controllers.update-osm-db.cronjob.suspend: true`

## After bootstrap completes

1. Confirm `/status` is healthy and `task nominatim:check-config` shows a populated `flatnode.file`
2. Open a follow-up PR (or edit this file) to set `suspend: false` so incremental OSC updates resume

## Testing

Flux apply only; no chart logic changes beyond CronJob `spec.suspend`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6b63079c-d91c-470e-be2d-6994348564f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6b63079c-d91c-470e-be2d-6994348564f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

