### PR TITLE
fix(dragonfly): sync operator ClusterRole with v1.6.1 RBAC

### DIFF
--- a/kubernetes/apps/database/dragonfly/app/rbac.yaml
+++ b/kubernetes/apps/database/dragonfly/app/rbac.yaml
@@ -11,8 +11,11 @@ rules:
     resources: ["events"]
     verbs: ["create", "patch"]
   - apiGroups: [""]
-    resources: ["pods", "services"]
+    resources: ["configmaps", "pods", "services"]
     verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  - apiGroups: [""]
+    resources: ["pods/status"]
+    verbs: ["get", "patch", "update"]
   - apiGroups: ["apps"]
     resources: ["statefulsets"]
     verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
@@ -25,6 +28,12 @@ rules:
   - apiGroups: ["dragonflydb.io"]
     resources: ["dragonflies/status"]
     verbs: ["get", "patch", "update"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["networkpolicies"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  - apiGroups: ["policy"]
+    resources: ["poddisruptionbudgets"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
## Summary
- Align `dragonfly-operator` ClusterRole with upstream v1.6.1 permissions (`configmaps`, `networkpolicies`, `pods/status`, `poddisruptionbudgets`)
- Fixes informer cache sync timeouts after the operator bump in #1273

## Test plan
- [ ] Merge and wait for Flux to apply RBAC
- [ ] Confirm operator pod stops Forbidden errors for ConfigMap/NetworkPolicy
- [ ] Confirm operator stays Ready without restart loops
- [ ] Confirm hindwing Dragonfly resources still reconcile


Made with [Cursor](https://cursor.com)