### PR TITLE
fix(dragonfly): put NetworkPolicy peer label on the Pod

### DIFF
--- a/kubernetes/apps/database/dragonfly/app/helmrelease.yaml
+++ b/kubernetes/apps/database/dragonfly/app/helmrelease.yaml
@@ -14,9 +14,6 @@ spec:
   values:
     controllers:
       dragonfly-operator:
-        # Required by operator-managed NetworkPolicy admin-port peer selector.
-        # Must be on the Pod (controllers.*.pod.labels), not the Deployment
-        # (controllers.*.labels) — app-template puts the latter only on the RS owner.
         pod:
           labels:
             control-plane: controller-manager

--- a/kubernetes/apps/database/dragonfly/app/helmrelease.yaml
+++ b/kubernetes/apps/database/dragonfly/app/helmrelease.yaml
@@ -14,9 +14,12 @@ spec:
   values:
     controllers:
       dragonfly-operator:
-        # Required by operator-managed NetworkPolicy admin-port peer selector
-        labels:
-          control-plane: controller-manager
+        # Required by operator-managed NetworkPolicy admin-port peer selector.
+        # Must be on the Pod (controllers.*.pod.labels), not the Deployment
+        # (controllers.*.labels) — app-template puts the latter only on the RS owner.
+        pod:
+          labels:
+            control-plane: controller-manager
         serviceAccount:
           identifier: *app
         containers:

--- a/kubernetes/apps/database/dragonfly/cluster/cluster.yaml
+++ b/kubernetes/apps/database/dragonfly/cluster/cluster.yaml
@@ -6,14 +6,12 @@ metadata:
 spec:
   image: ghcr.io/dragonflydb/dragonfly:v1.39.0
   replicas: 3
-  # Restricts admin :9999 to operator + peer pods (operator default since 1.6)
   networkPolicyEnabled: true
   args:
     - --maxmemory=$(MAX_MEMORY)Mi
     - --proactor_threads=2
     - --cluster_mode=emulated
     - --lock_on_hashtags
-    # Bull/BullMQ (NocoDB) without hashtag prefixes
     - --default_lua_flags=allow-undeclared-keys
   env:
     - name: MAX_MEMORY


### PR DESCRIPTION
## Summary
- Move `control-plane: controller-manager` from `controllers.*.labels` (Deployment only) to `controllers.*.pod.labels` so the operator Pod matches the admin-port NetworkPolicy peer selector

## Context
#1287 applied the label in the wrong place for app-template — it landed on the Deployment metadata, not the Pod. Operator still cannot dial `:9999` (`i/o timeout`), and hindwing remains stuck in `RollingUpdate`.

## Test plan
- [ ] Confirm operator Pod has `control-plane=controller-manager`
- [ ] Confirm `:9999` dial timeouts stop
- [ ] Confirm hindwing finishes RollingUpdate → Ready


Made with [Cursor](https://cursor.com)