### PR TITLE
feat(apps): dual-run canonical Tailscale HTTPRoutes

### DIFF
--- a/kubernetes/apps/ai/open-webui/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/open-webui/app/helmrelease.yaml
@@ -26,7 +26,7 @@ spec:
       enabled: false
     extraEnvVars:
       - name: CORS_ALLOW_ORIGIN
-        value: "https://open-webui.internal;https://open-webui.zebernst.dev;https://open-webui.kite-harmonic.ts.net;http://open-webui.ai.svc.cluster.local"
+        value: "https://open-webui.internal;https://open-webui.jptr.zebernst.dev;http://open-webui.ai.svc.cluster.local"
     ollamaUrls:
       - http://ollama.ai.svc.cluster.local:11434
     persistence:

--- a/kubernetes/apps/ai/open-webui/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/open-webui/app/helmrelease.yaml
@@ -26,7 +26,7 @@ spec:
       enabled: false
     extraEnvVars:
       - name: CORS_ALLOW_ORIGIN
-        value: "https://open-webui.internal;https://open-webui.jptr.zebernst.dev;http://open-webui.ai.svc.cluster.local"
+        value: "https://open-webui.jptr.zebernst.dev;http://open-webui.ai.svc.cluster.local"
     ollamaUrls:
       - http://ollama.ai.svc.cluster.local:11434
     persistence:

--- a/kubernetes/apps/ai/open-webui/app/httproute.yaml
+++ b/kubernetes/apps/ai/open-webui/app/httproute.yaml
@@ -23,3 +23,19 @@ spec:
     - backendRefs:
         - name: open-webui
           port: 80
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: open-webui-canon
+spec:
+  hostnames:
+    - open-webui.jptr.zebernst.dev
+  parentRefs:
+    - name: tailscale
+      namespace: kube-system
+      sectionName: https-canon
+  rules:
+    - backendRefs:
+        - name: open-webui
+          port: 80

--- a/kubernetes/apps/ai/open-webui/app/httproute.yaml
+++ b/kubernetes/apps/ai/open-webui/app/httproute.yaml
@@ -3,34 +3,10 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: open-webui
-  annotations:
-    # *.internal listener serves a private-CA cert gatus can't verify
-    gatus.home-operations.com/endpoint: |
-      name: open-webui
-      group: ai
-      client:
-        dns-resolver: tcp://kube-dns.kube-system.svc:53
-        insecure: true
-spec:
-  hostnames:
-    - open-webui.internal
-  parentRefs:
-    - name: internal
-      namespace: kube-system
-      sectionName: https-internal
-  rules:
-    - backendRefs:
-        - name: open-webui
-          port: 80
----
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
-metadata:
   name: open-webui-canonical
   annotations:
     gatus.home-operations.com/endpoint: |
-      name: open-webui-jptr
+      name: open-webui
       group: ai
 spec:
   hostnames:

--- a/kubernetes/apps/ai/open-webui/app/httproute.yaml
+++ b/kubernetes/apps/ai/open-webui/app/httproute.yaml
@@ -27,7 +27,7 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: open-webui-canon
+  name: open-webui-canonical
 spec:
   hostnames:
     - open-webui.jptr.zebernst.dev

--- a/kubernetes/apps/ai/open-webui/app/httproute.yaml
+++ b/kubernetes/apps/ai/open-webui/app/httproute.yaml
@@ -28,6 +28,10 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: open-webui-canonical
+  annotations:
+    gatus.home-operations.com/endpoint: |
+      name: open-webui-jptr
+      group: ai
 spec:
   hostnames:
     - open-webui.jptr.zebernst.dev

--- a/kubernetes/apps/ai/paperless-ai/app/httproute.yaml
+++ b/kubernetes/apps/ai/paperless-ai/app/httproute.yaml
@@ -3,14 +3,18 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: paperless-ai
+  name: paperless-ai-canonical
+  annotations:
+    gatus.home-operations.com/endpoint: |
+      name: paperless-ai
+      group: ai
 spec:
   hostnames:
-    - paperless-ai.internal
+    - paperless-ai.jptr.zebernst.dev
   parentRefs:
-    - name: internal
+    - name: tailscale
       namespace: kube-system
-      sectionName: https-internal
+      sectionName: https-canon
   rules:
     - backendRefs:
         - name: paperless-ai

--- a/kubernetes/apps/auth/pocket-id/app/helmrelease.yaml
+++ b/kubernetes/apps/auth/pocket-id/app/helmrelease.yaml
@@ -152,7 +152,7 @@ spec:
           - backendRefs:
               - name: *app
                 port: *port
-      canon:
+      canonical:
         hostnames:
           - id.jptr.zebernst.dev
         parentRefs:

--- a/kubernetes/apps/auth/pocket-id/app/helmrelease.yaml
+++ b/kubernetes/apps/auth/pocket-id/app/helmrelease.yaml
@@ -152,6 +152,17 @@ spec:
           - backendRefs:
               - name: *app
                 port: *port
+      canon:
+        hostnames:
+          - id.jptr.zebernst.dev
+        parentRefs:
+          - name: tailscale
+            namespace: kube-system
+            sectionName: https-canon
+        rules:
+          - backendRefs:
+              - name: *app
+                port: *port
 
 
     serviceMonitor:

--- a/kubernetes/apps/auth/pocket-id/app/helmrelease.yaml
+++ b/kubernetes/apps/auth/pocket-id/app/helmrelease.yaml
@@ -153,6 +153,10 @@ spec:
               - name: *app
                 port: *port
       canonical:
+        annotations:
+          gatus.home-operations.com/endpoint: |
+            name: "{{ .Release.Name }}-jptr"
+            group: "{{ .Release.Namespace }}"
         hostnames:
           - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/auth/pocket-id/app/helmrelease.yaml
+++ b/kubernetes/apps/auth/pocket-id/app/helmrelease.yaml
@@ -154,7 +154,7 @@ spec:
                 port: *port
       canonical:
         hostnames:
-          - id.jptr.zebernst.dev
+          - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:
           - name: tailscale
             namespace: kube-system

--- a/kubernetes/apps/downloads/autobrr/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/autobrr/app/helmrelease.yaml
@@ -88,7 +88,7 @@ spec:
           - hosts:
               - *tsHost
     route:
-      canon:
+      canonical:
         hostnames:
           - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/downloads/autobrr/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/autobrr/app/helmrelease.yaml
@@ -89,6 +89,10 @@ spec:
               - *tsHost
     route:
       canonical:
+        annotations:
+          gatus.home-operations.com/endpoint: |
+            name: "{{ .Release.Name }}"
+            group: "{{ .Release.Namespace }}"
         hostnames:
           - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/downloads/autobrr/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/autobrr/app/helmrelease.yaml
@@ -87,6 +87,14 @@ spec:
         tls:
           - hosts:
               - *tsHost
+    route:
+      canon:
+        hostnames:
+          - "{{ .Release.Name }}.jptr.zebernst.dev"
+        parentRefs:
+          - name: tailscale
+            namespace: kube-system
+            sectionName: https-canon
     serviceMonitor:
       app:
         serviceName: *app

--- a/kubernetes/apps/downloads/bazarr/hd/helmrelease.yaml
+++ b/kubernetes/apps/downloads/bazarr/hd/helmrelease.yaml
@@ -122,6 +122,14 @@ spec:
         tls:
           - hosts:
               - *tsHost
