### PR TITLE
fix(nominatim): prefer scheduling controller with nominatim-db

### DIFF
--- a/kubernetes/apps/self-hosted/nominatim/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/nominatim/app/helmrelease.yaml
@@ -138,6 +138,17 @@ spec:
                 memory: 16Gi
               limits:
                 memory: 24Gi
+        pod:
+          # Prefer same node as nominatim-db (CNPG has the reverse preference).
+          affinity:
+            podAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - weight: 100
+                  podAffinityTerm:
+                    labelSelector:
+                      matchLabels:
+                        cnpg.io/cluster: nominatim-db
+                    topologyKey: kubernetes.io/hostname
       ui:
         annotations:
           reloader.stakater.com/auto: "true"


### PR DESCRIPTION
## Summary
- Add preferred `podAffinity` on the Nominatim controller toward `cnpg.io/cluster=nominatim-db` so the API prefers the same node as the CNPG database (matching the reverse preference already set on the DB side).

## Test plan
- [ ] Flux reconciles the Nominatim HelmRelease without errors
- [ ] Controller pod schedules with the new preferred affinity (check pod spec / events)
- [ ] Nominatim API remains healthy after reschedule if any


Made with [Cursor](https://cursor.com)