### PR TITLE
fix(nominatim): raise app memory for region imports

### DIFF
--- a/kubernetes/apps/self-hosted/nominatim/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/nominatim/app/helmrelease.yaml
@@ -135,9 +135,9 @@ spec:
             resources:
               requests:
                 cpu: 500m
-                memory: 4Gi
+                memory: 16Gi
               limits:
-                memory: 8Gi
+                memory: 24Gi
       ui:
         annotations:
           reloader.stakater.com/auto: "true"

--- a/kubernetes/apps/self-hosted/nominatim/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/nominatim/app/helmrelease.yaml
@@ -83,6 +83,11 @@ spec:
               PROJECT_DIR: /nominatim
               # Required for North America / multi-region imports (created during bootstrap osm2pgsql).
               NOMINATIM_FLATNODE_FILE: /nominatim/flatnode/flatnode.file
+              # In-cluster DB traffic is already plaintext; skip SSL/GSS negotiation
+              # so pg_isready and the worker pool stop logging "could not accept SSL
+              # connection: EOF" on the shared CNPG cluster.
+              PGSSLMODE: disable
+              PGGSSENCMODE: disable
               GUNICORN_WORKERS: "4"
               NOMINATIM_API_POOL_SIZE: "5"
               # Daily cron only applies incremental OSC updates; full region PBF imports are opt-in.


### PR DESCRIPTION
## Summary
- Raise the Nominatim app pod to **16Gi request / 24Gi limit** (from 4Gi/8Gi) so `osm2pgsql --append` + flatnode mmap has a realistic cgroup after the CNPG split
- Leaves `nominatim-db` at 24–28Gi; net tree change vs `main` is only this memory bump (SSL quieting already landed in #1311)

## Test plan
- [ ] Flux reconciles `nominatim` HelmRelease with 16Gi/24Gi
- [ ] Pod schedules (may land off ganymede if that node stays memory-tight)
- [ ] `/status` still OK against `nominatim-db-rw`
- [ ] Re-run `task nominatim:import-region REGION=north-america/canada` and confirm no app-cgroup OOM mid-import


Made with [Cursor](https://cursor.com)