### PR TITLE
feat(nominatim-db): promote CNPG cluster (replica.enabled: false)

### DIFF
--- a/kubernetes/apps/self-hosted/nominatim-db/app/cluster.yaml
+++ b/kubernetes/apps/self-hosted/nominatim-db/app/cluster.yaml
@@ -47,7 +47,7 @@ spec:
     pg_basebackup:
       source: nominatim-legacy
   replica:
-    enabled: true
+    enabled: false
     source: nominatim-legacy
   externalClusters:
     - name: nominatim-legacy


### PR DESCRIPTION
## Summary

Cutover promote step: set `spec.replica.enabled: false` on Cluster `nominatim-db` so CNPG stops following the embedded Nominatim Postgres and becomes a writable primary.

Prerequisite (already done ops-side): Nominatim API scaled to 0 / HelmRelease suspended so the source is quiescent.

## Test plan

- [ ] Flux reconciles `nominatim-db`; cluster leaves replica mode
- [ ] `task nominatim-cnpg:cnpg-status` shows `replica_enabled: false` and healthy
- [ ] `SELECT postgis_full_version();` works on `nominatim-db-1`
- [ ] Proceed with app cutover (DSN + `start-external.sh`) per runbook


Made with [Cursor](https://cursor.com)