### PR TITLE
fix(nominatim): quiet DB SSL negotiation noise

### DIFF
--- a/kubernetes/apps/self-hosted/nominatim/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/nominatim/app/helmrelease.yaml
@@ -83,6 +83,11 @@ spec:
               PROJECT_DIR: /nominatim
               # Required for North America / multi-region imports (created during bootstrap osm2pgsql).
               NOMINATIM_FLATNODE_FILE: /nominatim/flatnode/flatnode.file
+              # In-cluster DB traffic is already plaintext; skip SSL/GSS negotiation
+              # so pg_isready and the worker pool stop logging "could not accept SSL
+              # connection: EOF" on the shared CNPG cluster.
+              PGSSLMODE: disable
+              PGGSSENCMODE: disable
               GUNICORN_WORKERS: "4"
               NOMINATIM_API_POOL_SIZE: "5"
               # Daily cron only applies incremental OSC updates; full region PBF imports are opt-in.


### PR DESCRIPTION
## Summary
- Startup `pg_isready` loop and the Gunicorn worker pool each open an SSL/GSS negotiation that CNPG logs as `could not accept SSL connection: EOF detected`.
- Established `nominatim` connections already run with `ssl = f` (plaintext in-cluster), so the negotiation is wasted.
- Set `PGSSLMODE=disable` / `PGGSSENCMODE=disable` so libpq connects directly — no behavior change, just quieter shared-DB logs.

## Test plan
- [ ] After rollout, `nominatim-db-1` postgres logs show no new `EOF detected` on pod start
- [ ] `/status` healthy; `pg_stat_activity` still shows `nominatim` connections (now without the failed SSL attempts)


Made with [Cursor](https://cursor.com)