### PR TITLE
fix(nominatim): increase flatnode PVC to 200Gi

### DIFF
--- a/kubernetes/apps/self-hosted/nominatim/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/nominatim/app/helmrelease.yaml
@@ -249,7 +249,8 @@ spec:
       flatnode:
         type: persistentVolumeClaim
         accessMode: ReadWriteOnce
-        size: 100Gi
+        # osm2pgsql pre-allocates ~8 bytes × max OSM node ID (~100GB for US); 100Gi PVC fills up.
+        size: 200Gi
         storageClass: ceph-block
         advancedMounts:
           nominatim:

--- a/kubernetes/apps/self-hosted/nominatim/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/nominatim/app/helmrelease.yaml
@@ -249,8 +249,7 @@ spec:
       flatnode:
         type: persistentVolumeClaim
         accessMode: ReadWriteOnce
-        # osm2pgsql pre-allocates ~8 bytes × max OSM node ID (~100GB for US); 100Gi PVC fills up.
-        size: 200Gi
+        size: 250Gi
         storageClass: ceph-block
         advancedMounts:
           nominatim:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

US bootstrap import failed during osm2pgsql with:

```
ERROR: Could not resize file: Not enough space on filesystem: No space left on device
```

Flatnode was configured correctly (`--flat-nodes /nominatim/flatnode/flatnode.file`, `--cache 0`). The 100Gi flatnode PVC is too small: osm2pgsql pre-allocates the flatnode file at ~8 bytes × max OSM node ID, which reaches ~100GB for the US extract with no filesystem headroom left in a 100Gi volume.

## Change

- Increase `flatnode` PVC from `100Gi` → `200Gi`

## Operator steps after merge

1. Expand or recreate the PVC (import failed, so deleting and re-running bootstrap is simplest):
   - `task nominatim:reset-for-flatnode` after Flux applies the new size, **or**
   - `kubectl -n self-hosted patch pvc nominatim-flatnode -p '{"spec":{"resources":{"requests":{"storage":"200Gi"}}}}'` if Ceph expansion is preferred
2. Re-run US bootstrap and confirm `flatnode.file` grows without ENOSPC
3. Re-enable maintenance cron (`suspend: false`) once import completes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6b63079c-d91c-470e-be2d-6994348564f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6b63079c-d91c-470e-be2d-6994348564f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

