### PR TITLE
fix(cilium): add resource requests/limits to cilium-operator

### DIFF
--- a/kubernetes/apps/kube-system/cilium/app/helm-values.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/helm-values.yaml
@@ -55,6 +55,12 @@ localRedirectPolicy: true
 operator:
   replicas: 2
   rollOutPods: true
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      memory: 512Mi
   prometheus:
     enabled: true
     serviceMonitor:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Today `cilium-operator` got stuck with no error logs, and it silently broke every route served by a Cilium `Gateway` resource — internal, external, and even the `tailscale`-class Cilium Gateway — while anything that bypasses Cilium's control plane entirely (raw `tailscale-operator` `Ingress`/`Service`s, e.g. Plex's `ts` service, VictoriaMetrics' Tailscale ingress) kept working fine.

That pointed squarely at `cilium-operator`, since it's the component that reconciles Gateway API resources (`Gateway`/`HTTPRoute`) into Cilium's Envoy/xDS config — everything downstream of it (all three `Gateway`s) went stale/unreachable, while everything that doesn't depend on it kept functioning. A manual `kubectl rollout restart deployment/cilium-operator` resolved it immediately.

Digging into why Kubernetes never caught and auto-healed this: the Cilium Helm chart's default for `operator.resources` is `{}` — completely unbounded — and this repo didn't override it. So regardless of whether the underlying issue was a memory leak or a stuck goroutine/deadlock (the operator's own liveness probe can pass fine even if its reconcile loop is wedged), there was no resource-based backstop for Kubernetes to detect and restart it automatically.

## Change

Add `operator.resources` to the Cilium Helm values:
- `requests`: `cpu: 100m`, `memory: 128Mi`
- `limits`: `memory: 512Mi` (no CPU limit, consistent with how the rest of this repo avoids CPU throttling)

This gives kubelet a backstop to OOMKill-and-restart the operator automatically if memory grows unbounded, rather than requiring a manual restart to notice and recover.

## Caveat

If the root cause turns out to be a pure deadlock rather than memory growth, this alone won't auto-heal it (the process would stay under the memory limit while still being logically stuck). Flagging in case the issue recurs and this doesn't resolve it — at that point a scheduled restart (e.g. a CronJob invoking `kubectl rollout restart`) or investigating cilium-operator logs from the next occurrence would be the follow-up.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f517d-6a26-7e0f-accd-bc5b6356a906"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f517d-6a26-7e0f-accd-bc5b6356a906"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

