### PR TITLE
feat(glance): add Kubernetes blog to RSS feeds

### DIFF
--- a/kubernetes/apps/self-hosted/glance/app/resources/glance.yml
+++ b/kubernetes/apps/self-hosted/glance/app/resources/glance.yml
@@ -33,6 +33,9 @@ pages:
                 title: Shubham Bose
               - url: https://jepsen.io/blog.rss
                 title: Jepsen
+              - url: https://kubernetes.io/feed.xml
+                title: Kubernetes Blog
+                limit: 4
 
       - size: full
         widgets:


### PR DESCRIPTION
Glance Home now includes the Kubernetes blog in the RSS widget, capped at 4 items so it doesn’t crowd out the other feeds.