+    route:
+      canon:
+        hostnames:
+          - "{{ .Release.Name }}.jptr.zebernst.dev"
+        parentRefs:
+          - name: tailscale
+            namespace: kube-system
+            sectionName: https-canon
     serviceMonitor:
       app:
         serviceName: *app

--- a/kubernetes/apps/downloads/bazarr/hd/helmrelease.yaml
+++ b/kubernetes/apps/downloads/bazarr/hd/helmrelease.yaml
@@ -124,6 +124,10 @@ spec:
               - *tsHost
     route:
       canonical:
+        annotations:
+          gatus.home-operations.com/endpoint: |
+            name: "{{ .Release.Name }}"
+            group: "{{ .Release.Namespace }}"
         hostnames:
           - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/downloads/bazarr/hd/helmrelease.yaml
+++ b/kubernetes/apps/downloads/bazarr/hd/helmrelease.yaml
@@ -123,7 +123,7 @@ spec:
           - hosts:
               - *tsHost
     route:
-      canon:
+      canonical:
         hostnames:
           - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/downloads/bazarr/uhd/helmrelease.yaml
+++ b/kubernetes/apps/downloads/bazarr/uhd/helmrelease.yaml
@@ -122,6 +122,14 @@ spec:
         tls:
           - hosts:
               - *tsHost
+    route:
+      canon:
+        hostnames:
+          - "{{ .Release.Name }}.jptr.zebernst.dev"
+        parentRefs:
+          - name: tailscale
+            namespace: kube-system
+            sectionName: https-canon
     serviceMonitor:
       app:
         serviceName: *app

--- a/kubernetes/apps/downloads/bazarr/uhd/helmrelease.yaml
+++ b/kubernetes/apps/downloads/bazarr/uhd/helmrelease.yaml
@@ -124,6 +124,10 @@ spec:
               - *tsHost
     route:
       canonical:
+        annotations:
+          gatus.home-operations.com/endpoint: |
+            name: "{{ .Release.Name }}"
+            group: "{{ .Release.Namespace }}"
         hostnames:
           - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/downloads/bazarr/uhd/helmrelease.yaml
+++ b/kubernetes/apps/downloads/bazarr/uhd/helmrelease.yaml
@@ -123,7 +123,7 @@ spec:
           - hosts:
               - *tsHost
     route:
-      canon:
+      canonical:
         hostnames:
           - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/downloads/lidarr/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/lidarr/app/helmrelease.yaml
@@ -122,6 +122,14 @@ spec:
         tls:
           - hosts:
               - *tsHost
+    route:
+      canon:
+        hostnames:
+          - "{{ .Release.Name }}.jptr.zebernst.dev"
+        parentRefs:
+          - name: tailscale
+            namespace: kube-system
+            sectionName: https-canon
     serviceMonitor:
       app:
         serviceName: *app

--- a/kubernetes/apps/downloads/lidarr/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/lidarr/app/helmrelease.yaml
@@ -124,6 +124,10 @@ spec:
               - *tsHost
     route:
       canonical:
+        annotations:
+          gatus.home-operations.com/endpoint: |
+            name: "{{ .Release.Name }}"
+            group: "{{ .Release.Namespace }}"
         hostnames:
           - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/downloads/lidarr/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/lidarr/app/helmrelease.yaml
@@ -123,7 +123,7 @@ spec:
           - hosts:
               - *tsHost
     route:
-      canon:
+      canonical:
         hostnames:
           - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/downloads/openbooks/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/openbooks/app/helmrelease.yaml
@@ -63,6 +63,10 @@ spec:
               - *tsHost
     route:
       canonical:
+        annotations:
+          gatus.home-operations.com/endpoint: |
+            name: "{{ .Release.Name }}"
+            group: "{{ .Release.Namespace }}"
         hostnames:
           - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/downloads/openbooks/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/openbooks/app/helmrelease.yaml
@@ -62,7 +62,7 @@ spec:
           - hosts:
               - *tsHost
     route:
-      canon:
+      canonical:
         hostnames:
           - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/downloads/openbooks/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/openbooks/app/helmrelease.yaml
@@ -61,6 +61,14 @@ spec:
         tls:
           - hosts:
               - *tsHost
+    route:
+      canon:
+        hostnames:
+          - "{{ .Release.Name }}.jptr.zebernst.dev"
+        parentRefs:
+          - name: tailscale
+            namespace: kube-system
+            sectionName: https-canon
     persistence:
       books:
         type: nfs

--- a/kubernetes/apps/downloads/prowlarr/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/prowlarr/app/helmrelease.yaml
@@ -121,7 +121,7 @@ spec:
           - hosts:
               - *tsHost
     route:
-      canon:
+      canonical:
         hostnames:
           - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/downloads/prowlarr/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/prowlarr/app/helmrelease.yaml
@@ -120,6 +120,14 @@ spec:
         tls:
           - hosts:
               - *tsHost
+    route:
+      canon:
+        hostnames:
+          - "{{ .Release.Name }}.jptr.zebernst.dev"
+        parentRefs:
+          - name: tailscale
+            namespace: kube-system
+            sectionName: https-canon
     serviceMonitor:
       app:
         serviceName: *app

--- a/kubernetes/apps/downloads/prowlarr/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/prowlarr/app/helmrelease.yaml
@@ -122,6 +122,10 @@ spec:
               - *tsHost
     route:
       canonical:
+        annotations:
+          gatus.home-operations.com/endpoint: |
+            name: "{{ .Release.Name }}"
+            group: "{{ .Release.Namespace }}"
         hostnames:
           - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/downloads/qui/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/qui/app/helmrelease.yaml
@@ -117,6 +117,13 @@ spec:
           - name: internal
             namespace: kube-system
             sectionName: https
+      canon:
+        hostnames:
+          - "{{ .Release.Name }}.jptr.zebernst.dev"
+        parentRefs:
+          - name: tailscale
+            namespace: kube-system
+            sectionName: https-canon
     persistence:
       config:
         existingClaim: *app

--- a/kubernetes/apps/downloads/qui/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/qui/app/helmrelease.yaml
@@ -117,7 +117,7 @@ spec:
           - name: internal
             namespace: kube-system
             sectionName: https
-      canon:
+      canonical:
         hostnames:
           - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/downloads/qui/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/qui/app/helmrelease.yaml
@@ -106,6 +106,7 @@ spec:
             interval: 1m
             scrapeTimeout: 10s
     route:
+      # Staged OIDC cutover: LAN stays primary redirect; Pocket ID must allow both callbacks
       qui:
         annotations:
           gatus.home-operations.com/endpoint: |

--- a/kubernetes/apps/downloads/qui/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/qui/app/helmrelease.yaml
@@ -118,6 +118,10 @@ spec:
             namespace: kube-system
             sectionName: https
       canonical:
+        annotations:
+          gatus.home-operations.com/endpoint: |
+            name: "{{ .Release.Name }}-jptr"
+            group: "{{ .Release.Namespace }}"
         hostnames:
           - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/downloads/radarr/app/hd/helmrelease.yaml
+++ b/kubernetes/apps/downloads/radarr/app/hd/helmrelease.yaml
@@ -124,7 +124,7 @@ spec:
           - hosts:
               - *tsHost
     route:
-      canon:
+      canonical:
         hostnames:
           - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/downloads/radarr/app/hd/helmrelease.yaml
+++ b/kubernetes/apps/downloads/radarr/app/hd/helmrelease.yaml
@@ -123,6 +123,14 @@ spec:
         tls:
           - hosts:
               - *tsHost
