### PR TITLE
fix(dawarich): raise web/sidekiq memory limits to reduce OOM risk

### DIFF
--- a/kubernetes/apps/self-hosted/dawarich/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/dawarich/app/helmrelease.yaml
@@ -89,9 +89,9 @@ spec:
             resources:
               requests:
                 cpu: 50m
-                memory: 512Mi
+                memory: 768Mi
               limits:
-                memory: 1Gi
+                memory: 1536Mi
           sidekiq:
             image:
               repository: freikin/dawarich
@@ -114,9 +114,9 @@ spec:
             resources:
               requests:
                 cpu: 50m
-                memory: 256Mi
+                memory: 512Mi
               limits:
-                memory: 1Gi
+                memory: 1536Mi
           redis:
             image:
               repository: docker.io/redis


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Same vmui memory-pressure audit as the rook-ceph/vmsingle PRs. Dawarich's `web` and `sidekiq` containers both came back close to their `1Gi` limits over the last 30 days:

- `web`: peak usage ~916Mi (91.6% of limit)
- `sidekiq`: peak usage ~872Mi (87.2% of limit)

## Change

- `web`: request memory `512Mi → 768Mi`, limit `1Gi → 1.5Gi`
- `sidekiq`: request memory `256Mi → 512Mi`, limit `1Gi → 1.5Gi`

Requests were bumped too, since the previous requests (especially sidekiq's `256Mi`) significantly understated actual sustained usage.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f517d-6a26-7e0f-accd-bc5b6356a906"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f517d-6a26-7e0f-accd-bc5b6356a906"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

