### PR TITLE
fix(nominatim): CNPG migration ops Taskfile + runbook

### DIFF
--- a/.taskfiles/nominatim-cnpg/Taskfile.yaml
+++ b/.taskfiles/nominatim-cnpg/Taskfile.yaml
@@ -14,6 +14,10 @@ vars:
   REPL_SECRET: nominatim-replication
   # Cluster pod CIDR (talos/machineconfig.yaml.j2 podSubnets)
   REPL_CIDR: 10.244.0.0/16
+  SOURCE_PVC: nominatim-pgdata
+  SOURCE_PGDATA: /var/lib/postgresql/16/main
+  CNPG_PVC: nominatim-db-1
+  CNPG_PGDATA: /var/lib/postgresql/data/pgdata
 
 tasks:
   default:
@@ -46,8 +50,8 @@ tasks:
           -c "SELECT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '{{.REPL_ROLE}}');" 2>/dev/null || echo unknown
       HBA_ENTRY:
         sh: >-
-          {{.KEXEC}} sh -c 'grep -F "{{.REPL_ROLE}}" "${PGDATA:-/var/lib/postgresql/16/main}/pg_hba.conf"' 2>/dev/null
-          || echo "(none)"
+          {{.KEXEC}} sh -c 'HBA="$(sudo -u postgres psql -At -c "SHOW hba_file;" | tr -d "[:space:]")";
+          grep -F "{{.REPL_ROLE}}" "${HBA}" 2>/dev/null' || echo "(none)"
       CRON_SUSPENDED:
         sh: >-
           kubectl -n {{.NS}} get cronjob {{.CRONJOB}}
@@ -60,14 +64,14 @@ tasks:
     interactive: true
     prompt: This mutates the embedded Postgres in deploy/nominatim (role, pg_hba, reload). Continue?
     cmds:
-      - >-
-        kubectl -n {{.NS}} exec -i deploy/{{.DEPLOYMENT}} -c {{.CONTAINER}} --
-        env REPL_USER={{.REPL_ROLE}} REPL_CIDR={{.REPL_CIDR}} REPL_PASSWORD="{{.REPL_PASSWORD}}"
-        bash -s < {{.RESOURCES_DIR}}/setup-replication.sh
+      - |
+        set -euo pipefail
+        pass="$(kubectl -n {{.NS}} get secret {{.REPL_SECRET}} -o jsonpath='{.data.password}' | base64 -d)"
+        # Pass secret via env on this shell only; do not interpolate into the argv string.
+        kubectl -n {{.NS}} exec -i deploy/{{.DEPLOYMENT}} -c {{.CONTAINER}} -- \
+          env REPL_USER={{.REPL_ROLE}} REPL_CIDR={{.REPL_CIDR}} REPL_PASSWORD="${pass}" \
+          bash -s < {{.RESOURCES_DIR}}/setup-replication.sh
       - task: pg-source-status
-    vars:
-      REPL_PASSWORD:
-        sh: kubectl -n {{.NS}} get secret {{.REPL_SECRET}} -o jsonpath='{.data.password}' | base64 -d
     preconditions:
       - which kubectl
       - kubectl -n {{.NS}} get secret {{.REPL_SECRET}}
@@ -78,30 +82,80 @@ tasks:
     desc: "One-off: verify source replication from a throwaway pod"
     interactive: true
     cmds:
