### PR TITLE
fix(rook-ceph): raise mgr/mon/osd memory limits to prevent OOMKills

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -57,9 +57,21 @@ spec:
         mgr:
           requests:
             cpu: 500m
-            memory: 512Mi
+            memory: 1Gi
           limits:
-            memory: 2Gi
+            memory: 3Gi
+        mon:
+          requests:
+            cpu: 1000m
+            memory: 1536Mi
+          limits:
+            memory: 3Gi
+        osd:
+          requests:
+            cpu: 1000m
+            memory: 6Gi
+          limits:
+            memory: 6Gi
       network:
         provider: host
         addressRanges:

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -57,13 +57,13 @@ spec:
         mgr:
           requests:
             cpu: 500m
-            memory: 1Gi
+            memory: 3Gi
           limits:
             memory: 3Gi
         mon:
           requests:
             cpu: 1000m
-            memory: 1536Mi
+            memory: 3Gi
           limits:
             memory: 3Gi
         osd:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Following up on `rook-ceph-mgr` occasionally getting OOMKilled. Ran this against vmui to quantify actual memory pressure across the last 30 days:

```promql
max_over_time(container_memory_working_set_bytes{container!=""}[30d])
/ on(namespace, pod, container) group_left()
kube_pod_container_resource_limits{resource="memory"}
```

Results for the Ceph components:

| Component | Current limit | Peak usage (30d) | Ratio |
|---|---|---|---|
| `mgr` | 2Gi (already a repo override above the chart's 1Gi default) | ~1.99Gi | 99.6% |
| `mon` | 2Gi (chart default — no repo override existed) | ~1.92Gi | 96.2% |
| `osd` | 4Gi (chart default, Guaranteed QoS) | ~3.52Gi | 88.0% |

## Change

- `mgr`: `2Gi → 3Gi` limit, request memory `512Mi → 3Gi` (== limit)
- `mon`: new explicit override, `3Gi` limit, request memory `3Gi` (== limit) (previously relying on the chart's 2Gi default)
- `osd`: new explicit override, `6Gi` limit/request (previously relying on the chart's 4Gi default)

`mon` and `osd` are Ceph quorum/data pods, so getting ahead of them before they join `mgr` at the ceiling seemed worthwhile rather than waiting for a corresponding OOM report.

## Memory request == limit for mgr/mon/osd

All three now have memory request pinned equal to their limit. This doesn't formally make them Guaranteed QoS (CPU still has a request but no limit — see below for why), but it does mean kubelet's node-memory-pressure eviction scoring (which ranks Burstable pods by how far usage exceeds *request*) can never flag these as having reclaimable slack, so they're much less likely to be evicted ahead of less-critical neighbor pods sharing the same node. That matters here specifically because this cluster schedules general workloads onto control-plane nodes alongside Ceph's mon/osd pods.

CPU is deliberately left as request-only (no limit), matching this repo's consistent pattern of avoiding CPU limits elsewhere (to avoid CFS-quota throttling). Checked actual peak CPU usage via vmui before deciding: `rook-ceph-osd-0` already bursts to ~1.7 cores against its 1000m CPU request, so adding a matching CPU limit for true Guaranteed QoS would introduce real throttling on Ceph's data path — not worth it for the marginal QoS benefit.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f517d-6a26-7e0f-accd-bc5b6356a906"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f517d-6a26-7e0f-accd-bc5b6356a906"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

