### PR TITLE
fix: VM scrape objects landing in default namespace + Hubble cert expiry crash loop

### DIFF
--- a/kubernetes/apps/database/dragonfly/ks.yaml
+++ b/kubernetes/apps/database/dragonfly/ks.yaml
@@ -33,6 +33,8 @@ spec:
       app.kubernetes.io/name: *app
   dependsOn:
     - name: dragonfly
+    - name: victoria-metrics-operator
+      namespace: observability
   path: kubernetes/apps/database/dragonfly/cluster
   prune: true
   sourceRef:

--- a/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
@@ -22,6 +22,17 @@ spec:
   values:
     hubble:
       enabled: true
+      tls:
+        auto:
+          # "helm" (chart default) only generates certs once at install time and
+          # never renews them — Flux's periodic HelmRelease reconciles are no-ops
+          # against an unchanged chart, so the certs silently expire after
+          # certValidityDuration with no automatic recovery. "cronJob" adds an
+          # in-cluster CronJob that periodically regenerates certs before they
+          # expire, independent of whether Flux ever runs another helm upgrade.
+          method: cronJob
+          certValidityDuration: 365
+          schedule: "0 0 1 */2 *"
       metrics:
         enabled:
           - dns:query

--- a/kubernetes/apps/self-hosted/dawarich/ks.yaml
+++ b/kubernetes/apps/self-hosted/dawarich/ks.yaml
@@ -21,6 +21,8 @@ spec:
       namespace: external-secrets
     - name: rook-ceph-cluster
       namespace: rook-ceph
+    - name: victoria-metrics-operator
+      namespace: observability
     - name: volsync
       namespace: volsync-system
   path: kubernetes/apps/self-hosted/dawarich/app

--- a/kubernetes/apps/volsync-system/volsync/ks.yaml
+++ b/kubernetes/apps/volsync-system/volsync/ks.yaml
@@ -10,6 +10,9 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
+  dependsOn:
+    - name: victoria-metrics-operator
+      namespace: observability
   path: kubernetes/apps/volsync-system/volsync/app
   prune: true
   sourceRef:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## VMServiceScrape/VMPodScrape landing in `default` namespace

`dawarich`, `dragonfly-cluster`, and `volsync` each define a `VMServiceScrape`/`VMPodScrape`, but unlike every other app that does (`gatus`, `blackbox-exporter`, `holmesgpt`, `vmalert`, ...), none of them declared `dependsOn: victoria-metrics-operator`.

Without that ordering guarantee, `kustomize-controller` can reconcile these Kustomizations before the VictoriaMetrics operator CRDs are registered with the API server. When it can't resolve the CRD's scope, the `targetNamespace` transform is skipped and the object gets applied to `default` instead of `self-hosted`/`database`/`volsync-system`. Since VMAgent's `VMServiceScrape`/`VMPodScrape` selectors are namespace-scoped to the resource's *own* namespace by default, the stray objects in `default` never match the actual Services/Pods — which is exactly the `ScrapePoolHasNoTargets` alerts seen firing in Alertmanager.

Fix: add the missing `dependsOn: victoria-metrics-operator` (namespace `observability`) to all three Kustomizations, matching the existing pattern used elsewhere in the repo. Flux prune should clean up the stray `default`-namespace objects automatically on the next reconcile.

## Hubble-relay crash loop / Cilium HelmRelease stuck on upgrade

Logs showed hubble-relay failing peer auth with an expired cert:

```
transport: authentication handshake failed: tls: failed to verify certificate: x509: certificate has expired or is not yet valid: current time 2026-07-11T17:21:53Z is after 2026-06-22T00:41:45Z
```

`hubble.tls.auto.method` was left at its chart default, `"helm"`. That method only generates the `hubble-server-certs`/`hubble-relay-*-certs` secrets once, at install time, with a 365-day default `certValidityDuration` — and per [Cilium's own docs](https://docs.cilium.io/en/stable/observability/hubble/configuration/tls/), they are **never automatically renewed**; a `helm upgrade` is required before they expire. Since this cluster is GitOps-managed via Flux, periodic HelmRelease reconciles are no-ops against an unchanged chart/values, so nothing ever re-triggered cert generation and the certs quietly expired, taking down hubble-relay and blocking the Cilium HelmRelease from reaching Ready.

Fix: switch `hubble.tls.auto.method` to `cronJob`, which schedules an in-cluster CronJob to unconditionally regenerate the certs every 2 months — independent of whether Flux ever triggers another helm upgrade.

**Manual step still required to unblock the current crash loop:** certgen (either method) only generates a secret if it doesn't already exist, so this change alone won't retroactively fix the already-expired secrets. Delete them so the next reconcile regenerates fresh ones:

```bash
kubectl -n kube-system delete secret \
  hubble-server-certs \
  hubble-relay-server-certs \
  hubble-relay-client-certs \
  hubble-ui-client-certs
```


<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f517d-6a26-7e0f-accd-bc5b6356a906"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f517d-6a26-7e0f-accd-bc5b6356a906"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