-      - >-
-        kubectl -n {{.NS}} run nominatim-repl-preflight --rm -i --restart=Never
-        --image=ghcr.io/cloudnative-pg/postgresql:16
-        --env=PGPASSWORD="{{.REPL_PASSWORD}}" --command --
-        bash -c 'pg_isready -h {{.PG_SOURCE_SVC}}.{{.NS}}.svc -p 5432 -U {{.REPL_ROLE}}
-        && psql "host={{.PG_SOURCE_SVC}}.{{.NS}}.svc user={{.REPL_ROLE}} dbname=postgres replication=database"
-        -c "IDENTIFY_SYSTEM;"'
-    vars:
-      REPL_PASSWORD:
-        sh: kubectl -n {{.NS}} get secret {{.REPL_SECRET}} -o jsonpath='{.data.password}' | base64 -d
+      - |
+        set -euo pipefail
+        pass="$(kubectl -n {{.NS}} get secret {{.REPL_SECRET}} -o jsonpath='{.data.password}' | base64 -d)"
+        kubectl -n {{.NS}} run nominatim-repl-preflight --rm -i --restart=Never \
+          --image=ghcr.io/cloudnative-pg/postgresql:16 \
+          --env="PGPASSWORD=${pass}" --command -- bash -ec \
+          'pg_isready -h {{.PG_SOURCE_SVC}}.{{.NS}}.svc -p 5432 -U {{.REPL_ROLE}}
+           psql "host={{.PG_SOURCE_SVC}}.{{.NS}}.svc user={{.REPL_ROLE}} dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"'
     preconditions:
       - which kubectl
       - kubectl -n {{.NS}} get secret {{.REPL_SECRET}}
       - kubectl -n {{.NS}} get svc {{.PG_SOURCE_SVC}}
 
-  repl-lag:
-    desc: Show streaming replication lag from embedded Postgres (read-only)
+  pgdata-sizes:
+    desc: Compare source vs CNPG pgdata used/capacity (basebackup progress)
     silent: true
     cmds:
+      - |
+        set -euo pipefail
+        ns="{{.NS}}"
+        src_pvc="{{.SOURCE_PVC}}"
+        cnpg_pvc="{{.CNPG_PVC}}"
+        src_path="{{.SOURCE_PGDATA}}"
+        cnpg_path="{{.CNPG_PGDATA}}"
+
+        src_cap="$(kubectl -n "${ns}" get pvc "${src_pvc}" -o jsonpath='{.status.capacity.storage}' 2>/dev/null || echo '?')"
+        cnpg_cap="$(kubectl -n "${ns}" get pvc "${cnpg_pvc}" -o jsonpath='{.status.capacity.storage}' 2>/dev/null || echo '?')"
+
+        src_used_b="$(kubectl -n "${ns}" exec deploy/{{.DEPLOYMENT}} -c {{.CONTAINER}} -- \
+          du -sb "${src_path}" 2>/dev/null | awk '{print $1}')" || src_used_b=""
+        src_used_h="$(kubectl -n "${ns}" exec deploy/{{.DEPLOYMENT}} -c {{.CONTAINER}} -- \
+          du -sh "${src_path}" 2>/dev/null | awk '{print $1}')" || src_used_h="?"
+
+        cnpg_pod="$(kubectl -n "${ns}" get pods -l cnpg.io/cluster=nominatim-db \
+          --field-selector=status.phase=Running \
+          -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)"
+        cnpg_used_b=""
+        cnpg_used_h="?"
+        if [ -n "${cnpg_pod}" ]; then
+          # pgbasebackup job and instance pods both use the postgres data mount.
+          cnpg_ctr="$(kubectl -n "${ns}" get pod "${cnpg_pod}" -o jsonpath='{.spec.containers[0].name}')"
+          cnpg_used_b="$(kubectl -n "${ns}" exec "${cnpg_pod}" -c "${cnpg_ctr}" -- \
+            du -sb "${cnpg_path}" 2>/dev/null | awk '{print $1}')" || cnpg_used_b=""
+          cnpg_used_h="$(kubectl -n "${ns}" exec "${cnpg_pod}" -c "${cnpg_ctr}" -- \
+            du -sh "${cnpg_path}" 2>/dev/null | awk '{print $1}')" || cnpg_used_h="?"
+        fi
+
+        pct="?"
+        if [ -n "${src_used_b}" ] && [ -n "${cnpg_used_b}" ] && [ "${src_used_b}" -gt 0 ] 2>/dev/null; then
+          pct="$(awk -v a="${cnpg_used_b}" -v b="${src_used_b}" 'BEGIN { printf "%.1f", (a*100)/b }')"
+        fi
+
+        echo "pgdata_source: ${src_used_h} used / ${src_cap} cap  (pvc/${src_pvc})"
+        echo "pgdata_cnpg:   ${cnpg_used_h} used / ${cnpg_cap} cap  (pvc/${cnpg_pvc}${cnpg_pod:+ @ ${cnpg_pod}})"
+        echo "basebackup:    ${pct}% of source size"
+    preconditions:
+      - which kubectl
+
+  repl-lag:
+    desc: Show streaming / basebackup progress from embedded Postgres (read-only)
+    silent: true
+    cmds:
+      - task: pgdata-sizes
+      - echo
       - >-
