### PR TITLE
fix(nominatim): create Linux user in start-external

### DIFF
--- a/kubernetes/apps/self-hosted/nominatim/app/scripts/start-external.sh
+++ b/kubernetes/apps/self-hosted/nominatim/app/scripts/start-external.sh
@@ -92,8 +92,7 @@ if [ ! -f "${IMPORT_FINISHED}" ]; then
   touch "${IMPORT_FINISHED}"
 fi
 
-# Linux user (distinct from the Postgres role). mediagis /app/start.sh creates this
-# before init; we skip that path, so create it here for sudo -u.
+# mediagis init normally creates this OS user; we skip that path.
 if ! id nominatim >/dev/null 2>&1; then
   echo "[nominatim] Creating Linux user nominatim"
   useradd -m -p "${NOMINATIM_PASSWORD:-}" nominatim

--- a/kubernetes/apps/self-hosted/nominatim/app/scripts/start-external.sh
+++ b/kubernetes/apps/self-hosted/nominatim/app/scripts/start-external.sh
@@ -92,6 +92,13 @@ if [ ! -f "${IMPORT_FINISHED}" ]; then
   touch "${IMPORT_FINISHED}"
 fi
 
+# Linux user (distinct from the Postgres role). mediagis /app/start.sh creates this
+# before init; we skip that path, so create it here for sudo -u.
+if ! id nominatim >/dev/null 2>&1; then
+  echo "[nominatim] Creating Linux user nominatim"
+  useradd -m -p "${NOMINATIM_PASSWORD:-}" nominatim
+fi
+
 echo "[nominatim] Refreshing website + SQL functions against external DB"
 sudo -E -u nominatim nominatim refresh --website --functions --project-dir "${PROJECT_DIR}"
 


### PR DESCRIPTION
## Summary
- `start-external.sh` skips mediagis `/app/start.sh`, which normally creates the Linux `nominatim` user.
- After #1308 cutover, refresh/gunicorn failed with `sudo: unknown user nominatim`.
- Create that OS user (same pattern as `resume-import.sh`) before `sudo -u nominatim`.

## Test plan
- [ ] Flux rolls ConfigMap + nominatim Deployment
- [ ] Pod logs show `Creating Linux user nominatim` (or skip if already present), then refresh proceeds
- [ ] `/status` comes up; no more `sudo: unknown user nominatim`


Made with [Cursor](https://cursor.com)