+    route:
+      canon:
+        hostnames:
+          - "{{ .Release.Name }}.jptr.zebernst.dev"
+        parentRefs:
+          - name: tailscale
+            namespace: kube-system
+            sectionName: https-canon
     serviceMonitor:
       app:
         serviceName: *app

--- a/kubernetes/apps/downloads/radarr/app/hd/helmrelease.yaml
+++ b/kubernetes/apps/downloads/radarr/app/hd/helmrelease.yaml
@@ -125,6 +125,10 @@ spec:
               - *tsHost
     route:
       canonical:
+        annotations:
+          gatus.home-operations.com/endpoint: |
+            name: "{{ .Release.Name }}"
+            group: "{{ .Release.Namespace }}"
         hostnames:
           - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/downloads/radarr/app/uhd/helmrelease.yaml
+++ b/kubernetes/apps/downloads/radarr/app/uhd/helmrelease.yaml
@@ -124,7 +124,7 @@ spec:
           - hosts:
               - *tsHost
     route:
-      canon:
+      canonical:
         hostnames:
           - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/downloads/radarr/app/uhd/helmrelease.yaml
+++ b/kubernetes/apps/downloads/radarr/app/uhd/helmrelease.yaml
@@ -123,6 +123,14 @@ spec:
         tls:
           - hosts:
               - *tsHost
+    route:
+      canon:
+        hostnames:
+          - "{{ .Release.Name }}.jptr.zebernst.dev"
+        parentRefs:
+          - name: tailscale
+            namespace: kube-system
+            sectionName: https-canon
     serviceMonitor:
       app:
         serviceName: *app

--- a/kubernetes/apps/downloads/radarr/app/uhd/helmrelease.yaml
+++ b/kubernetes/apps/downloads/radarr/app/uhd/helmrelease.yaml
@@ -125,6 +125,10 @@ spec:
               - *tsHost
     route:
       canonical:
+        annotations:
+          gatus.home-operations.com/endpoint: |
+            name: "{{ .Release.Name }}"
+            group: "{{ .Release.Namespace }}"
         hostnames:
           - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/downloads/sonarr/app/hd/helmrelease.yaml
+++ b/kubernetes/apps/downloads/sonarr/app/hd/helmrelease.yaml
@@ -122,7 +122,7 @@ spec:
           - hosts:
               - *tsHost
     route:
-      canon:
+      canonical:
         hostnames:
           - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/downloads/sonarr/app/hd/helmrelease.yaml
+++ b/kubernetes/apps/downloads/sonarr/app/hd/helmrelease.yaml
@@ -123,6 +123,10 @@ spec:
               - *tsHost
     route:
       canonical:
+        annotations:
+          gatus.home-operations.com/endpoint: |
+            name: "{{ .Release.Name }}"
+            group: "{{ .Release.Namespace }}"
         hostnames:
           - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/downloads/sonarr/app/hd/helmrelease.yaml
+++ b/kubernetes/apps/downloads/sonarr/app/hd/helmrelease.yaml
@@ -121,6 +121,14 @@ spec:
         tls:
           - hosts:
               - *tsHost
+    route:
+      canon:
+        hostnames:
+          - "{{ .Release.Name }}.jptr.zebernst.dev"
+        parentRefs:
+          - name: tailscale
+            namespace: kube-system
+            sectionName: https-canon
     serviceMonitor:
       app:
         serviceName: *app

--- a/kubernetes/apps/downloads/sonarr/app/uhd/helmrelease.yaml
+++ b/kubernetes/apps/downloads/sonarr/app/uhd/helmrelease.yaml
@@ -122,7 +122,7 @@ spec:
           - hosts:
               - *tsHost
     route:
-      canon:
+      canonical:
         hostnames:
           - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/downloads/sonarr/app/uhd/helmrelease.yaml
+++ b/kubernetes/apps/downloads/sonarr/app/uhd/helmrelease.yaml
@@ -123,6 +123,10 @@ spec:
               - *tsHost
     route:
       canonical:
+        annotations:
+          gatus.home-operations.com/endpoint: |
+            name: "{{ .Release.Name }}"
+            group: "{{ .Release.Namespace }}"
         hostnames:
           - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/downloads/sonarr/app/uhd/helmrelease.yaml
+++ b/kubernetes/apps/downloads/sonarr/app/uhd/helmrelease.yaml
@@ -121,6 +121,14 @@ spec:
         tls:
           - hosts:
               - *tsHost
+    route:
+      canon:
+        hostnames:
+          - "{{ .Release.Name }}.jptr.zebernst.dev"
+        parentRefs:
+          - name: tailscale
+            namespace: kube-system
+            sectionName: https-canon
     serviceMonitor:
       app:
         serviceName: *app

--- a/kubernetes/apps/downloads/whisparr/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/whisparr/app/helmrelease.yaml
@@ -86,6 +86,14 @@ spec:
         tls:
           - hosts:
               - *tsHost
+    route:
+      canon:
+        hostnames:
+          - "{{ .Release.Name }}.jptr.zebernst.dev"
+        parentRefs:
+          - name: tailscale
+            namespace: kube-system
+            sectionName: https-canon
     persistence:
       config:
         existingClaim: whisparr

--- a/kubernetes/apps/downloads/whisparr/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/whisparr/app/helmrelease.yaml
@@ -88,6 +88,10 @@ spec:
               - *tsHost
     route:
       canonical:
+        annotations:
+          gatus.home-operations.com/endpoint: |
+            name: "{{ .Release.Name }}"
+            group: "{{ .Release.Namespace }}"
         hostnames:
           - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/downloads/whisparr/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/whisparr/app/helmrelease.yaml
@@ -87,7 +87,7 @@ spec:
           - hosts:
               - *tsHost
     route:
-      canon:
+      canonical:
         hostnames:
           - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/games/minecraft/router/app/dnsendpoint.yaml
+++ b/kubernetes/apps/games/minecraft/router/app/dnsendpoint.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: externaldns.k8s.io/v1alpha1
+kind: DNSEndpoint
+metadata:
+  name: mc-router
+spec:
+  endpoints:
+    - dnsName: "minecraft.zebernst.dev"
+      recordType: CNAME
+      targets: ["ipv4.zebernst.dev"]
+      providerSpecific:
+        - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
+          value: "false"

--- a/kubernetes/apps/games/minecraft/router/app/helmrelease.yaml
+++ b/kubernetes/apps/games/minecraft/router/app/helmrelease.yaml
@@ -105,19 +105,6 @@ spec:
             port: *port
           api:
             port: 8080
-    ingress:
-      mc-router:
-        className: external
-        annotations:
-          external-dns.alpha.kubernetes.io/cloudflare-proxied: "false"
-          external-dns.alpha.kubernetes.io/target: ipv4.zebernst.dev
-        hosts:
-          - host: "minecraft.zebernst.dev"
-            paths:
-              - path: /
-                service:
-                  identifier: *app
-                  port: java
     serviceMonitor:
       mc-router:
         serviceName: *app

--- a/kubernetes/apps/games/minecraft/router/app/kustomization.yaml
+++ b/kubernetes/apps/games/minecraft/router/app/kustomization.yaml
@@ -3,4 +3,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - dnsendpoint.yaml
   - helmrelease.yaml

--- a/kubernetes/apps/kube-system/cilium/gateway/hubble.yaml
+++ b/kubernetes/apps/kube-system/cilium/gateway/hubble.yaml
@@ -4,6 +4,10 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: hubble-ui-canonical
+  annotations:
+    gatus.home-operations.com/endpoint: |
+      name: hubble
+      group: kube-system
 spec:
   hostnames:
     - hubble.jptr.zebernst.dev

