### PR TITLE
fix(observability): quiet false-positive Alertmanager/Pushover noise

### DIFF
--- a/kubernetes/apps/ai/holmesgpt/app/ciliumnetworkpolicy.yaml
+++ b/kubernetes/apps/ai/holmesgpt/app/ciliumnetworkpolicy.yaml
@@ -15,16 +15,6 @@ spec:
           - holmes-operator
   egress:
     # DNS
-    - toServices:
-        - k8sService:
-            serviceName: kube-dns
-            namespace: kube-system
-      toPorts:
-        - ports:
-            - port: "53"
-              protocol: UDP
-            - port: "53"
-              protocol: TCP
     - toEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: kube-system
@@ -32,9 +22,10 @@ spec:
       toPorts:
         - ports:
             - port: "53"
-              protocol: UDP
-            - port: "53"
-              protocol: TCP
+              protocol: ANY
+          rules:
+            dns:
+              - matchPattern: "*"
     # Kubernetes API server
     - toEntities:
         - kube-apiserver
@@ -84,8 +75,8 @@ spec:
             - port: "8000"
               protocol: TCP
 ---
-# GitHub MCP server: only allowed to reach api.github.com.
-# All other internet egress is denied.
+# GitHub MCP: egress locked to api.github.com; ingress only from holmes.
+# Chart NetworkPolicy is disabled — owned here.
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
@@ -94,18 +85,23 @@ spec:
   endpointSelector:
     matchLabels:
       app.kubernetes.io/name: github-mcp-server
-  egress:
-    # DNS (required to resolve api.github.com)
-    - toServices:
-        - k8sService:
-            serviceName: kube-dns
-            namespace: kube-system
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            app: holmes
       toPorts:
         - ports:
-            - port: "53"
-              protocol: UDP
-            - port: "53"
+            - port: "8000"
               protocol: TCP
+    # Required whenever this endpoint has ingress enforcement: DNS replies
+    # arrive sourced as the kube-dns ClusterIP identity (KPR, no pod socket-LB)
+    # and miss conntrack after DNS-proxy interception, so they hit ingress.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+  egress:
+    # Canonical toFQDNs companion: proxy/inspect DNS via kube-dns
     - toEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: kube-system
@@ -113,10 +109,10 @@ spec:
       toPorts:
         - ports:
             - port: "53"
-              protocol: UDP
-            - port: "53"
-              protocol: TCP
-    # GitHub API — named egress, no general internet
+              protocol: ANY
+          rules:
+            dns:
+              - matchPattern: "*"
     - toFQDNs:
         - matchName: "api.github.com"
       toPorts:

--- a/kubernetes/apps/ai/holmesgpt/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/holmesgpt/app/helmrelease.yaml
@@ -92,5 +92,7 @@ spec:
         config:
           # Restrict to the minimum tools needed for PR proposals — no issue/action access
           tools: "get_file_contents,create_branch,create_or_update_file,create_pull_request,list_commits,get_me,get_pull_request"
+        # Owned by ciliumnetworkpolicy.yaml (holmes ingress + toFQDNs egress).
+        # Chart NP is ingress-only and breaks DNS replies under KPR/toFQDNs.
         networkPolicy:
-          enabled: true
+          enabled: false

--- a/kubernetes/apps/ai/ollama/app/httproute.yaml
+++ b/kubernetes/apps/ai/ollama/app/httproute.yaml
@@ -4,6 +4,12 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: ollama-lan
+  annotations:
+    # *.internal listener serves a private-CA cert gatus can't verify
+    gatus.home-operations.com/endpoint: |
+      client:
+        dns-resolver: tcp://kube-dns.kube-system.svc:53
+        insecure: true
 spec:
   hostnames:
     - ollama.internal

--- a/kubernetes/apps/ai/open-webui/app/httproute.yaml
+++ b/kubernetes/apps/ai/open-webui/app/httproute.yaml
@@ -4,6 +4,12 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: open-webui
+  annotations:
+    # *.internal listener serves a private-CA cert gatus can't verify
+    gatus.home-operations.com/endpoint: |
+      client:
+        dns-resolver: tcp://kube-dns.kube-system.svc:53
+        insecure: true
 spec:
   hostnames:
     - open-webui.internal

--- a/kubernetes/apps/database/dragonfly/cluster/networkpolicy.yaml
+++ b/kubernetes/apps/database/dragonfly/cluster/networkpolicy.yaml
@@ -4,7 +4,8 @@
 # allows :6379 from pods in the database namespace, cutting off cross-namespace
 # clients (nocodb, paperless) and the redis.internal LoadBalancer. NetworkPolicies
 # are additive, so this restores open ingress on :6379 while the operator policy
