### PR TITLE
feat(flux-system): deploy konflate for rendered Flux PR review

### DIFF
--- a/.github/workflows/flux-check.yaml
+++ b/.github/workflows/flux-check.yaml
@@ -84,9 +84,6 @@ jobs:
     needs: [filter]
     name: Flate - Diff
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
     strategy:
       matrix:
         resource: [helmrelease, kustomization]
@@ -113,6 +110,7 @@ jobs:
           cache: true
           token: "${{ steps.app-token.outputs.token }}"
 
+      # PR comments are owned by in-cluster konflate; keep the Actions step summary only.
       - name: Run flate diff
         env:
           FLATE_BASE: ""
@@ -125,6 +123,12 @@ jobs:
             -o github \
             > diff.patch 2> diff.err || rc=$?
           if [[ "$rc" -eq 0 ]]; then
+            {
+              echo "### Diff"
+              echo '```diff'
+              cat diff.patch
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
           if [[ -s diff.patch ]]; then
@@ -142,41 +146,6 @@ jobs:
           fi
           cat diff.err >&2
           exit "$rc"
-
-      - name: Generate Diff
-        id: diff
-        run: |
-          if [ -s diff.patch ]; then
-            echo "has_diff=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_diff=false" >> "$GITHUB_OUTPUT"
-          fi
-
-          {
-            echo "### Diff"
-            echo '```diff'
-            cat diff.patch
-            echo '```'
-          } >> "$GITHUB_STEP_SUMMARY"
-
-          {
-            echo '```diff'
-            head -c 500000 diff.patch
-            if [ "$(wc -c < diff.patch)" -gt 500000 ]; then
-              echo ""
-              echo "... diff truncated for PR comment ($(wc -c < diff.patch) bytes total). See workflow run summary for full output."
-            fi
-            echo '```'
-          } > diff-comment.md
-
-      - if: ${{ steps.diff.outputs.has_diff == 'true' }}
-        name: Add Comment
-        uses: mshick/add-pr-comment@v3
-        with:
-          repo-token: "${{ steps.app-token.outputs.token }}"
-          message-id: "${{ github.event.pull_request.number }}/kubernetes/${{ matrix.resource }}"
-          message-failure: Diff was not successful
-          message-path: diff-comment.md
 
   flate-success:
     needs: [filter, test, diff]

--- a/kubernetes/apps/flux-system/konflate/app/externalsecret.yaml
+++ b/kubernetes/apps/flux-system/konflate/app/externalsecret.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: konflate
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: konflate-secret
+    template:
+      engineVersion: v2
+      data:
+        KONFLATE_WEBHOOK_SECRET: "{{ .KONFLATE_WEBHOOK_SECRET }}"
+        KONFLATE_APP_CLIENT_ID: "{{ .GITHUB_BOT_APP_CLIENT_ID }}"
+        KONFLATE_APP_PRIVATE_KEY: "{{ .GITHUB_BOT_APP_PRIVATE_KEY }}"
+  dataFrom:
+    - extract:
+        key: konflate
+    - extract:
+        key: github-bot

--- a/kubernetes/apps/flux-system/konflate/app/externalsecret.yaml
+++ b/kubernetes/apps/flux-system/konflate/app/externalsecret.yaml
@@ -14,8 +14,8 @@ spec:
       engineVersion: v2
       data:
         KONFLATE_WEBHOOK_SECRET: "{{ .KONFLATE_WEBHOOK_SECRET }}"
-        KONFLATE_APP_CLIENT_ID: "{{ .GITHUB_BOT_APP_CLIENT_ID }}"
-        KONFLATE_APP_PRIVATE_KEY: "{{ .GITHUB_BOT_APP_PRIVATE_KEY }}"
+        KONFLATE_APP_CLIENT_ID: "{{ .GITHUB_APP_CLIENT_ID }}"
+        KONFLATE_APP_PRIVATE_KEY: "{{ .GITHUB_APP_PRIVATE_KEY }}"
   dataFrom:
     - extract:
         key: konflate

--- a/kubernetes/apps/flux-system/konflate/app/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/konflate/app/helmrelease.yaml
@@ -1,0 +1,64 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: konflate
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    # renovate: datasource=docker depName=ghcr.io/home-operations/charts/konflate
+    tag: 0.4.0
+  url: oci://ghcr.io/home-operations/charts/konflate
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: konflate
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: konflate
+
+  values:
+    config:
+      repo: github://zebernst/homelab
+      # Empty = repo root; Flux paths here are root-relative (kubernetes/...).
+      clusterPath: ""
+      statusChecks: true
+      prComments: true
+      publicUrl: https://konflate.zebernst.dev
+      verifyImages: true
+    secret:
+      existingSecret: konflate-secret
+    httpRoute:
+      enabled: true
+      annotations:
+        gatus.home-operations.com/endpoint: |
+          path: /readyz
+      parentRefs:
+        - name: external
+          namespace: kube-system
+          sectionName: https
+      hostnames:
+        - konflate.zebernst.dev
+    persistence:
+      enabled: true
+      storageClass: ceph-block
+      size: 5Gi
+    monitoring:
+      serviceMonitor:
+        enabled: true
+    priorityClassName: external-facing
+    resources:
+      requests:
+        cpu: 50m
+        memory: 256Mi
+      limits:
+        memory: 1Gi
+    deploymentAnnotations:
+      reloader.stakater.com/auto: "true"

--- a/kubernetes/apps/flux-system/konflate/app/kustomization.yaml
+++ b/kubernetes/apps/flux-system/konflate/app/kustomization.yaml
@@ -2,9 +2,6 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: flux-system
-components:
-  - ../../components/common
 resources:
-  - flux-operator/ks.yaml
-  - konflate/ks.yaml
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/flux-system/konflate/ks.yaml
+++ b/kubernetes/apps/flux-system/konflate/ks.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app konflate
+  namespace: &ns flux-system
+spec:
+  targetNamespace: *ns
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: onepassword
+      namespace: external-secrets
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+  path: kubernetes/apps/flux-system/konflate/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Deploys [konflate](https://github.com/home-operations/konflate) under `flux-system` so PRs can be reviewed as **rendered** Flux diffs (via flate), with commit statuses and PR comments.

Also stops Flate GHA from posting PR comments so konflate is the only review commenter. Flate CI still runs `test`/`diff` as the gate and writes the Actions step summary.

Modeled on [onedr0p/home-ops](https://github.com/onedr0p/home-ops/tree/main/kubernetes/apps/flux-system/konflate), adapted to this repo’s conventions.

## What’s included

| Change | Purpose |
|--------|---------|
| `konflate/` under `flux-system` | Chart 0.4.0 + ExternalSecret + HTTPRoute |
| `flux-check.yaml` | Remove `add-pr-comment`; keep test/diff + step summary |

UI: `https://konflate.zebernst.dev` → Gateway `external`.

## Manual setup (required after merge)

### 1. 1Password

Create item **`konflate`** in the Connect vault with:

- `KONFLATE_WEBHOOK_SECRET` — random string (e.g. `openssl rand -hex 32`)

Reuse item **`github-bot`** fields:

- `GITHUB_APP_CLIENT_ID`
- `GITHUB_APP_PRIVATE_KEY`

### 2. GitHub App permissions

On that app, ensure at least:

- Contents: **Read**
- Pull requests: **Read & write** (for PR comments)
- Commit statuses: **Read & write**

### 3. Repository webhook

After Flux reconciles and DNS is live:

- URL: `https://konflate.zebernst.dev/hooks`
- Content type: `application/json`
- Secret: same as `KONFLATE_WEBHOOK_SECRET`
- Events: **Pull requests** (and optionally **Pushes**)

## Notes

- Konflate embeds flate as a Go library in-cluster; it does **not** invoke the Flate GitHub Action or share CI cache — two independent consumers of the same render engine.
- downflate (image pre-pull) is intentionally out of scope for this PR.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-50df801d-6f1d-4aa1-9126-581ccf7a3ab1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-50df801d-6f1d-4aa1-9126-581ccf7a3ab1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