-        {{.KEXEC}} sudo -u postgres psql -At -F': '
-        -c "SELECT application_name, state, sync_state,
-        pg_size_pretty(pg_wal_lsn_diff(pg_current_wal_lsn(), replay_lsn)) AS replay_lag
-        FROM pg_stat_replication;"
+        {{.KEXEC}} sudo -u postgres psql -P pager=off -c
+        "SELECT coalesce(nullif(application_name, ''), '(none)') AS app,
+         state, sync_state, client_addr,
+         pg_size_pretty(pg_wal_lsn_diff(pg_current_wal_lsn(), sent_lsn)) AS sent_lag,
+         CASE WHEN replay_lsn IS NULL THEN 'n/a (basebackup)'
+              ELSE pg_size_pretty(pg_wal_lsn_diff(pg_current_wal_lsn(), replay_lsn))
+         END AS replay_lag,
+         backend_start
+         FROM pg_stat_replication ORDER BY backend_start;"
     preconditions:
       - which kubectl
 
@@ -113,7 +167,8 @@ tasks:
       - "echo 'replica_enabled: {{.REPLICA_ENABLED}}'"
       - "echo 'instances: {{.INSTANCES}}'"
       - "echo 'scheduled_backup: {{.SBACKUP}}'"
-      - "echo 'cutover_runbook: docs/runbooks/nominatim-cnpg-cutover.md'"
+      - task: pgdata-sizes
+      - "echo 'cutover_runbook: docs/runbooks/2026-07-24-nominatim-cnpg-cutover.md'"
     vars:
       CLUSTER_STATUS:
         sh: >-
@@ -161,15 +216,14 @@ tasks:
     cmds:
       - |
         cat <<'EOF'
-        Follow docs/runbooks/nominatim-cnpg-cutover.md.
+        Runbook: docs/runbooks/2026-07-24-nominatim-cnpg-cutover.md
 
-        One-off setup/cutover steps:
           task nominatim-cnpg:setup-replication
           task nominatim-cnpg:repl-preflight
           task nominatim-cnpg:repl-lag
+          task nominatim-cnpg:cnpg-status
           task nominatim-cnpg:cutover-scale-down
           task nominatim-cnpg:cutover-scale-up
 
-        Durable state remains managed by Flux.
-        Delete .taskfiles/nominatim-cnpg and its root include after migration cleanup.
+        After soak/cleanup, delete .taskfiles/nominatim-cnpg and its root include.
         EOF

--- a/.taskfiles/nominatim-cnpg/resources/setup-replication.sh
+++ b/.taskfiles/nominatim-cnpg/resources/setup-replication.sh
@@ -5,14 +5,20 @@
 # Idempotent: safe to re-run after rotating nominatim-replication password.
 set -euo pipefail
 
-PGDATA="${PGDATA:-/var/lib/postgresql/16/main}"
-HBA_FILE="${PGDATA}/pg_hba.conf"
 REPL_USER="${REPL_USER:-cnpg_replica}"
 REPL_PASSWORD="${REPL_PASSWORD:?REPL_PASSWORD is required}"
 # Cluster pod CIDR (talos/machineconfig.yaml.j2 podSubnets); scoped to the
 # replication pseudo-database and this role only.
 REPL_CIDR="${REPL_CIDR:-10.244.0.0/16}"
 HBA_LINE="host replication ${REPL_USER} ${REPL_CIDR} scram-sha-256"
