### PR TITLE
fix(nominatim): skip dangling staging symlinks during resume chown

### DIFF
--- a/kubernetes/apps/self-hosted/nominatim/app/scripts/resume-import.sh
+++ b/kubernetes/apps/self-hosted/nominatim/app/scripts/resume-import.sh
@@ -273,10 +273,12 @@ ensure_project_ownership() {
   flatnode_dir="$(dirname "${FLATNODE_FILE}")"
   log "Fixing ownership under ${PROJECT_DIR} (excluding ${flatnode_dir})"
   chown nominatim:nominatim "${PROJECT_DIR}"
+  # -h: start.sh creates staging symlinks into emptyDir; targets are often missing
+  # on resume and plain chown would fail with "cannot dereference".
   find "${PROJECT_DIR}" -mindepth 1 \
     \( -path "${flatnode_dir}" -o -path "${flatnode_dir}/*" \) -prune -o \
     -print0 \
-    | xargs -0 -r chown nominatim:nominatim
+    | xargs -0 -r chown -h nominatim:nominatim
 }
 
 run_continue() {

--- a/kubernetes/apps/self-hosted/nominatim/app/scripts/resume-import.sh
+++ b/kubernetes/apps/self-hosted/nominatim/app/scripts/resume-import.sh
@@ -273,12 +273,13 @@ ensure_project_ownership() {
   flatnode_dir="$(dirname "${FLATNODE_FILE}")"
   log "Fixing ownership under ${PROJECT_DIR} (excluding ${flatnode_dir})"
   chown nominatim:nominatim "${PROJECT_DIR}"
-  # -h: start.sh creates staging symlinks into emptyDir; targets are often missing
-  # on resume and plain chown would fail with "cannot dereference".
+  # Skip dangling symlinks (start.sh points staging names at emptyDir; targets are
+  # often missing on resume and are unused for --continue indexing/load-data).
   find "${PROJECT_DIR}" -mindepth 1 \
     \( -path "${flatnode_dir}" -o -path "${flatnode_dir}/*" \) -prune -o \
+    \( -type l ! -exec test -e {} \; \) -prune -o \
     -print0 \
-    | xargs -0 -r chown -h nominatim:nominatim
+    | xargs -0 -r chown nominatim:nominatim
 }
 
 run_continue() {


### PR DESCRIPTION
## Summary
- Skip dangling staging symlinks when fixing project ownership on resume
- Those links point at emptyDir and are unused for `--continue indexing` / `load-data` — better to skip than `chown -h` on stubs

## Context
Follow-up to #1300. Resume died with `chown: cannot dereference` on `/nominatim/data.osm.pbf` etc.

## Test plan
- [ ] Pod restarts with new ConfigMap
- [ ] Resume reaches `nominatim import --continue indexing` without chown errors