--- a/kubernetes/apps/kube-system/cilium/gateway/hubble.yaml
+++ b/kubernetes/apps/kube-system/cilium/gateway/hubble.yaml
@@ -3,7 +3,7 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: hubble-ui-canon
+  name: hubble-ui-canonical
 spec:
   hostnames:
     - cilium.jptr.zebernst.dev

--- a/kubernetes/apps/kube-system/cilium/gateway/hubble.yaml
+++ b/kubernetes/apps/kube-system/cilium/gateway/hubble.yaml
@@ -3,19 +3,15 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: ollama
-  annotations:
-    gatus.home-operations.com/endpoint: |
-      name: ollama
-      group: ai
+  name: hubble-ui-canon
 spec:
   hostnames:
-    - ollama.jptr.zebernst.dev
+    - cilium.jptr.zebernst.dev
   parentRefs:
     - name: tailscale
       namespace: kube-system
       sectionName: https-canon
   rules:
     - backendRefs:
-        - name: ollama
-          port: 11434
+        - name: hubble-ui
+          port: 80

--- a/kubernetes/apps/kube-system/cilium/gateway/hubble.yaml
+++ b/kubernetes/apps/kube-system/cilium/gateway/hubble.yaml
@@ -6,7 +6,7 @@ metadata:
   name: hubble-ui-canonical
 spec:
   hostnames:
-    - cilium.jptr.zebernst.dev
+    - hubble.jptr.zebernst.dev
   parentRefs:
     - name: tailscale
       namespace: kube-system

--- a/kubernetes/apps/kube-system/cilium/gateway/kustomization.yaml
+++ b/kubernetes/apps/kube-system/cilium/gateway/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - external.yaml
+  - hubble.yaml
   - internal.yaml
   - redirect.yaml
   - tailscale.yaml

--- a/kubernetes/apps/media/agregarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/agregarr/app/helmrelease.yaml
@@ -63,17 +63,17 @@ spec:
             port: *port
 
     route:
-      internal:
+      canonical:
         annotations:
           gatus.home-operations.com/endpoint: |
             name: "{{ .Release.Name }}"
             group: "{{ .Release.Namespace }}"
         hostnames:
-          - agregarr.zebernst.dev
+          - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:
-          - name: internal
+          - name: tailscale
             namespace: kube-system
-            sectionName: https
+            sectionName: https-canon
 
     persistence:
       config:

--- a/kubernetes/apps/media/capacitarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/capacitarr/app/helmrelease.yaml
@@ -62,7 +62,7 @@ spec:
             port: *port
 
     route:
-      capacitarr:
+      canonical:
         annotations:
           # App requires auth on / (401); probe the unauthenticated health endpoint
           gatus.home-operations.com/endpoint: |
@@ -70,11 +70,11 @@ spec:
             group: "{{ .Release.Namespace }}"
             path: /api/v1/health
         hostnames:
-          - "{{ .Release.Name }}.zebernst.dev"
+          - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:
-          - name: internal
+          - name: tailscale
             namespace: kube-system
-            sectionName: https
+            sectionName: https-canon
         rules:
           # SSE endpoint — no timeout so the connection stays open
           - matches:

--- a/kubernetes/apps/media/maintainerr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/maintainerr/app/helmrelease.yaml
@@ -67,7 +67,7 @@ spec:
           - hosts:
               - *tsHost
     route:
-      canon:
+      canonical:
         hostnames:
           - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/media/maintainerr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/maintainerr/app/helmrelease.yaml
@@ -66,6 +66,14 @@ spec:
         tls:
           - hosts:
               - *tsHost
+    route:
+      canon:
+        hostnames:
+          - "{{ .Release.Name }}.jptr.zebernst.dev"
+        parentRefs:
+          - name: tailscale
+            namespace: kube-system
+            sectionName: https-canon
     persistence:
       data:
         existingClaim: maintainerr

--- a/kubernetes/apps/media/maintainerr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/maintainerr/app/helmrelease.yaml
@@ -68,6 +68,10 @@ spec:
               - *tsHost
     route:
       canonical:
+        annotations:
+          gatus.home-operations.com/endpoint: |
+            name: "{{ .Release.Name }}"
+            group: "{{ .Release.Namespace }}"
         hostnames:
           - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/media/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/media/plex/app/helmrelease.yaml
@@ -26,7 +26,7 @@ spec:
               tag: 1.43.3.10828@sha256:0c0b6899339503af17cb190b25af6acf10f0030e2820985e16ee14ef428f49d7
             env:
               TZ: America/Chicago
-              PLEX_ADVERTISE_URL: https://plex.zebernst.dev:443,http://192.168.20.5:32400,http://[::ffff:c0a8:1405]:32400,http://plex.kite-harmonic.ts.net:32400
+              PLEX_ADVERTISE_URL: https://plex.zebernst.dev:443,https://plex.jptr.zebernst.dev:443,http://192.168.20.5:32400,http://[::ffff:c0a8:1405]:32400
               PLEX_NO_AUTH_NETWORKS: 10.0.0.0/8
             probes:
               liveness: &probe
@@ -98,7 +98,7 @@ spec:
           - name: external
             namespace: kube-system
             sectionName: https
-        rules:
+        rules: &plexRules
           # Remove the 'Range' header from streaming requests.
           - backendRefs:
               - identifier: *app
@@ -111,35 +111,49 @@ spec:
               - path:
                   type: PathPrefix
                   value: /library/streams
-          # Redirect root requests to the Plex landing page
-          # commented until https://github.com/bjw-s-labs/helm-charts/issues/486 is fixed.
-#          - filters:
-#              - type: RequestRedirect
-#                requestRedirect:
-#                  path:
-#                    type: ReplaceFullPath
-#                    replaceFullPath: /web
-#                  statusCode:
-#                    302
-#            matches:
-#              - headers:
-#                  - type: Exact
-#                    name: X-Plex-Device-Name
-#                    value: ""
-#                path:
-#                  type: Exact
-#                  value: /
-#              - queryParams:
-#                  - type: Exact
-#                    name: X-Plex-Device-Name
-#                    value: ""
-#                path:
-#                  type: Exact
-#                  value: /
+          # Keep Plex clients at root when they identify themselves by header or query.
+          - backendRefs:
+              - identifier: *app
+                port: *port
+            matches:
+              - headers:
+                  - name: X-Plex-Device-Name
+                    type: RegularExpression
+                    value: ".+"
+                path:
+                  type: Exact
+                  value: /
+              - path:
+                  type: Exact
+                  value: /
+                queryParams:
+                  - name: X-Plex-Device-Name
+                    type: RegularExpression
+                    value: ".+"
+          # Redirect unidentified root requests to the Plex landing page.
+          - filters:
+              - type: RequestRedirect
+                requestRedirect:
+                  path:
+                    type: ReplaceFullPath
+                    replaceFullPath: /web
+                  statusCode: 302
+            matches:
+              - path:
+                  type: Exact
+                  value: /
           # Catch-all for everything else
           - backendRefs:
               - identifier: *app
                 port: *port
+      canon:
+        hostnames:
+          - "{{ .Release.Name }}.jptr.zebernst.dev"
+        parentRefs:
+          - name: tailscale
+            namespace: kube-system
+            sectionName: https-canon
+        rules: *plexRules
     persistence:
       config:
         existingClaim: plex