+
+# mediagis/nominatim uses Debian-style config under /etc/postgresql — not $PGDATA.
+HBA_FILE="${HBA_FILE:-$(sudo -u postgres psql -At -c 'SHOW hba_file;' | tr -d '[:space:]')}"
+if [ -z "${HBA_FILE}" ] || [ ! -f "${HBA_FILE}" ]; then
+  echo "[setup-replication] ERROR: could not resolve hba_file (got '${HBA_FILE:-}')" >&2
+  exit 1
+fi
+echo "[setup-replication] Using hba_file=${HBA_FILE}"
 
 echo "[setup-replication] Ensuring role ${REPL_USER} exists with REPLICATION LOGIN"
 # Use psql variables + \gexec so substitution works (variables do not expand
@@ -41,6 +47,13 @@ fi
 
 echo "[setup-replication] Reloading PostgreSQL configuration"
 sudo -u postgres psql -v ON_ERROR_STOP=1 -c 'SELECT pg_reload_conf();'
+
+echo "[setup-replication] Active replication HBA rules:"
+sudo -u postgres psql -c \
+  "SELECT type, database, user_name, address, auth_method
+   FROM pg_hba_file_rules
+   WHERE database @> ARRAY['replication']
+   ORDER BY line_number;"
 
 echo "[setup-replication] Current wal_level / max_wal_senders:"
 sudo -u postgres psql -At -c "SHOW wal_level; SHOW max_wal_senders;"

--- a/docs/runbooks/2026-07-24-nominatim-cnpg-cutover.md
+++ b/docs/runbooks/2026-07-24-nominatim-cnpg-cutover.md
@@ -1,116 +1,184 @@
-# Nominatim → CloudNativePG cutover runbook
+# Nominatim → CloudNativePG cutover
 
-Durable state is IaC (git → Flux): the `nominatim-db` Cluster/ObjectStore/secrets,
-the source Service, and the Phase D app cutover commit. One-off migration steps
-(role setup, preflight, scaling for the cutover window) are local Taskfile
-executions from the operator's machine — they are short-lived and not worth
-encoding as committed Jobs.
+## Goal
 
-## Split
+Move Nominatim’s PostgreSQL database (~176 GB) out of the `mediagis/nominatim`
+container into a dedicated CloudNativePG cluster (`nominatim-db`), then point
+the Nominatim API at that cluster.
 
-| Phase | Mechanism | When |
-|-------|-----------|------|
-| Prep manifests | Git → Flux: Barman plugin, `nominatim-db` Cluster (replica), source Service, `start-external.sh` in ConfigMap (unused) | Merge anytime |
-| One-off setup | Taskfile: `setup-replication`, `repl-preflight` | After prep merge |
-| Cutover | Taskfile scale-down + git: promote `replica.enabled: false`, flip HelmRelease + ExternalSecret DSN (Phase D) | Ops window after lag ≈ 0 |
-| Cleanup | Git: remove source Service + replication script; delete unmounted `nominatim-pgdata` | After soak + recovery test |
+Until cutover finishes, Nominatim keeps serving from its **embedded** Postgres
+on the `nominatim-pgdata` PVC. After cutover, Postgres runs only in CNPG;
+Nominatim is an API (and OSM update) client.
 
-## Preconditions
+## How the migration works
 
-- [ ] 1Password item `nominatim-db` has `POSTGRES_SUPER_USER`, `POSTGRES_SUPER_PASS`, `REPLICATION_PASS`
-- [ ] 1Password `nominatim` / `NOMINATIM_PASSWORD` matches the cloned `nominatim` DB role
-- [ ] OSM update CronJob remains `suspend: true` (`task nominatim-cnpg:pg-source-status`)
+1. **Replicate.** CNPG takes a physical copy of the live DB (`pg_basebackup`)
+  and streams WAL from the embedded Postgres until it is caught up.
+2. **Promote.** Stop the API briefly, promote the CNPG copy to primary.
+3. **Point the app.** Redeploy Nominatim with an external DB connection
+  (`start-external.sh`) instead of starting local Postgres.
+4. **Soak, then delete the old PVC.** Keep `nominatim-pgdata` until backups and
+  a recovery check look good.
 
