### PR TITLE
fix(dragonfly): restore cross-namespace Redis ingress

### DIFF
--- a/kubernetes/apps/database/dragonfly/cluster/kustomization.yaml
+++ b/kubernetes/apps/database/dragonfly/cluster/kustomization.yaml
@@ -4,4 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - cluster.yaml
+  - networkpolicy.yaml
   - vmpodscrape.yaml

--- a/kubernetes/apps/database/dragonfly/cluster/networkpolicy.yaml
+++ b/kubernetes/apps/database/dragonfly/cluster/networkpolicy.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/networking.k8s.io/networkpolicy_v1.json
+---
+# The operator-managed "hindwing" NetworkPolicy (networkPolicyEnabled: true) only
+# allows :6379 from pods in the database namespace, cutting off cross-namespace
+# clients (nocodb, paperless) and the redis.internal LoadBalancer. NetworkPolicies
+# are additive, so this restores open ingress on :6379 while the operator policy
+# keeps admin :9999 restricted to the operator and peer pods.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: hindwing-redis-ingress
+spec:
+  podSelector:
+    matchLabels:
+      app: hindwing
+      app.kubernetes.io/name: dragonfly
+      app.kubernetes.io/part-of: dragonfly
+  policyTypes:
+    - Ingress
+  ingress:
+    - ports:
+        - port: 6379
+          protocol: TCP


### PR DESCRIPTION
## Summary
NocoDB and Paperless can reach Hindwing Redis again after the Dragonfly operator began restricting ingress to the `database` namespace.

The supplementary policy permits Redis traffic on TCP 6379 while leaving the operator-managed admin-port restrictions intact. Connectivity from `self-hosted` currently times out, confirming the failure mode; the policy has not been applied manually so Flux can reconcile it after merge.