--- a/kubernetes/apps/media/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/media/plex/app/helmrelease.yaml
@@ -147,6 +147,10 @@ spec:
               - identifier: *app
                 port: *port
       canonical:
+        annotations:
+          gatus.home-operations.com/endpoint: |
+            name: "{{ .Release.Name }}"
+            group: "{{ .Release.Namespace }}"
         hostnames:
           - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/media/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/media/plex/app/helmrelease.yaml
@@ -146,7 +146,7 @@ spec:
           - backendRefs:
               - identifier: *app
                 port: *port
-      canon:
+      canonical:
         hostnames:
           - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/media/shelfmark/app/helmrelease.yaml
+++ b/kubernetes/apps/media/shelfmark/app/helmrelease.yaml
@@ -54,17 +54,17 @@ spec:
             port: *port
 
     route:
-      app:
+      canonical:
         annotations:
           gatus.home-operations.com/endpoint: |
             name: "{{ .Release.Name }}"
             group: "{{ .Release.Namespace }}"
         hostnames:
-          - "{{ .Release.Name }}.zebernst.dev"
+          - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:
-          - name: internal
+          - name: tailscale
             namespace: kube-system
-            sectionName: https
+            sectionName: https-canon
 
     persistence:
       config:

--- a/kubernetes/apps/media/stash/app/helmrelease.yaml
+++ b/kubernetes/apps/media/stash/app/helmrelease.yaml
@@ -99,6 +99,10 @@ spec:
               - *tsHost
     route:
       canonical:
+        annotations:
+          gatus.home-operations.com/endpoint: |
+            name: "{{ .Release.Name }}"
+            group: "{{ .Release.Namespace }}"
         hostnames:
           - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/media/stash/app/helmrelease.yaml
+++ b/kubernetes/apps/media/stash/app/helmrelease.yaml
@@ -31,7 +31,7 @@ spec:
               STASH_METADATA: /metadata/
               STASH_CACHE: /cache/
               STASH_PORT: &port 9999
-              STASH_EXTERNAL_HOST: https://stash.kite-harmonic.ts.net
+              STASH_EXTERNAL_HOST: https://stash.jptr.zebernst.dev
 
             probes:
               liveness: &probe
@@ -97,6 +97,14 @@ spec:
         tls:
           - hosts:
               - *tsHost
+    route:
+      canon:
+        hostnames:
+          - "{{ .Release.Name }}.jptr.zebernst.dev"
+        parentRefs:
+          - name: tailscale
+            namespace: kube-system
+            sectionName: https-canon
     persistence:
       config:
         existingClaim: stash

--- a/kubernetes/apps/media/stash/app/helmrelease.yaml
+++ b/kubernetes/apps/media/stash/app/helmrelease.yaml
@@ -98,7 +98,7 @@ spec:
           - hosts:
               - *tsHost
     route:
-      canon:
+      canonical:
         hostnames:
           - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/media/steam/app/helmrelease.yaml
+++ b/kubernetes/apps/media/steam/app/helmrelease.yaml
@@ -107,6 +107,10 @@ spec:
               - *tsHost
     route:
       canonical:
+        annotations:
+          gatus.home-operations.com/endpoint: |
+            name: "{{ .Release.Name }}"
+            group: "{{ .Release.Namespace }}"
         hostnames:
           - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/media/steam/app/helmrelease.yaml
+++ b/kubernetes/apps/media/steam/app/helmrelease.yaml
@@ -106,7 +106,7 @@ spec:
           - hosts:
               - *tsHost
     route:
-      canon:
+      canonical:
         hostnames:
           - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/media/steam/app/helmrelease.yaml
+++ b/kubernetes/apps/media/steam/app/helmrelease.yaml
@@ -105,6 +105,14 @@ spec:
         tls:
           - hosts:
               - *tsHost
+    route:
+      canon:
+        hostnames:
+          - "{{ .Release.Name }}.jptr.zebernst.dev"
+        parentRefs:
+          - name: tailscale
+            namespace: kube-system
+            sectionName: https-canon
     persistence:
       home:
         existingClaim: *app

--- a/kubernetes/apps/media/tautulli/app/helmrelease.yaml
+++ b/kubernetes/apps/media/tautulli/app/helmrelease.yaml
@@ -95,6 +95,10 @@ spec:
               - name: *app
                 port: *port
       canonical:
+        annotations:
+          gatus.home-operations.com/endpoint: |
+            name: "{{ .Release.Name }}-jptr"
+            group: "{{ .Release.Namespace }}"
         hostnames:
           - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/media/tautulli/app/helmrelease.yaml
+++ b/kubernetes/apps/media/tautulli/app/helmrelease.yaml
@@ -79,25 +79,10 @@ spec:
           - hosts:
               - *tsHost
     route:
-      tautulli:
-        annotations:
-          gatus.home-operations.com/endpoint: |
-            name: "{{ .Release.Name }}"
-            group: "{{ .Release.Namespace }}"
-        hostnames:
-          - "{{ .Release.Name }}.zebernst.dev"
-        parentRefs:
-          - name: internal
-            namespace: kube-system
-            sectionName: https
-        rules:
-          - backendRefs:
-              - name: *app
-                port: *port
       canonical:
         annotations:
           gatus.home-operations.com/endpoint: |
-            name: "{{ .Release.Name }}-jptr"
+            name: "{{ .Release.Name }}"
             group: "{{ .Release.Namespace }}"
         hostnames:
           - "{{ .Release.Name }}.jptr.zebernst.dev"
@@ -105,6 +90,10 @@ spec:
           - name: tailscale
             namespace: kube-system
             sectionName: https-canon
+        rules:
+          - backendRefs:
+              - name: *app
+                port: *port
     persistence:
       config:
         existingClaim: *app

--- a/kubernetes/apps/media/tautulli/app/helmrelease.yaml
+++ b/kubernetes/apps/media/tautulli/app/helmrelease.yaml
@@ -94,6 +94,13 @@ spec:
           - backendRefs:
               - name: *app
                 port: *port
+      canon:
+        hostnames:
+          - "{{ .Release.Name }}.jptr.zebernst.dev"
+        parentRefs:
+          - name: tailscale
+            namespace: kube-system
+            sectionName: https-canon
     persistence:
       config:
         existingClaim: *app

--- a/kubernetes/apps/media/tautulli/app/helmrelease.yaml
+++ b/kubernetes/apps/media/tautulli/app/helmrelease.yaml
@@ -94,7 +94,7 @@ spec:
           - backendRefs:
               - name: *app
                 port: *port
-      canon:
+      canonical:
         hostnames:
           - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/observability/karma/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/karma/app/helmrelease.yaml
@@ -65,6 +65,10 @@ spec:
               - *tsHost
     route:
       canonical:
+        annotations:
+          gatus.home-operations.com/endpoint: |
+            name: "{{ .Release.Name }}"
+            group: "{{ .Release.Namespace }}"
         hostnames:
           - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/observability/karma/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/karma/app/helmrelease.yaml
@@ -64,7 +64,7 @@ spec:
           - hosts:
               - *tsHost
     route:
-      canon:
+      canonical:
         hostnames:
           - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/observability/karma/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/karma/app/helmrelease.yaml
@@ -63,6 +63,14 @@ spec:
         tls:
           - hosts:
               - *tsHost
