### PR TITLE
fix(tailscale): request devic.es/tun after generic-device-plugin 0.2.0

### DIFF
--- a/kubernetes/apps/kube-system/generic-device-plugin/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/generic-device-plugin/app/helmrelease.yaml
@@ -21,7 +21,7 @@ spec:
           app:
             image:
               repository: ghcr.io/squat/generic-device-plugin
-              tag: latest@sha256:dc192e164c69b03f156765793a1be62ca437709ae477b27ca7d8f3dcf5021576
+              tag: 0.2.0@sha256:dc192e164c69b03f156765793a1be62ca437709ae477b27ca7d8f3dcf5021576
             args:
               - --log-level=info
               - --config=/config/config.yaml

--- a/kubernetes/apps/network/tailscale-operator/app/proxyclass.yaml
+++ b/kubernetes/apps/network/tailscale-operator/app/proxyclass.yaml
@@ -9,7 +9,7 @@ spec:
       tailscaleContainer:
         resources:
           limits:
-            squat.ai/tun: "1"
+            devic.es/tun: "1"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:


### PR DESCRIPTION
## Summary
- Update Tailscale `ProxyClass` to request `devic.es/tun` instead of `squat.ai/tun`, matching generic-device-plugin 0.2.0's new default resource domain
- Pin the generic-device-plugin image tag to `0.2.0` (same digest) so the domain change is explicit

Without this, Tailscale proxy pods stay `Pending` with `Insufficient squat.ai/tun` while nodes advertise `devic.es/tun`.

## Test plan
- [ ] Flux reconciles `generic-device-plugin` and `tailscale-operator`/`ProxyClass`
- [ ] Nodes show allocatable `devic.es/tun` > 0
- [ ] `ts-*` pods in `network` schedule and become Ready
- [ ] Spot-check a Tailscale Ingress (e.g. bazarr) resolves over the tailnet


Made with [Cursor](https://cursor.com)