### PR TITLE
fix(tinyauth): increase memory limit to reduce OOM risk

### DIFF
--- a/kubernetes/apps/auth/tinyauth/app/helmrelease.yaml
+++ b/kubernetes/apps/auth/tinyauth/app/helmrelease.yaml
@@ -36,9 +36,9 @@ spec:
             resources:
               requests:
                 cpu: 10m
-                memory: 32Mi
+                memory: 64Mi
               limits:
-                memory: 128Mi
+                memory: 512Mi
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

`kubernetes/apps/auth/tinyauth/app/ciliumenvoyconfig.yaml` wires tinyauth's `/api/auth/envoy` endpoint into an `ext_authz` HTTP filter on the **whole `cilium-gateway-external` listener** (not scoped to `auth.zebernst.dev` — this predates Cilium's native per-route `ExternalAuth` HTTPRoute filter). That means every external HTTPRoute's requests wait on a synchronous call to tinyauth, with a 10s timeout and `failure_mode_allow: false`.

tinyauth was previously capped at a 128Mi memory limit (32Mi request) — thin for a process handling every external request's auth check. If it gets OOMKilled or memory-pressured, the blast radius isn't just `auth.zebernst.dev`, it's every external route behind `cilium-gateway-external`.

## Change

- `resources.requests.memory`: `32Mi` → `64Mi`
- `resources.limits.memory`: `128Mi` → `512Mi`

Still a small footprint for a Go auth proxy, but removes an easy OOM ceiling as a contributing factor to the intermittent 502s currently under investigation.

## Not included

- `failure_mode_allow` stays `false` (fail-closed) — flipping it to fail-open was considered as a stopgap but rejected, since it would let anyone bypass auth simply by making tinyauth unavailable (e.g. via a DoS).
- No change to the CEC's listener-wide scoping yet; that's a larger, separate change (e.g. adopting Cilium's native `ExternalAuth` HTTPRoute filter to scope auth per-route) that deserves its own PR.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f517d-6a26-7e0f-accd-bc5b6356a906"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f517d-6a26-7e0f-accd-bc5b6356a906"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

