### PR TITLE
feat(glance): add Lux Camera RSS feed

### DIFF
--- a/kubernetes/apps/self-hosted/glance/app/resources/glance.yml
+++ b/kubernetes/apps/self-hosted/glance/app/resources/glance.yml
@@ -27,6 +27,8 @@ pages:
                 limit: 4
               - url: https://ciechanow.ski/atom.xml
                 title: Bartosz Ciechanowski
+              - url: https://www.lux.camera/rss
+                title: Lux
               - url: https://samwho.dev/rss.xml
                 title: Sam Rose
               - url: https://thatshubham.com/rss.xml


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds the [Lux](https://www.lux.camera/) RSS feed to the Home page RSS widget in Glance.

## Changes

- `kubernetes/apps/self-hosted/glance/app/resources/glance.yml`: new feed entry `https://www.lux.camera/rss` with title **Lux**, placed with the other technical writing feeds in the small-column RSS widget.

## Notes

After Flux reconciles the `glance` Kustomization, the updated ConfigMap will roll out to the Glance deployment automatically.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eacfa338-cb42-4465-acfa-f1d6705d5a3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eacfa338-cb42-4465-acfa-f1d6705d5a3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