-# keeps admin :9999 restricted to the operator and peer pods.
+# keeps admin :9999 restricted to the operator and peer pods — plus vmagent,
+# which scrapes Dragonfly metrics on the admin port (see cluster/vmpodscrape.yaml).
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -20,4 +21,14 @@ spec:
   ingress:
     - ports:
         - port: 6379
+          protocol: TCP
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: observability
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: vmagent
+      ports:
+        - port: 9999
           protocol: TCP

--- a/kubernetes/apps/fission/functions/ics-proxy/trigger.yaml
+++ b/kubernetes/apps/fission/functions/ics-proxy/trigger.yaml
@@ -15,6 +15,11 @@ spec:
     hostnames:
       - fn.zebernst.dev
     path: /ics/proxy
+    # Bare probe without ?calendar= returns 400 by design (same pattern as flux-webhook)
+    annotations:
+      gatus.home-operations.com/endpoint: |
+        conditions:
+          - "[STATUS] == 400"
     gateway:
       parentRefs:
         - name: external

--- a/kubernetes/apps/games/minecraft/atm10/app/helmrelease.yaml
+++ b/kubernetes/apps/games/minecraft/atm10/app/helmrelease.yaml
@@ -10,6 +10,17 @@ spec:
     kind: OCIRepository
     name: app-template
     namespace: flux-system
+  # Let mc-router own StatefulSet replicas (scale subresource) without Helm
+  # resetting them on every reconcile.
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: StatefulSet
+              name: atm10
+            patch: |
+              - op: remove
+                path: /spec/replicas
 
   values:
     controllers:
@@ -129,21 +140,13 @@ spec:
     service:
       atm10:
         annotations:
-          gatus.home-operations.com/enabled: "true"
-          gatus.home-operations.com/endpoint: |
-            name: all the mods 10
-            group: public
-            url: tcp://atm10.games.svc.cluster.local:25565
-            interval: 1m
-            conditions:
-              - "[CONNECTED] == true"
-            ui:
-              hide-url: true
-              hide-hostname: true
-              hide-port: true
           mc-router.itzg.me/externalServerName: "atm10.zebernst.dev"
           mc-router.itzg.me/autoScaleUp: "true"
-          mc-router.itzg.me/autoScaleDown: "false"
+          mc-router.itzg.me/autoScaleDown: "true"
+          mc-router.itzg.me/autoScaleAsleepMOTD: "§eATM10 is sleeping.§r Join once to wake it, then reconnect in a few minutes."
+          mc-router.itzg.me/autoScaleLoadingMOTD: "§eATM10 is starting…§r Modpack boot takes a few minutes — reconnect shortly."
+          # Match startup probe window: initialDelaySeconds(30) + periodSeconds(1)*failureThreshold(300)
+          mc-router.itzg.me/autoScaleWaitTimeout: "5m30s"
         ports:
           game:
             port: 25565

--- a/kubernetes/apps/games/minecraft/atmons/app/helmrelease.yaml
+++ b/kubernetes/apps/games/minecraft/atmons/app/helmrelease.yaml
@@ -10,6 +10,17 @@ spec:
     kind: OCIRepository
     name: app-template
     namespace: flux-system
+  # Let mc-router own StatefulSet replicas (scale subresource) without Helm
+  # resetting them on every reconcile.
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: StatefulSet
+              name: atmons
+            patch: |
+              - op: remove
+                path: /spec/replicas
 
   values:
     controllers:
@@ -131,21 +142,13 @@ spec:
     service:
       atmons:
         annotations:
-          gatus.home-operations.com/enabled: "true"
-          gatus.home-operations.com/endpoint: |
-            name: all the mons
-            group: public
-            url: tcp://atmons.games.svc.cluster.local:25565
-            interval: 1m
-            conditions:
-              - "[CONNECTED] == true"
-            ui:
-              hide-url: true
-              hide-hostname: true
-              hide-port: true
           mc-router.itzg.me/externalServerName: "atmons.zebernst.dev"
           mc-router.itzg.me/autoScaleUp: "true"
-          mc-router.itzg.me/autoScaleDown: "false"
+          mc-router.itzg.me/autoScaleDown: "true"
+          mc-router.itzg.me/autoScaleAsleepMOTD: "§eAll the Mons is sleeping.§r Join once to wake it, then reconnect in a few minutes."
+          mc-router.itzg.me/autoScaleLoadingMOTD: "§eAll the Mons is starting…§r Modpack boot takes a few minutes — reconnect shortly."
+          # Match startup probe window: initialDelaySeconds(30) + periodSeconds(1)*failureThreshold(300)
+          mc-router.itzg.me/autoScaleWaitTimeout: "5m30s"
         ports:
           game:
             port: 25565

