### PR TITLE
fix(ci): restore Flate diffs after flate 0.4 dropped -o markdown

### DIFF
--- a/.github/workflows/flux-check.yaml
+++ b/.github/workflows/flux-check.yaml
@@ -122,7 +122,7 @@ jobs:
           flate diff ${{ matrix.resource }} \
             --path ./kubernetes \
             --allow-missing-secrets \
-            -o markdown \
+            -o github \
             > diff.patch 2> diff.err || rc=$?
           if [[ "$rc" -eq 0 ]]; then
             exit 0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Renovate bumped `home-operations/flate` from `0.1.35` → `v0.4.10`. Diff jobs started failing immediately with:

```text
flate error: invalid argument "markdown" for "-o, --output" flag:
must be one of: human, github, diff, html, brief, gitlab, gitea
```

`flate test` still passed; only `flate diff` broke on the removed output format.

## Fix

Switch `-o markdown` → `-o github` in `.github/workflows/flux-check.yaml`, matching current flate CLI docs and [buroa/k8s-gitops](https://github.com/buroa/k8s-gitops/blob/main/.github/workflows/flate.yaml) (`FLATE_OUTPUT: github`).

## Context from related projects

| Tool | Role |
|------|------|
| **flate** | Offline Flux renderer/validator used in CI (`test` + `diff`) |
| **konflate** | In-cluster PR review UI that embeds flate (onedr0p/buroa deploy it under `flux-system`; this repo does not yet) |
| **downflate** | In-cluster image pre-pull via Talos API (buroa replaced GHA image-pull with this; our `pre-pull-images.yaml` is the older GHA approach and is currently dispatch-only) |

onedr0p still uses **flux-local** in GitHub Actions and flate locally (`just` recipes); buroa runs flate directly in CI like this repo.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-50df801d-6f1d-4aa1-9126-581ccf7a3ab1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-50df801d-6f1d-4aa1-9126-581ccf7a3ab1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

