### PR TITLE
fix(nominatim): drop deprecated refresh --website

### DIFF
--- a/kubernetes/apps/self-hosted/nominatim/app/scripts/start-external.sh
+++ b/kubernetes/apps/self-hosted/nominatim/app/scripts/start-external.sh
@@ -98,8 +98,8 @@ if ! id nominatim >/dev/null 2>&1; then
   useradd -m -p "${NOMINATIM_PASSWORD:-}" nominatim
 fi
 
-echo "[nominatim] Refreshing website + SQL functions against external DB"
-sudo -E -u nominatim nominatim refresh --website --functions --project-dir "${PROJECT_DIR}"
+echo "[nominatim] Refreshing SQL functions against external DB"
+sudo -E -u nominatim nominatim refresh --functions --project-dir "${PROJECT_DIR}"
 
 if [ -z "${GUNICORN_WORKERS:-}" ]; then
   GUNICORN_WORKERS="$(nproc)"


### PR DESCRIPTION
## Summary
- `nominatim refresh --website` is deprecated in Nominatim 5.x ("Website setup is no longer required").
- Drop `--website`; keep `--functions` on the cutover entrypoint.

## Test plan
- [ ] Next pod start logs `Refreshing SQL functions` with no website deprecation warning
- [ ] `/status` still healthy


Made with [Cursor](https://cursor.com)