+    route:
+      canon:
+        hostnames:
+          - "{{ .Release.Name }}.jptr.zebernst.dev"
+        parentRefs:
+          - name: tailscale
+            namespace: kube-system
+            sectionName: https-canon
     service:
       karma:
         controller: *app

--- a/kubernetes/apps/observability/scanopy/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/scanopy/app/helmrelease.yaml
@@ -32,6 +32,7 @@ spec:
             env:
               TZ: America/Chicago
               SCANOPY_LOG_LEVEL: info
+              # Staged OIDC cutover: LAN stays primary; Pocket ID must allow both callbacks
               SCANOPY_PUBLIC_URL: https://scanopy.zebernst.dev
               SCANOPY_WEB_EXTERNAL_PATH: /app/static
               SCANOPY_USE_SECURE_SESSION_COOKIES: "true"
@@ -70,6 +71,7 @@ spec:
           http:
             port: *port
     route:
+      # Staged OIDC cutover: LAN stays primary; Pocket ID must allow both callbacks
       scanopy:
         annotations:
           gatus.home-operations.com/endpoint: |
@@ -82,6 +84,22 @@ spec:
           - name: internal
             namespace: kube-system
             sectionName: https
+        rules:
+          - backendRefs:
+              - name: *app
+                port: *port
+      canonical:
+        annotations:
+          gatus.home-operations.com/endpoint: |
+            name: "{{ .Release.Name }}-jptr"
+            group: "{{ .Release.Namespace }}"
+            path: /api/health
+        hostnames:
+          - "{{ .Release.Name }}.jptr.zebernst.dev"
+        parentRefs:
+          - name: tailscale
+            namespace: kube-system
+            sectionName: https-canon
         rules:
           - backendRefs:
               - name: *app

--- a/kubernetes/apps/observability/victoria-logs/app/httproute.yaml
+++ b/kubernetes/apps/observability/victoria-logs/app/httproute.yaml
@@ -3,7 +3,7 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: victoria-logs-canon
+  name: victoria-logs-canonical
 spec:
   hostnames:
     - logs.jptr.zebernst.dev

--- a/kubernetes/apps/observability/victoria-logs/app/httproute.yaml
+++ b/kubernetes/apps/observability/victoria-logs/app/httproute.yaml
@@ -4,6 +4,10 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: victoria-logs-canonical
+  annotations:
+    gatus.home-operations.com/endpoint: |
+      name: victoria-logs
+      group: observability
 spec:
   hostnames:
     - victoria-logs.jptr.zebernst.dev

--- a/kubernetes/apps/observability/victoria-logs/app/httproute.yaml
+++ b/kubernetes/apps/observability/victoria-logs/app/httproute.yaml
@@ -6,7 +6,7 @@ metadata:
   name: victoria-logs-canonical
 spec:
   hostnames:
-    - logs.jptr.zebernst.dev
+    - victoria-logs.jptr.zebernst.dev
   parentRefs:
     - name: tailscale
       namespace: kube-system

--- a/kubernetes/apps/observability/victoria-logs/app/httproute.yaml
+++ b/kubernetes/apps/observability/victoria-logs/app/httproute.yaml
@@ -3,19 +3,15 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: ollama
-  annotations:
-    gatus.home-operations.com/endpoint: |
-      name: ollama
-      group: ai
+  name: victoria-logs-canon
 spec:
   hostnames:
-    - ollama.jptr.zebernst.dev
+    - logs.jptr.zebernst.dev
   parentRefs:
     - name: tailscale
       namespace: kube-system
       sectionName: https-canon
   rules:
     - backendRefs:
-        - name: ollama
-          port: 11434
+        - name: victoria-logs
+          port: 9428

--- a/kubernetes/apps/observability/victoria-logs/app/kustomization.yaml
+++ b/kubernetes/apps/observability/victoria-logs/app/kustomization.yaml
@@ -4,3 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./httproute.yaml

--- a/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
@@ -201,14 +201,10 @@ spec:
             group: observability
         hostnames:
           - victoria-metrics.zebernst.dev
-          - victoria-metrics.jptr.zebernst.dev
         parentRefs:
           - name: internal
             namespace: kube-system
             sectionName: https
-          - name: tailscale
-            namespace: kube-system
-            sectionName: https-canon
 
     vmalert:
       enabled: true

--- a/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
@@ -39,7 +39,7 @@ spec:
 
     external:
       grafana:
-        host: https://grafana.kite-harmonic.ts.net
+        host: https://grafana.jptr.zebernst.dev
         datasource: Prometheus
 
     defaultDatasources:
@@ -201,10 +201,14 @@ spec:
             group: observability
         hostnames:
           - victoria-metrics.zebernst.dev
+          - victoria-metrics.jptr.zebernst.dev
         parentRefs:
           - name: internal
             namespace: kube-system
             sectionName: https
+          - name: tailscale
+            namespace: kube-system
+            sectionName: https-canon
 
     vmalert:
       enabled: true

--- a/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
@@ -108,7 +108,7 @@ spec:
         # the operator forces continue: true on first-level routes and alerts fan out
         # to multiple receivers (e.g. blackhole + pushover).
         disableRouteContinueEnforce: true
-        externalURL: https://alertmanager.zebernst.dev
+        externalURL: https://alertmanager.jptr.zebernst.dev
         storage:
           volumeClaimTemplate:
             spec:
@@ -191,20 +191,6 @@ spec:
         tls:
           - hosts:
               - victoria-metrics.kite-harmonic.ts.net
-      route:
-        enabled: true
-        apiVersion: gateway.networking.k8s.io/v1
-        kind: HTTPRoute
-        annotations:
-          gatus.home-operations.com/endpoint: |
-            name: victoria-metrics
-            group: observability
-        hostnames:
-          - victoria-metrics.zebernst.dev
-        parentRefs:
-          - name: internal
-            namespace: kube-system
-            sectionName: https
 
     vmalert:
       enabled: true

--- a/kubernetes/apps/observability/victoria-metrics/app/httproute.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/httproute.yaml
@@ -5,6 +5,10 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: vmui-canonical
+  annotations:
+    gatus.home-operations.com/endpoint: |
+      name: vmui
+      group: observability
 spec:
   hostnames:
     - vmui.jptr.zebernst.dev
@@ -21,6 +25,10 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: alertmanager-canonical
+  annotations:
+    gatus.home-operations.com/endpoint: |
+      name: alertmanager
+      group: observability
 spec:
   hostnames:
     - alertmanager.jptr.zebernst.dev
@@ -37,6 +45,10 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: vmalert-canonical
+  annotations:
+    gatus.home-operations.com/endpoint: |
+      name: vmalert
+      group: observability
 spec:
   hostnames:
     - vmalert.jptr.zebernst.dev
@@ -53,6 +65,10 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: vmagent-canonical
+  annotations:
+    gatus.home-operations.com/endpoint: |
+      name: vmagent
+      group: observability
 spec:
   hostnames:
     - vmagent.jptr.zebernst.dev

--- a/kubernetes/apps/observability/victoria-metrics/app/httproute.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/httproute.yaml
@@ -3,19 +3,15 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: ollama
-  annotations:
-    gatus.home-operations.com/endpoint: |
-      name: ollama
-      group: ai
+  name: alertmanager-canon
 spec:
   hostnames:
-    - ollama.jptr.zebernst.dev
+    - alertmanager.jptr.zebernst.dev
   parentRefs:
     - name: tailscale
       namespace: kube-system
       sectionName: https-canon
   rules:
     - backendRefs:
