### PR TITLE
fix(renovate): stop nominatim group from swallowing all updates

### DIFF
--- a/.github/renovate/groups.json5
+++ b/.github/renovate/groups.json5
@@ -108,7 +108,9 @@
     {
       description: "Nominatim",
       groupName: "nominatim",
-      matchFilePaths: ["kubernetes/apps/self-hosted/nominatim/**"],
+      // matchFileNames (not matchFilePaths) — unknown matchers are ignored, and a
+      // groupName rule with no valid matchers applies to every dependency.
+      matchFileNames: ["kubernetes/apps/self-hosted/nominatim/**"],
       group: {
         commitMessageTopic: "{{{groupName}}} group",
       },

--- a/.github/renovate/groups.json5
+++ b/.github/renovate/groups.json5
@@ -108,8 +108,6 @@
     {
       description: "Nominatim",
       groupName: "nominatim",
-      // matchFileNames (not matchFilePaths) — unknown matchers are ignored, and a
-      // groupName rule with no valid matchers applies to every dependency.
       matchFileNames: ["kubernetes/apps/self-hosted/nominatim/**"],
       group: {
         commitMessageTopic: "{{{groupName}}} group",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Renovate’s Dependency Dashboard ([#48](https://github.com/zebernst/homelab/issues/48)) shows nearly every update stuffed into `nominatim` PRs (#1133 / #1134).

**Culprit:** the Nominatim group added in #1101 used `matchFilePaths`, which is not a Renovate option. Renovate ignores unknown keys, so the rule was effectively:

```json5
{ groupName: "nominatim" }
```

A `groupName` rule with no valid matchers applies to **every** dependency. That’s why unrelated charts/images (cert-manager, cilium, flux, …) all landed in the nominatim group. Groups defined *after* nominatim (e.g. Minecraft) still won for their packages; everything else lost.

**Fix:** rename to the real matcher, `matchFileNames`.

## After merge

Close/supersede the bad grouped PRs (#1133, #1134) and let Renovate recreate normal per-package / intended-group PRs on the next run.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-32c88168-9bb6-441d-bcaa-cbeb9a671a13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-32c88168-9bb6-441d-bcaa-cbeb9a671a13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