--- a/kubernetes/apps/games/minecraft/router/app/helmrelease.yaml
+++ b/kubernetes/apps/games/minecraft/router/app/helmrelease.yaml
@@ -64,8 +64,10 @@ spec:
               RECORD_LOGINS: true
               AUTO_SCALE_UP: "true"
               AUTO_SCALE_DOWN: "true"
+              # Idle long enough that a brief disconnect doesn't tear the server down
               AUTO_SCALE_DOWN_AFTER: "2h"
-              AUTO_SCALE_ASLEEP_MOTD: "Server is sleeping. Connecting will wake it -- please wait a few minutes."
+              AUTO_SCALE_ASLEEP_MOTD: "§eServer is sleeping.§r Join once to wake it, then reconnect in a few minutes."
+              AUTO_SCALE_LOADING_MOTD: "§eServer is starting…§r Modpack boot takes a few minutes — reconnect shortly."
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true
@@ -115,6 +117,21 @@ spec:
     route:
       api:
         kind: HTTPRoute
+        annotations:
+          # Single Minecraft health signal — backends scale to zero and shouldn't be probed
+          gatus.home-operations.com/endpoint: |
+            name: minecraft
+            group: public
+            url: https://mc-api.zebernst.dev/routes
+            interval: 1m
+            client:
+              dns-resolver: tcp://1.1.1.1:53
+            conditions:
+              - "[STATUS] == 200"
+            ui:
+              hide-url: true
+              hide-hostname: true
+              hide-port: true
         hostnames: ["mc-api.zebernst.dev"]
         parentRefs:
           - name: internal

--- a/kubernetes/apps/games/minecraft/vanilla/app/helmrelease.yaml
+++ b/kubernetes/apps/games/minecraft/vanilla/app/helmrelease.yaml
@@ -130,18 +130,6 @@ spec:
     service:
       vanilla:
         annotations:
-          gatus.home-operations.com/enabled: "true"
-          gatus.home-operations.com/endpoint: |
-            name: vanilla
-            group: public
-            url: tcp://vanilla.games.svc.cluster.local:25565
-            interval: 1m
-            conditions:
-              - "[CONNECTED] == true"
-            ui:
-              hide-url: true
-              hide-hostname: true
-              hide-port: true
           mc-router.itzg.me/defaultServer: "true"
           mc-router.itzg.me/autoScaleUp: "true"
           mc-router.itzg.me/autoScaleDown: "false"

--- a/kubernetes/apps/media/capacitarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/capacitarr/app/helmrelease.yaml
@@ -63,6 +63,10 @@ spec:
 
     route:
       capacitarr:
+        annotations:
+          # App requires auth on / (401); probe the unauthenticated health endpoint
+          gatus.home-operations.com/endpoint: |
+            path: /api/v1/health
         hostnames:
           - "{{ .Release.Name }}.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/media/steam/ks.yaml
+++ b/kubernetes/apps/media/steam/ks.yaml
@@ -32,4 +32,4 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      VOLSYNC_CAPACITY: 50Gi
+      VOLSYNC_CAPACITY: 100Gi


### PR DESCRIPTION
## Summary
- Fix noisy Gatus probes (capacitarr health path, `*.internal` TLS, ics-proxy expected 400, collapse Minecraft checks to `mc-api` so game-port probes don't wake backends)
- Unblock Dragonfly/hindwing metrics by allowing vmagent to `:9999`; fix Holmes GitHub MCP DNS under Cilium KPR/toFQDNs
- Enable atm10/atmons scale-to-zero (MOTDs, 5m30s wait aligned with startup probes, strip STS replicas so Flux doesn't fight mc-router) and bump steam PVC 50→100Gi

## Test plan
- [ ] After merge, confirm GatusEndpointDown clears for capacitarr, ollama, open-webui, ics-proxy, and former Minecraft TCP endpoints
- [ ] Confirm `minecraft` endpoint stays green on `https://mc-api.zebernst.dev/routes` without scaling backends
- [ ] Confirm hindwing TargetDown clears once vmagent can scrape `:9999`
- [ ] Confirm Holmes GitHub MCP resolves `api.github.com` (ScheduledHealthCheck timeouts may still need a separate LLM pass)
- [ ] Confirm atm10/atmons sleep after idle and wake on join without Helm resetting replicas
- [ ] Confirm steam PVC expands and KubePersistentVolumeFillingUp clears
- [ ] Follow-up (out of band): delete orphan `ServiceMonitor`s `snmp-exporter-{nas,ups}` in `default`


Made with [Cursor](https://cursor.com)