-## Phase A — Source replication prep (Taskfile, one-off)
+OSM update CronJobs stay **suspended** for the whole migration so incremental
+updates do not race the replica.
 
-1. `task nominatim-cnpg:pg-source-status` — CronJob suspended; Service present after Flux.
-2. `task nominatim-cnpg:setup-replication` — creates/updates the `cnpg_replica` role,
-   appends the pg_hba entry, reloads config (idempotent; script lives under
-   `.taskfiles/nominatim-cnpg/resources/` and is piped into the pod via stdin).
-3. `task nominatim-cnpg:repl-preflight` — throwaway pod runs `pg_isready` +
-   `IDENTIFY_SYSTEM` against `nominatim-pg-source.self-hosted.svc`.
+## What to use when
 
-## Phase B — Replica bootstrap
 
-1. Confirm Cluster `nominatim-db` completed `pg_basebackup` and is streaming
-   (`task nominatim-cnpg:cnpg-status`).
-2. Wait until replication lag ≈ 0 (`task nominatim-cnpg:repl-lag`).
-3. Soft affinity should prefer the nominatim API/flatnode node.
+| Kind                   | Where                   | Examples                                                                                           |
+| ---------------------- | ----------------------- | -------------------------------------------------------------------------------------------------- |
+| Durable cluster state  | Git → Flux              | `nominatim-db` Cluster, ObjectStore, secrets, `nominatim-pg-source` Service, app cutover manifests |
+| One-off operator steps | `task nominatim-cnpg:*` | Create replication role, preflight, lag check, scale API for the cutover window                    |
 
-## Phase C — Promote
 
-1. `task nominatim-cnpg:cutover-scale-down` — suspends the Flux HelmRelease and scales
-   the nominatim API to 0 for the window.
-2. Wait for lag 0 again (`task nominatim-cnpg:repl-lag`).
-3. In `kubernetes/apps/self-hosted/nominatim-db/app/cluster.yaml` set:
-   ```yaml
-   replica:
-     enabled: false
-   ```
-   (remove or leave `source` per CNPG docs after promote.) Commit, push.
-4. Verify PostGIS on primary:
-   ```bash
-   kubectl -n self-hosted exec nominatim-db-1 -c postgres -- \
-     psql -U postgres -d nominatim -c 'SELECT postgis_full_version();'
-   ```
+After cleanup, delete `.taskfiles/nominatim-cnpg/` and its include in the root
+`Taskfile.yaml`.
 
-## Phase D — App cutover (follow-up commit during ops window)
+## Prerequisites
 
-Apply all of the following in **one** commit so Flux does not briefly inject DSN into
-`start.sh`:
-
-### 1. ExternalSecret (`app/externalsecret.yaml`)
-
-Add to `target.template.data` (keep `NOMINATIM_PASSWORD`):
-
-```yaml
-NOMINATIM_DATABASE_DSN: "pgsql:dbname=nominatim;host=nominatim-db-rw.self-hosted.svc;user=nominatim;password={{ .NOMINATIM_PASSWORD }}"
-PGHOST: nominatim-db-rw.self-hosted.svc
-PGDATABASE: nominatim
-PGUSER: nominatim
-PGPASSWORD: "{{ .NOMINATIM_PASSWORD }}"
-```
-
-### 2. HelmRelease (`app/helmrelease.yaml`)
-
-- `command: ["/bin/bash", "/scripts/start-external.sh"]`
-- Remove `POSTGRES_SHARED_BUFFERS` / `POSTGRES_MAINTENANCE_WORK_MEM` /
-  `POSTGRES_AUTOVACUUM_WORK_MEM` / `POSTGRES_EFFECTIVE_CACHE_SIZE`
-- Resources: e.g. requests `memory: 4Gi`, limits `memory: 8Gi` (API-only)
-- Startup `failureThreshold: 40` (no multi-day import on boot)
-- Keep CronJob `suspend: true`
-- **Retain** `persistence.pgdata` PVC but set `advancedMounts: {}` so Helm does not
-  delete the claim through soak
-
-### 3. Restore replicas
-
-Push the commit, then `task nominatim-cnpg:cutover-scale-up` (scales the API back to 1
-and resumes the Flux HelmRelease so the cutover values roll out).
-
-### 4. Verify
+- Prep PR merged (Barman plugin, `nominatim-db` app, source Service,
+`start-external.sh` in the Nominatim ConfigMap but **not** yet the Deployment
+command).
+- 1Password item `nominatim-db`: `POSTGRES_SUPER_USER`, `POSTGRES_SUPER_PASS`,
+`REPLICATION_PASS`.
+- 1Password item `nominatim`: `NOMINATIM_PASSWORD` matches the `nominatim` DB
+role (unchanged by the physical clone).
+- OSM update CronJob still suspended.
 
 ```bash
-kubectl -n self-hosted exec deploy/nominatim -c nominatim -- curl -fsS http://127.0.0.1:8080/status
-kubectl -n self-hosted exec deploy/nominatim -c nominatim -- \
-  sudo -E -u nominatim nominatim admin --check-database --project-dir /nominatim
-# search, reverse, UI
+task nominatim-cnpg:pg-source-status
+task nominatim-cnpg:help
 ```
 
