### PR TITLE
fix(minecraft): route vanilla by hostname instead of default

### DIFF
--- a/kubernetes/apps/games/minecraft/vanilla/app/dnsendpoint.yaml
+++ b/kubernetes/apps/games/minecraft/vanilla/app/dnsendpoint.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: externaldns.k8s.io/v1alpha1
+kind: DNSEndpoint
+metadata:
+  name: ${APP}
+spec:
+  endpoints:
+    - dnsName: "${APP}.zebernst.dev"
+      recordType: CNAME
+      targets: ["minecraft.zebernst.dev"]
+      providerSpecific:
+        - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
+          value: "false"

--- a/kubernetes/apps/games/minecraft/vanilla/app/helmrelease.yaml
+++ b/kubernetes/apps/games/minecraft/vanilla/app/helmrelease.yaml
@@ -130,7 +130,7 @@ spec:
     service:
       vanilla:
         annotations:
-          mc-router.itzg.me/defaultServer: "true"
+          mc-router.itzg.me/externalServerName: "minecraft.zebernst.dev,vanilla.zebernst.dev"
           mc-router.itzg.me/autoScaleUp: "true"
           mc-router.itzg.me/autoScaleDown: "false"
         ports:

--- a/kubernetes/apps/games/minecraft/vanilla/app/kustomization.yaml
+++ b/kubernetes/apps/games/minecraft/vanilla/app/kustomization.yaml
@@ -3,6 +3,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - dnsendpoint.yaml
   - externalsecret.yaml
   - helmrelease.yaml
 generatorOptions:


### PR DESCRIPTION
## Summary
- Remove `mc-router.itzg.me/defaultServer` from vanilla so unmatched Minecraft hostnames are no longer routed there
- Route vanilla via `externalServerName` for `minecraft.zebernst.dev` and `vanilla.zebernst.dev`
- Add a `DNSEndpoint` for `vanilla.zebernst.dev` → `minecraft.zebernst.dev`, matching atm10/atmons

## Test plan
- [ ] Flux reconciles the vanilla HelmRelease / DNSEndpoint
- [ ] `vanilla.zebernst.dev` resolves to `minecraft.zebernst.dev` (unproxied)
- [ ] Connecting to `minecraft.zebernst.dev` and `vanilla.zebernst.dev` reaches vanilla
- [ ] Connecting with an unknown hostname is refused (no default backend)
- [ ] `atm10.zebernst.dev` / `atmons.zebernst.dev` still route correctly


Made with [Cursor](https://cursor.com)