### PR TITLE
fix(konflate): raise memory to 2Gi and cap render concurrency

### DIFF
--- a/.github/workflows/flux-check.yaml
+++ b/.github/workflows/flux-check.yaml
@@ -110,7 +110,6 @@ jobs:
           cache: true
           token: "${{ steps.app-token.outputs.token }}"
 
-      # PR comments are owned by in-cluster konflate; keep the Actions step summary only.
       - name: Run flate diff
         env:
           FLATE_BASE: ""

--- a/kubernetes/apps/flux-system/konflate/app/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/konflate/app/helmrelease.yaml
@@ -33,6 +33,9 @@ spec:
       prComments: true
       publicUrl: https://konflate.zebernst.dev
       verifyImages: true
+      # Cap concurrent flate renders — without a CPU limit the chart auto-fans
+      # out to 4 and a Renovate burst OOMs a 1Gi pod.
+      maxDiffConcurrency: 2
     secret:
       existingSecret: konflate-secret
     httpRoute:
@@ -56,9 +59,10 @@ spec:
     priorityClassName: external-facing
     resources:
       requests:
-        cpu: 50m
-        memory: 256Mi
+        cpu: 100m
+        memory: 512Mi
       limits:
-        memory: 1Gi
+        cpu: "2"
+        memory: 2Gi
     deploymentAnnotations:
       reloader.stakater.com/auto: "true"

--- a/kubernetes/apps/flux-system/konflate/app/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/konflate/app/helmrelease.yaml
@@ -27,14 +27,11 @@ spec:
   values:
     config:
       repo: github://zebernst/homelab
-      # Empty = repo root; Flux paths here are root-relative (kubernetes/...).
       clusterPath: ""
       statusChecks: true
       prComments: true
       publicUrl: https://konflate.zebernst.dev
       verifyImages: true
-      # Cap concurrent flate renders — without a CPU limit the chart auto-fans
-      # out to 4 and a Renovate burst OOMs a 1Gi pod.
       maxDiffConcurrency: 2
     secret:
       existingSecret: konflate-secret


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Konflate (which embeds flate) was OOMKilled at the chart default **1Gi** memory limit while rendering PRs.

## Changes

- Memory limit `1Gi` → `2Gi` (request `512Mi`)
- CPU limit `2` so GOMAXPROCS stays bounded
- `maxDiffConcurrency: 2` so Renovate bursts don’t fan out to 4 concurrent full-tree flate renders

The chart docs call out raising the limit for large clusters; without a CPU limit, concurrency auto-scales up to 4 and peak Helm heap exceeds 1Gi.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-50df801d-6f1d-4aa1-9126-581ccf7a3ab1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-50df801d-6f1d-4aa1-9126-581ccf7a3ab1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

