### PR TITLE
fix(renovate): group only nominatim packages by name

### DIFF
--- a/.github/renovate/groups.json5
+++ b/.github/renovate/groups.json5
@@ -98,7 +98,10 @@
     {
       description: "Nominatim",
       groupName: "nominatim",
-      matchFileNames: ["kubernetes/apps/self-hosted/nominatim/**"],
+      matchPackageNames: [
+        "/mediagis/nominatim/",
+        "/osm-search/nominatim-ui/",
+      ],
       group: {
         commitMessageTopic: "{{{groupName}}} group",
       },


### PR DESCRIPTION
The nominatim Renovate group was matching by directory, so alpine, nginx, and kubectl updates from the same helmrelease got bundled into #1278. It now matches only `mediagis/nominatim` and `osm-search/nominatim-ui` by package name.

Validated with `renovate-config-validator --strict`. After merge, close or rebase #1278 so Renovate recreates separate PRs for the unrelated deps.

Related: #1278
