### PR TITLE
fix(observability): use silence-operator chart default image registry

### DIFF
--- a/kubernetes/apps/observability/silence-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/silence-operator/app/helmrelease.yaml
@@ -28,7 +28,5 @@ spec:
     crds: CreateReplace
   values:
     alertmanagerAddress: http://vmalertmanager-vmks.observability.svc.cluster.local:9093
-    image:
-      registry: quay.io
     networkPolicy:
       enabled: false


### PR DESCRIPTION
Helm upgrades to silence-operator `0.20.0` were ImagePullBackOff because values forced `quay.io`, and that registry has no `0.20.0` tag (latest there is `0.19.0`). The chart’s default registry `gsoci.azurecr.io` does publish `0.20.0`; confirmed with a local pull.

Dropping the `image.registry` override matches the chart defaults and [onedr0p/home-ops](https://github.com/onedr0p/home-ops). After merge, Flux should bump the HelmRelease generation and retry the stalled upgrade (it is currently `RetriesExceeded` after rollback to `0.19.0`).
