### PR TITLE
fix(nominatim): use PVC subPath to avoid initdb lost+found error

### DIFF
--- a/kubernetes/apps/self-hosted/nominatim/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/nominatim/app/helmrelease.yaml
@@ -240,6 +240,7 @@ spec:
           nominatim:
             nominatim:
               - path: /var/lib/postgresql/16/main
+                subPath: pgdata
       project:
         existingClaim: nominatim-project
         advancedMounts:
@@ -255,6 +256,7 @@ spec:
           nominatim:
             nominatim:
               - path: /nominatim/flatnode
+                subPath: flatnode
       scripts:
         type: configMap
         name: nominatim-scripts


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Fresh `nominatim-pgdata` PVC bootstrap fails with:

```
initdb: error: directory "/var/lib/postgresql/16/main" exists but is not empty
initdb: detail: It contains a lost+found directory, perhaps due to it being a mount point.
```

Kubernetes block volumes mount the filesystem root at the pod path, which includes `lost+found`. The mediagis image runs `initdb -D /var/lib/postgresql/16/main` directly on that mount.

## Fix

Mount PVC data via `subPath` so Postgres and flatnode use empty subdirectories on the volume:

- `pgdata` → `/var/lib/postgresql/16/main`
- `flatnode` → `/nominatim/flatnode`

## Operator steps

After merge, reset bootstrap so new mounts take effect on fresh PVCs:

```bash
task nominatim:reset-for-flatnode
```

Existing data at the volume root (outside the subPath) is ignored after this change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6b63079c-d91c-470e-be2d-6994348564f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6b63079c-d91c-470e-be2d-6994348564f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