-### 5. Backup
+---
 
-Set `ScheduledBackup` `immediate: true` once (or add a one-shot Backup) via git;
-confirm plugin backup Completes. Then set `immediate: false` again if desired.
 
-## Phase E — Soak and cleanup
 
-1. Soak until ≥ one successful daily/plugin backup; CronJob still suspended.
-2. Cleanup PR: remove `nominatim-pg-source` Service; remove `persistence.pgdata`
-   from the HelmRelease; delete PVC `nominatim-pgdata` only after explicit confirmation.
-   Delete `.taskfiles/nominatim-cnpg/` and remove its include from the root
-   `Taskfile.yaml`.
+## 1. Allow CNPG to stream from embedded Postgres
+
+Creates the `cnpg_replica` role and a `pg_hba` rule on the Nominatim pod’s
+Postgres, then checks connectivity through Service `nominatim-pg-source`.
+
+```bash
+task nominatim-cnpg:setup-replication
+task nominatim-cnpg:repl-preflight
+```
+
+Both are safe to re-run.
+
+## 2. Wait for the replica to catch up
+
+Flux should already be creating Cluster `nominatim-db` as a standalone replica
+of the embedded DB.
+
+```bash
+task nominatim-cnpg:cnpg-status   # expect a healthy streaming replica
+task nominatim-cnpg:repl-lag      # wait until lag is ~0
+```
+
+The base backup of ~176 GB can take a long time. Do not promote until lag is
+essentially zero.
+
+## 3. Promote CNPG (maintenance window)
+
+Stop writes from the API, promote the replica, confirm PostGIS.
+
+```bash
+task nominatim-cnpg:cutover-scale-down   # suspend HelmRelease + scale API to 0
+task nominatim-cnpg:repl-lag             # confirm still ~0
+```
+
+In git, set the cluster to primary and push:
+
+```yaml
+# kubernetes/apps/self-hosted/nominatim-db/app/cluster.yaml
+replica:
+  enabled: false
+```
+
+After Flux applies that:
+
+```bash
+kubectl -n self-hosted exec nominatim-db-1 -c postgres -- \
+  psql -U postgres -d nominatim -c 'SELECT postgis_full_version();'
+```
+
+Leave the API at 0 replicas until the next step lands.
+
+## 4. Point Nominatim at CNPG
+
+Ship **one** git commit that does all of the following together (so Flux never
+briefly feeds a CNPG DSN into the old local-Postgres startup path):
+
+1. **ExternalSecret** (`kubernetes/apps/self-hosted/nominatim/app/externalsecret.yaml`)
+  Keep `NOMINATIM_PASSWORD`. Add:
+2. **HelmRelease** (`kubernetes/apps/self-hosted/nominatim/app/helmrelease.yaml`)
+  - Command: `/scripts/start-external.sh` (not `/scripts/start.sh`)
+  - Remove embedded `POSTGRES_*` tuning env vars
+  - Lower API memory (Postgres is no longer in this pod; e.g. ~4–8Gi)
+  - Keep the OSM CronJob suspended
+  - Keep the `pgdata` PVC defined but **unmounted** (`advancedMounts: {}`) so
+  Helm does not delete the old data during soak
+
+Push, then bring the API back:
+
+```bash
+task nominatim-cnpg:cutover-scale-up
+```
+
+Smoke-test:
+
+```bash
+kubectl -n self-hosted exec deploy/nominatim -c nominatim -- \
+  curl -fsS http://127.0.0.1:8080/status
+
+kubectl -n self-hosted exec deploy/nominatim -c nominatim -- \
+  sudo -E -u nominatim nominatim admin --check-database --project-dir /nominatim
+```
+
+Also hit search, reverse, and the UI.
+
+## 5. First backup and soak
+
+Trigger a successful Barman/plugin backup (e.g. set ScheduledBackup
+`immediate: true` once via git, confirm Completed, then turn it back off if you
+want). Keep the OSM CronJob suspended until you are happy.
+
+Soak through at least one successful scheduled backup.
+
+## 6. Cleanup (separate PR, after soak)
+
+Only after you trust CNPG + backups:
+
+1. Remove Service `nominatim-pg-source` (and any leftover replication-only
+  wiring you no longer need).
+2. Remove `persistence.pgdata` from the HelmRelease.
+3. Delete PVC `nominatim-pgdata` **only with an explicit go-ahead**.
+4. Delete `.taskfiles/nominatim-cnpg/` and its include in the root `Taskfile.yaml`.
+5. Re-enable the OSM update CronJob when ready for incremental updates again.
+
+---
+
+
 
 ## Rollback
 
