### PR TITLE
fix(nominatim): create Linux nominatim user before resume chown

### DIFF
--- a/kubernetes/apps/self-hosted/nominatim/app/scripts/resume-import.sh
+++ b/kubernetes/apps/self-hosted/nominatim/app/scripts/resume-import.sh
@@ -91,6 +91,16 @@ ensure_roles() {
   fi
 }
 
+# Linux user (distinct from the Postgres role). mediagis start.sh creates this
+# before init; we resume before that path runs, so create it here for chown/sudo -u.
+ensure_os_user() {
+  if id nominatim >/dev/null 2>&1; then
+    return 0
+  fi
+  log "Creating Linux user nominatim"
+  useradd -m -p "${NOMINATIM_PASSWORD:-}" nominatim
+}
+
 start_postgres() {
   enable_import_conf
   if pg_isready -q 2>/dev/null; then
@@ -366,6 +376,7 @@ if [ ! -f "${PGDATA}/PG_VERSION" ]; then
 fi
 
 acquire_lock
+ensure_os_user
 start_postgres
 ensure_roles
 


### PR DESCRIPTION
## Summary
- Resume runs before mediagis `start.sh` creates the Linux `nominatim` user, so `chown nominatim:nominatim` failed with `invalid user`
- Create the OS user the same way mediagis does (`useradd -m`) before ownership fix / `sudo -u nominatim`

## Context
Follow-up to #1299. Pod got past `.env`/roles and detected `indexing`, then crashlooped on chown.

## Test plan
- [ ] Flux applies ConfigMap; pod restarts
- [ ] Logs show detected stage `indexing`, then `nominatim import --continue indexing` (no `invalid user`)
- [ ] Indexing progresses


Made with [Cursor](https://cursor.com)