-        - name: ollama
-          port: 11434
+        - name: vmalertmanager-vmks
+          port: 9093

--- a/kubernetes/apps/observability/victoria-metrics/app/httproute.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/httproute.yaml
@@ -3,7 +3,7 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: alertmanager-canon
+  name: alertmanager-canonical
 spec:
   hostnames:
     - alertmanager.jptr.zebernst.dev

--- a/kubernetes/apps/observability/victoria-metrics/app/httproute.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/httproute.yaml
@@ -1,5 +1,22 @@
 # yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
 ---
+# VMUI (vmsingle)
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: victoria-metrics-canonical
+spec:
+  hostnames:
+    - victoria-metrics.jptr.zebernst.dev
+  parentRefs:
+    - name: tailscale
+      namespace: kube-system
+      sectionName: https-canon
+  rules:
+    - backendRefs:
+        - name: vmsingle-vmks
+          port: 8428
+---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -15,3 +32,35 @@ spec:
     - backendRefs:
         - name: vmalertmanager-vmks
           port: 9093
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: vmalert-canonical
+spec:
+  hostnames:
+    - vmalert.jptr.zebernst.dev
+  parentRefs:
+    - name: tailscale
+      namespace: kube-system
+      sectionName: https-canon
+  rules:
+    - backendRefs:
+        - name: vmalert-vmks
+          port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: vmagent-canonical
+spec:
+  hostnames:
+    - vmagent.jptr.zebernst.dev
+  parentRefs:
+    - name: tailscale
+      namespace: kube-system
+      sectionName: https-canon
+  rules:
+    - backendRefs:
+        - name: vmagent-vmks
+          port: 8429

--- a/kubernetes/apps/observability/victoria-metrics/app/httproute.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/httproute.yaml
@@ -4,10 +4,10 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: victoria-metrics-canonical
+  name: vmui-canonical
 spec:
   hostnames:
-    - victoria-metrics.jptr.zebernst.dev
+    - vmui.jptr.zebernst.dev
   parentRefs:
     - name: tailscale
       namespace: kube-system

--- a/kubernetes/apps/observability/victoria-metrics/app/kustomization.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/kustomization.yaml
@@ -5,4 +5,5 @@ kind: Kustomization
 resources:
   - externalsecret.yaml
   - helmrelease.yaml
+  - httproute.yaml
   - vmalertmanagerconfig.yaml

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/httproute.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/httproute.yaml
@@ -4,6 +4,10 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: rook-ceph-dashboard-canonical
+  annotations:
+    gatus.home-operations.com/endpoint: |
+      name: rook
+      group: rook-ceph
 spec:
   hostnames:
     - rook.jptr.zebernst.dev

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/httproute.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/httproute.yaml
@@ -3,7 +3,7 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: rook-ceph-dashboard-canon
+  name: rook-ceph-dashboard-canonical
 spec:
   hostnames:
     - rook.jptr.zebernst.dev

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/httproute.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/httproute.yaml
@@ -3,19 +3,15 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: ollama
-  annotations:
-    gatus.home-operations.com/endpoint: |
-      name: ollama
-      group: ai
+  name: rook-ceph-dashboard-canon
 spec:
   hostnames:
-    - ollama.jptr.zebernst.dev
+    - rook.jptr.zebernst.dev
   parentRefs:
     - name: tailscale
       namespace: kube-system
       sectionName: https-canon
   rules:
     - backendRefs:
-        - name: ollama
-          port: 11434
+        - name: rook-ceph-mgr-dashboard
+          port: 7000

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/kustomization.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/kustomization.yaml
@@ -4,3 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - helmrelease.yaml
+  - httproute.yaml

--- a/kubernetes/apps/self-hosted/atuin/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/atuin/app/helmrelease.yaml
@@ -89,6 +89,13 @@ spec:
           - name: external
             namespace: kube-system
             sectionName: https
+      canon:
+        hostnames:
+          - "{{ .Release.Name }}.jptr.zebernst.dev"
+        parentRefs:
+          - name: tailscale
+            namespace: kube-system
+            sectionName: https-canon
     ingress:
       tailscale:
         className: tailscale

--- a/kubernetes/apps/self-hosted/atuin/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/atuin/app/helmrelease.yaml
@@ -90,6 +90,10 @@ spec:
             namespace: kube-system
             sectionName: https
       canonical:
+        annotations:
+          gatus.home-operations.com/endpoint: |
+            name: "{{ .Release.Name }}"
+            group: "{{ .Release.Namespace }}"
         hostnames:
           - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/self-hosted/atuin/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/atuin/app/helmrelease.yaml
@@ -89,7 +89,7 @@ spec:
           - name: external
             namespace: kube-system
             sectionName: https
-      canon:
+      canonical:
         hostnames:
           - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/self-hosted/atuin/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/atuin/app/helmrelease.yaml
@@ -78,17 +78,6 @@ spec:
           metrics:
             port: *metricsPort
     route:
-      app:
-        annotations:
-          gatus.home-operations.com/endpoint: |
-            name: "{{ .Release.Name }}"
-            group: "{{ .Release.Namespace }}"
-        hostnames:
-          - sh.zebernst.dev
-        parentRefs:
-          - name: external
-            namespace: kube-system
-            sectionName: https
       canonical:
         annotations:
           gatus.home-operations.com/endpoint: |

--- a/kubernetes/apps/self-hosted/dawarich/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/dawarich/app/helmrelease.yaml
@@ -33,7 +33,7 @@ spec:
               RAILS_ENV: production
               RAILS_LOG_TO_STDOUT: "true"
               RAILS_SERVE_STATIC_FILES: "true"
-              APPLICATION_HOSTS: "timeline.zebernst.dev,localhost,127.0.0.1"
+              APPLICATION_HOSTS: "timeline.zebernst.dev,timeline.jptr.zebernst.dev,localhost,127.0.0.1"
               APPLICATION_PROTOCOL: https
               TIME_ZONE: America/Chicago
               SELF_HOSTED: "true"
@@ -42,6 +42,7 @@ spec:
               SIDEKIQ_METRICS_URL: http://127.0.0.1:9394/metrics
               OIDC_ISSUER: https://id.zebernst.dev
               OIDC_PROVIDER_NAME: Pocket ID
+              # Staged cutover: LAN stays primary; Pocket ID must allow both callbacks
               OIDC_REDIRECT_URI: https://timeline.zebernst.dev/users/auth/openid_connect/callback
               OIDC_AUTO_REGISTER: "true"
               ALLOW_EMAIL_PASSWORD_REGISTRATION: "false"
@@ -143,6 +144,7 @@ spec:
             port: 3000
 
     route:
+      # Staged OIDC cutover: LAN stays primary redirect; Pocket ID must allow both callbacks
       app:
         annotations:
           gatus.home-operations.com/endpoint: |
@@ -154,6 +156,21 @@ spec:
           - name: internal
             namespace: kube-system
             sectionName: https
+        rules:
+          - backendRefs:
+              - name: *app
+                port: 3000
+      canonical:
+        annotations:
+          gatus.home-operations.com/endpoint: |
+            name: "{{ .Release.Name }}-jptr"
+            group: "{{ .Release.Namespace }}"
+        hostnames:
+          - timeline.jptr.zebernst.dev
+        parentRefs:
+          - name: tailscale
+            namespace: kube-system
+            sectionName: https-canon
         rules:
           - backendRefs:
               - name: *app

--- a/kubernetes/apps/self-hosted/glance/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/glance/app/helmrelease.yaml
@@ -91,17 +91,17 @@ spec:
           ext-k8s:
             port: 8080
     route:
