### PR TITLE
fix(dragonfly): label operator for admin-port NetworkPolicy

### DIFF
--- a/kubernetes/apps/database/dragonfly/app/helmrelease.yaml
+++ b/kubernetes/apps/database/dragonfly/app/helmrelease.yaml
@@ -24,6 +24,11 @@ spec:
             image:
               repository: ghcr.io/dragonflydb/operator
               tag: v1.6.1@sha256:b11411142935f92ed0ec30a5ddeb31680e09ab66beecb827cb0224f1c4238638
+            env:
+              POD_NAMESPACE:
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.namespace
             args:
               - --health-probe-bind-address=:8081
               - --metrics-bind-address=:8080
@@ -55,6 +60,7 @@ spec:
             resources:
               requests:
                 cpu: 10m
+                memory: 64Mi
               limits:
                 memory: 128Mi
             securityContext:

--- a/kubernetes/apps/database/dragonfly/app/helmrelease.yaml
+++ b/kubernetes/apps/database/dragonfly/app/helmrelease.yaml
@@ -14,6 +14,9 @@ spec:
   values:
     controllers:
       dragonfly-operator:
+        # Required by operator-managed NetworkPolicy admin-port peer selector
+        labels:
+          control-plane: controller-manager
         serviceAccount:
           identifier: *app
         containers:

--- a/kubernetes/apps/database/dragonfly/cluster/cluster.yaml
+++ b/kubernetes/apps/database/dragonfly/cluster/cluster.yaml
@@ -6,6 +6,8 @@ metadata:
 spec:
   image: ghcr.io/dragonflydb/dragonfly:v1.39.0
   replicas: 3
+  # Restricts admin :9999 to operator + peer pods (operator default since 1.6)
+  networkPolicyEnabled: true
   args:
     - --maxmemory=$(MAX_MEMORY)Mi
     - --proactor_threads=2


### PR DESCRIPTION
## Summary
- Add `control-plane: controller-manager` to the dragonfly-operator pod so it matches the peer selector on the operator-managed NetworkPolicy
- Set `POD_NAMESPACE` from the pod fieldRef (upstream uses this for NP namespace pinning)
- Add operator memory request `64Mi` to match upstream
- Set `networkPolicyEnabled: true` explicitly on hindwing

## Context
Operator v1.6.1 enables NetworkPolicies by default and restricts `:9999` to pods with that label (upstream deploy sets it; our app-template chart did not). Symptom: `dial tcp …:9999: i/o timeout` during reconcile/rollout.

## Test plan
- [ ] Merge and wait for Flux to roll the operator Deployment + Dragonfly CR
- [ ] Confirm operator pod has `control-plane=controller-manager` and `POD_NAMESPACE=database`
- [ ] Confirm `:9999` dial timeouts stop
- [ ] Confirm hindwing finishes RollingUpdate → Ready