-- **Before promote:** keep `replica.enabled: true`; app stays on `start.sh` + pgdata.
-- **After promote / before soak ends:** prefer Barman restore to a new Cluster; remounting
-  stale `nominatim-pgdata` is last resort.
+**Before promote** (`replica.enabled: true`): leave the app on `start.sh` and
+the embedded PVC. You can abandon or recreate the CNPG cluster.
+
+**After promote, during soak:** prefer restoring from a Barman backup onto a
+new CNPG cluster. Remounting the old `nominatim-pgdata` is a last resort — it
+will be stale relative to anything written on CNPG after promote.
+
+## Related paths
+
+
+| Path                                                                  | Role                                        |
+| --------------------------------------------------------------------- | ------------------------------------------- |
+| `kubernetes/apps/self-hosted/nominatim-db/`                           | CNPG Cluster, ObjectStore, backups, secrets |
+| `kubernetes/apps/self-hosted/nominatim/app/service-pg-source.yaml`    | Temporary Service to embedded Postgres      |
+| `kubernetes/apps/self-hosted/nominatim/app/scripts/start-external.sh` | External-DB entrypoint (used after step 4)  |
+| `.taskfiles/nominatim-cnpg/`                                          | Temporary operator tasks for this migration |
+
+


### PR DESCRIPTION
## Summary

Follow-up to #1305 after starting the live `pg_basebackup`.

- **HBA fix:** `setup-replication` now writes to Postgres’s active `hba_file` (`/etc/postgresql/16/main/pg_hba.conf` on mediagis), not `$PGDATA/pg_hba.conf`.
- **Secrets:** stop interpolating `REPL_PASSWORD` into the visible kubectl argv.
- **Progress:** `cnpg-status` / `repl-lag` show source vs CNPG pgdata used/capacity and `% of source` for monitoring the basebackup.
- **Runbook:** rewritten as a standalone guide (`docs/runbooks/2026-07-24-nominatim-cnpg-cutover.md`).

## Test plan

- [x] `task nominatim-cnpg:setup-replication` appends to active HBA; `pg_hba_file_rules` shows `cnpg_replica`
- [x] `task nominatim-cnpg:repl-preflight` → `IDENTIFY_SYSTEM` succeeds
- [x] Live basebackup progressing; `task nominatim-cnpg:repl-lag` shows source/CNPG sizes + percent
- [ ] Skim rewritten runbook for cutover clarity


Made with [Cursor](https://cursor.com)