-      glance:
+      canonical:
         annotations:
           gatus.home-operations.com/endpoint: |
             name: "{{ .Release.Name }}"
             group: "{{ .Release.Namespace }}"
         hostnames:
-          - glance.zebernst.dev
+          - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:
-          - name: internal
+          - name: tailscale
             namespace: kube-system
-            sectionName: https
+            sectionName: https-canon
         rules:
           - backendRefs:
               - name: *app

--- a/kubernetes/apps/self-hosted/hajimari/app/httproute.yaml
+++ b/kubernetes/apps/self-hosted/hajimari/app/httproute.yaml
@@ -3,19 +3,15 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: ollama
-  annotations:
-    gatus.home-operations.com/endpoint: |
-      name: ollama
-      group: ai
+  name: hajimari-canon
 spec:
   hostnames:
-    - ollama.jptr.zebernst.dev
+    - hajimari.jptr.zebernst.dev
   parentRefs:
     - name: tailscale
       namespace: kube-system
       sectionName: https-canon
   rules:
     - backendRefs:
-        - name: ollama
-          port: 11434
+        - name: hajimari
+          port: 3000

--- a/kubernetes/apps/self-hosted/hajimari/app/httproute.yaml
+++ b/kubernetes/apps/self-hosted/hajimari/app/httproute.yaml
@@ -4,6 +4,10 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: hajimari-canonical
+  annotations:
+    gatus.home-operations.com/endpoint: |
+      name: hajimari
+      group: self-hosted
 spec:
   hostnames:
     - hajimari.jptr.zebernst.dev

--- a/kubernetes/apps/self-hosted/hajimari/app/httproute.yaml
+++ b/kubernetes/apps/self-hosted/hajimari/app/httproute.yaml
@@ -3,7 +3,7 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: hajimari-canon
+  name: hajimari-canonical
 spec:
   hostnames:
     - hajimari.jptr.zebernst.dev

--- a/kubernetes/apps/self-hosted/hajimari/app/kustomization.yaml
+++ b/kubernetes/apps/self-hosted/hajimari/app/kustomization.yaml
@@ -4,4 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - helmrelease.yaml
+  - httproute.yaml
   - vmprobe.yaml

--- a/kubernetes/apps/self-hosted/it-tools/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/it-tools/app/helmrelease.yaml
@@ -56,6 +56,14 @@ spec:
         tls:
           - hosts:
               - *tsHost
+    route:
+      canon:
+        hostnames:
+          - "{{ .Release.Name }}.jptr.zebernst.dev"
+        parentRefs:
+          - name: tailscale
+            namespace: kube-system
+            sectionName: https-canon
     persistence:
       tmp:
         type: emptyDir

--- a/kubernetes/apps/self-hosted/it-tools/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/it-tools/app/helmrelease.yaml
@@ -57,7 +57,7 @@ spec:
           - hosts:
               - *tsHost
     route:
-      canon:
+      canonical:
         hostnames:
           - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/self-hosted/it-tools/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/it-tools/app/helmrelease.yaml
@@ -58,6 +58,10 @@ spec:
               - *tsHost
     route:
       canonical:
+        annotations:
+          gatus.home-operations.com/endpoint: |
+            name: "{{ .Release.Name }}"
+            group: "{{ .Release.Namespace }}"
         hostnames:
           - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/self-hosted/nocodb/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/nocodb/app/helmrelease.yaml
@@ -32,7 +32,7 @@ spec:
             env:
               PORT: &port 8080
               NC_JWT_EXPIRES_IN: 48h
-              NC_PUBLIC_URL: "https://{{ .Release.Name }}.kite-harmonic.ts.net"
+              NC_PUBLIC_URL: "https://{{ .Release.Name }}.jptr.zebernst.dev"
             envFrom: *envFrom
             resources:
               requests:
@@ -68,6 +68,14 @@ spec:
         tls:
           - hosts:
               - *tsHost
+    route:
+      canon:
+        hostnames:
+          - "{{ .Release.Name }}.jptr.zebernst.dev"
+        parentRefs:
+          - name: tailscale
+            namespace: kube-system
+            sectionName: https-canon
     persistence:
       data:
         existingClaim: *app

--- a/kubernetes/apps/self-hosted/nocodb/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/nocodb/app/helmrelease.yaml
@@ -69,7 +69,7 @@ spec:
           - hosts:
               - *tsHost
     route:
-      canon:
+      canonical:
         hostnames:
           - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/self-hosted/nocodb/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/nocodb/app/helmrelease.yaml
@@ -70,6 +70,10 @@ spec:
               - *tsHost
     route:
       canonical:
+        annotations:
+          gatus.home-operations.com/endpoint: |
+            name: "{{ .Release.Name }}"
+            group: "{{ .Release.Namespace }}"
         hostnames:
           - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/self-hosted/nominatim/app/httproute.yaml
+++ b/kubernetes/apps/self-hosted/nominatim/app/httproute.yaml
@@ -3,14 +3,18 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: nominatim
+  name: nominatim-canonical
+  annotations:
+    gatus.home-operations.com/endpoint: |
+      name: nominatim
+      group: self-hosted
 spec:
   hostnames:
-    - nominatim.zebernst.dev
+    - nominatim.jptr.zebernst.dev
   parentRefs:
-    - name: internal
+    - name: tailscale
       namespace: kube-system
-      sectionName: https
+      sectionName: https-canon
   rules:
     # Static UI assets under /ui
     - matches:

--- a/kubernetes/apps/self-hosted/unwrapped/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/unwrapped/app/helmrelease.yaml
@@ -66,17 +66,17 @@ spec:
           http:
             port: *port
     route:
-      app:
+      canonical:
         annotations:
           gatus.home-operations.com/endpoint: |
             name: "{{ .Release.Name }}"
             group: "{{ .Release.Namespace }}"
         hostnames:
-          - "{{ .Release.Name }}.zebernst.dev"
+          - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:
-          - name: internal
+          - name: tailscale
             namespace: kube-system
-            sectionName: https
+            sectionName: https-canon
     persistence:
       secrets:
         type: secret


### PR DESCRIPTION
## Summary
- Add `route.canonical` / `https-canon` companions at `$APP.jptr.zebernst.dev` while Tailscale Ingresses remain (later phase deletes them)
- Standard app-template apps + chart-native special cases (hajimari, hubble, rook, victoria-logs/metrics, etc.)
- Ollama jptr-only carve-out; mc-router DNS Ingress → DNSEndpoint; plex shared root rules (client header invert + `/web` redirect)
- Grafana/Paperless intentionally deferred (OIDC cutover)

## Test plan
- [ ] Spot-check ≥5 apps on `$APP.jptr` (include one former ts.net-only app)
- [ ] Ollama only on `ollama.jptr` (no lan/external companions)
- [ ] `minecraft.zebernst.dev` still resolves via DNSEndpoint
- [ ] Plex: browser `/` → `/web`; client with `X-Plex-Device-Name` stays on `/`; API paths unaffected
- [ ] No accidental new `external` parentRefs for formerly private apps
- [ ] `flate test` green

## Post-Deploy Monitoring & Validation
- Watch HTTPRoute Accepted/ResolvedRefs for a sample of `*-canonical` routes and app-template `route.canonical` children
- Failure signal: 404/timeout on `$APP.jptr` while `*.ts.net` still works (dual-run regression), or new public exposure for formerly private apps