### PR TITLE
fix(victoria-metrics): raise vmsingle memory limit to reduce OOM risk

### DIFF
--- a/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
@@ -157,9 +157,9 @@ spec:
         resources:
           requests:
             cpu: 100m
-            memory: 4Gi
+            memory: 6Gi
           limits:
-            memory: 4Gi
+            memory: 6Gi
         storage:
           accessModes:
             - ReadWriteOnce


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Same vmui memory-pressure audit as the rook-ceph PR. `vmsingle` (the cluster's entire metrics store) came back at the very top of the list:

- Current limit: `4Gi` (request == limit, Guaranteed QoS)
- Peak usage over 30d: ~4.0Gi (**99.98%** of its limit) — effectively pinned at the ceiling continuously, despite `memory.allowedPercent: "80"` already trying to keep vmsingle's own internal caches within budget.

## Change

- `resources.requests.memory` / `resources.limits.memory`: `4Gi → 6Gi` (kept request == limit to preserve Guaranteed QoS, consistent with `priorityClassName: control-plane-critical`)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f517d-6a26-7e0f-accd-bc5b6356a906"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f517d-6a26-7e0f-accd-bc5b6356a906"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

