### PR TITLE
refactor(gatus): namespace groups and endpoint naming

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,25 +204,37 @@ Useful kubectl plugins (via krew/aqua):
 ### Gatus exposure tiers
 
 Gatus runs as **two instances**, each with its own `gatus-sidecar`:
-- Public (`kubernetes/apps/observability/gatus/external/`, Release `gatus-external`) discovers the `external` Gateway only. Published at `status.zebernst.dev` (+ companion `status.jptr.zebernst.dev`). Never lists private inventory.
+- Public (`kubernetes/apps/observability/gatus/external/`, Release `gatus-external`) discovers the `external` Gateway only. Published at `status.zebernst.dev` (+ companion `gatus-ext.jptr.zebernst.dev`). Never lists private inventory.
 - Private (`kubernetes/apps/observability/gatus/private/`, Release `gatus`) discovers `internal` (→ `lan` after the rename) + `tailscale` Gateways plus opt-in cluster Services, plus buddy endpoints. Published only at `gatus.jptr.zebernst.dev` (tailnet).
 
-Tier defaults live on Gateways; per-app overrides should only set route-specific fields (`path:`, `enabled: "false"`, custom `url:`).
+Gateway annotations supply shared probe defaults (`client`, `conditions`). Per-route `gatus.home-operations.com/endpoint` sets Gatus fields (`name`, `group`, `ui`, `path`, … — see [Gatus endpoints](https://github.com/TwiN/gatus#endpoints)). **Group by Kubernetes namespace** on both instances; exposure tier is implied by which instance discovered the route (no `public`/`internal`/`private` groups).
 
 | Tier | Instance | Resource | Group | DNS resolver |
 |------|----------|----------|-------|--------------|
-| **Public** | public (`gatus-external`) | HTTPRoute → `external` Gateway | `public` | `1.1.1.1` (inherited from Gateway) |
-| **Internal/LAN** | `gatus` | HTTPRoute → `internal`/`lan` Gateway | `internal` (→ `lan`) | `kube-dns` (inherited from Gateway) |
-| **Private** | `gatus` | HTTPRoute → `tailscale` Gateway (`*.jptr`) | `private` | `dns-jptr` k8s_gateway (inherited from Gateway) |
-| **Cluster** | `gatus` | Service (opt-in) | `cluster` | in-cluster (auto `*.svc` URL) |
+| **Public** | `gatus-external` | HTTPRoute → `external` Gateway | `<namespace>` | `1.1.1.1` (inherited from Gateway) |
+| **Internal/LAN** | `gatus` | HTTPRoute → `internal`/`lan` Gateway | `<namespace>` | `kube-dns` (inherited from Gateway) |
+| **Private** | `gatus` | HTTPRoute → `tailscale` Gateway (`*.jptr`) | `<namespace>` | `dns-jptr` / `coredns-gateway` (inherited from Gateway) |
+| **Cluster** | `gatus` | Service (opt-in) | `<namespace>` | in-cluster (auto `*.svc` URL) |
 | **Buddy** | `gatus` | Static endpoints (`buddy.yaml`) | `buddy` | — |
+
+Typical per-route annotation (app-template):
+
+```yaml
+gatus.home-operations.com/endpoint: |
+  name: "{{ .Release.Name }}"
+  group: "{{ .Release.Namespace }}"
+  # path: /health   # optional probe path
+  # ui:             # optional; see Gatus endpoint UI options
+  #   hide-hostname: true
+```
 
 Cluster-tier Services require explicit opt-in:
 
 ```yaml
 gatus.home-operations.com/enabled: "true"
 gatus.home-operations.com/endpoint: |
-  group: cluster
+  name: myapp
+  group: "{{ .Release.Namespace }}"  # or hardcode the namespace
   # url: tcp://myapp.namespace.svc:8080  # optional override
 ```
 

--- a/kubernetes/apps/ai/ollama/app/httproute.yaml
+++ b/kubernetes/apps/ai/ollama/app/httproute.yaml
@@ -7,6 +7,8 @@ metadata:
   annotations:
     # *.internal listener serves a private-CA cert gatus can't verify
     gatus.home-operations.com/endpoint: |
+      name: ollama
+      group: ai
       client:
         dns-resolver: tcp://kube-dns.kube-system.svc:53
         insecure: true
@@ -26,6 +28,10 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: ollama-tailscale
+  annotations:
+    gatus.home-operations.com/endpoint: |
+      name: ollama-ts
+      group: ai
 spec:
   hostnames:
     - ollama.zebernst.dev

--- a/kubernetes/apps/ai/open-webui/app/httproute.yaml
+++ b/kubernetes/apps/ai/open-webui/app/httproute.yaml
@@ -7,6 +7,8 @@ metadata:
   annotations:
     # *.internal listener serves a private-CA cert gatus can't verify
     gatus.home-operations.com/endpoint: |
+      name: open-webui
+      group: ai
       client:
         dns-resolver: tcp://kube-dns.kube-system.svc:53
         insecure: true

--- a/kubernetes/apps/auth/pocket-id/app/helmrelease.yaml
+++ b/kubernetes/apps/auth/pocket-id/app/helmrelease.yaml
@@ -123,6 +123,10 @@ spec:
 
     route:
       internal:
+        annotations:
+          gatus.home-operations.com/endpoint: |
+            name: "{{ .Release.Name }}"
+            group: "{{ .Release.Namespace }}"
         hostnames:
           - id.zebernst.dev
         parentRefs:
@@ -134,6 +138,10 @@ spec:
               - name: *app
                 port: *port
       external:
+        annotations:
+          gatus.home-operations.com/endpoint: |
+            name: "{{ .Release.Name }}"
+            group: "{{ .Release.Namespace }}"
         hostnames:
           - id.zebernst.dev
         parentRefs:

--- a/kubernetes/apps/auth/tinyauth/app/helmrelease.yaml
+++ b/kubernetes/apps/auth/tinyauth/app/helmrelease.yaml
@@ -63,6 +63,10 @@ spec:
 
     route:
       external:
+        annotations:
+          gatus.home-operations.com/endpoint: |
+            name: "{{ .Release.Name }}"
+            group: "{{ .Release.Namespace }}"
         hostnames:
           - auth.zebernst.dev
         parentRefs:

--- a/kubernetes/apps/downloads/qui/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/qui/app/helmrelease.yaml
@@ -107,6 +107,10 @@ spec:
             scrapeTimeout: 10s
     route:
       qui:
+        annotations:
+          gatus.home-operations.com/endpoint: |
+            name: "{{ .Release.Name }}"
+            group: "{{ .Release.Namespace }}"
         hostnames:
           - "{{ .Release.Name }}.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/fission/functions/ics-proxy/trigger.yaml
+++ b/kubernetes/apps/fission/functions/ics-proxy/trigger.yaml
@@ -18,6 +18,8 @@ spec:
     # Bare probe without ?calendar= returns 400 by design (same pattern as flux-webhook)
     annotations:
       gatus.home-operations.com/endpoint: |
+        name: ics-proxy
+        group: fission
         conditions:
           - "[STATUS] == 400"
     gateway:

--- a/kubernetes/apps/flux-system/konflate/app/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/konflate/app/helmrelease.yaml
@@ -39,6 +39,8 @@ spec:
       enabled: true
       annotations:
         gatus.home-operations.com/endpoint: |
+          name: konflate
+          group: flux-system
           path: /readyz
       parentRefs:
         - name: external

--- a/kubernetes/apps/games/minecraft/bluemap/app/helmrelease.yaml
+++ b/kubernetes/apps/games/minecraft/bluemap/app/helmrelease.yaml
@@ -85,6 +85,10 @@ spec:
 
     route:
       external:
+        annotations:
+          gatus.home-operations.com/endpoint: |
+            name: "{{ .Release.Name }}"
+            group: "{{ .Release.Namespace }}"
         hostnames: ["worldmap.zebernst.dev"]
         parentRefs:
           - name: external

--- a/kubernetes/apps/games/minecraft/router/app/helmrelease.yaml
+++ b/kubernetes/apps/games/minecraft/router/app/helmrelease.yaml
@@ -91,7 +91,7 @@ spec:
           gatus.home-operations.com/enabled: "true"
           gatus.home-operations.com/endpoint: |
             name: minecraft
-            group: public
+            group: games
             url: http://mc-router.games.svc.cluster.local:8080/routes
             interval: 1m
             conditions:

--- a/kubernetes/apps/kube-system/cilium/gateway/external.yaml
+++ b/kubernetes/apps/kube-system/cilium/gateway/external.yaml
@@ -6,7 +6,6 @@ metadata:
   annotations:
     external-dns.alpha.kubernetes.io/target: &hostname external.zebernst.dev
     gatus.home-operations.com/endpoint: |
-      group: public
       client:
         dns-resolver: tcp://1.1.1.1:53
       conditions:

--- a/kubernetes/apps/kube-system/cilium/gateway/internal.yaml
+++ b/kubernetes/apps/kube-system/cilium/gateway/internal.yaml
@@ -6,7 +6,6 @@ metadata:
   annotations:
     external-dns.alpha.kubernetes.io/target: &hostname gw-internal.zebernst.dev
     gatus.home-operations.com/endpoint: |
-      group: internal
       client:
         dns-resolver: tcp://kube-dns.kube-system.svc:53
       conditions:

--- a/kubernetes/apps/kube-system/cilium/gateway/tailscale.yaml
+++ b/kubernetes/apps/kube-system/cilium/gateway/tailscale.yaml
@@ -26,7 +26,6 @@ metadata:
   name: tailscale
   annotations:
     gatus.home-operations.com/endpoint: |
-      group: private
       client:
         dns-resolver: tcp://dns-jptr.network.svc.cluster.local:53
       conditions:

--- a/kubernetes/apps/media/agregarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/agregarr/app/helmrelease.yaml
@@ -64,6 +64,10 @@ spec:
 
     route:
       internal:
+        annotations:
+          gatus.home-operations.com/endpoint: |
+            name: "{{ .Release.Name }}"
+            group: "{{ .Release.Namespace }}"
         hostnames:
           - agregarr.zebernst.dev
         parentRefs:

--- a/kubernetes/apps/media/booklore/app/helmrelease.yaml
+++ b/kubernetes/apps/media/booklore/app/helmrelease.yaml
@@ -64,6 +64,10 @@ spec:
 
     route:
       app:
+        annotations:
+          gatus.home-operations.com/endpoint: |
+            name: "{{ .Release.Name }}"
+            group: "{{ .Release.Namespace }}"
         hostnames:
           - "{{ .Release.Name }}.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/media/capacitarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/capacitarr/app/helmrelease.yaml
@@ -66,6 +66,8 @@ spec:
         annotations:
           # App requires auth on / (401); probe the unauthenticated health endpoint
           gatus.home-operations.com/endpoint: |
+            name: "{{ .Release.Name }}"
+            group: "{{ .Release.Namespace }}"
             path: /api/v1/health
         hostnames:
           - "{{ .Release.Name }}.zebernst.dev"

--- a/kubernetes/apps/media/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/media/plex/app/helmrelease.yaml
@@ -89,6 +89,8 @@ spec:
       plex:
         annotations:
           gatus.home-operations.com/endpoint: |
+            name: "{{ .Release.Name }}"
+            group: "{{ .Release.Namespace }}"
             path: /web/index.html
         hostnames:
           - "{{ .Release.Name }}.zebernst.dev"

--- a/kubernetes/apps/media/seerr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/seerr/app/helmrelease.yaml
@@ -67,6 +67,8 @@ spec:
       app:
         annotations:
           gatus.home-operations.com/endpoint: |
+            name: "{{ .Release.Name }}"
+            group: "{{ .Release.Namespace }}"
             path: /api/v1/status
         hostnames:
           - "requests.zebernst.dev"

--- a/kubernetes/apps/media/shelfmark/app/helmrelease.yaml
+++ b/kubernetes/apps/media/shelfmark/app/helmrelease.yaml
@@ -55,6 +55,10 @@ spec:
 
     route:
       app:
+        annotations:
+          gatus.home-operations.com/endpoint: |
+            name: "{{ .Release.Name }}"
+            group: "{{ .Release.Namespace }}"
         hostnames:
           - "{{ .Release.Name }}.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/media/tautulli/app/helmrelease.yaml
+++ b/kubernetes/apps/media/tautulli/app/helmrelease.yaml
@@ -80,6 +80,10 @@ spec:
               - *tsHost
     route:
       tautulli:
+        annotations:
+          gatus.home-operations.com/endpoint: |
+            name: "{{ .Release.Name }}"
+            group: "{{ .Release.Namespace }}"
         hostnames:
           - "{{ .Release.Name }}.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/media/wizarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/wizarr/app/helmrelease.yaml
@@ -50,6 +50,10 @@ spec:
             port: 5690
     route:
       app:
+        annotations:
+          gatus.home-operations.com/endpoint: |
+            name: "{{ .Release.Name }}"
+            group: "{{ .Release.Namespace }}"
         hostnames:
           - "join.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/network/echo-server/app/helmrelease.yaml
+++ b/kubernetes/apps/network/echo-server/app/helmrelease.yaml
@@ -69,6 +69,10 @@ spec:
             scrapeTimeout: 10s
     route:
       app:
+        annotations:
+          gatus.home-operations.com/endpoint: |
+            name: "{{ .Release.Name }}"
+            group: "{{ .Release.Namespace }}"
         hostnames:
           - "{{ .Release.Name }}.zebernst.dev"
         parentRefs:
@@ -76,6 +80,10 @@ spec:
             namespace: kube-system
             sectionName: https
       canonical:
+        annotations:
+          gatus.home-operations.com/endpoint: |
+            name: "{{ .Release.Name }}"
+            group: "{{ .Release.Namespace }}"
         hostnames:
           - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/observability/gatus/external/helmrelease.yaml
+++ b/kubernetes/apps/observability/gatus/external/helmrelease.yaml
@@ -32,7 +32,6 @@ spec:
             args:
               - --auto-httproute
               - --gateway-name=external
-              - --prefix-httproute=route/
             resources: &resources
               requests:
                 cpu: 10m
@@ -97,7 +96,7 @@ spec:
         annotations:
           gatus.home-operations.com/enabled: "false"
         hostnames:
-          - status.jptr.zebernst.dev
+          - gatus-ext.jptr.zebernst.dev
         parentRefs:
           - name: tailscale
             namespace: kube-system

--- a/kubernetes/apps/observability/gatus/external/resources/config.yaml
+++ b/kubernetes/apps/observability/gatus/external/resources/config.yaml
@@ -8,7 +8,7 @@ endpoints:
   # Flux GitHub receiver rejects unauthenticated probes with 400 on the hashed path.
   # FLUX_WEBHOOK_PATH is derived in gatus-external-secret from the flux webhook token (Receiver formula).
   - name: flux-webhook
-    group: public
+    group: flux-system
     url: https://flux-webhook.zebernst.dev${FLUX_WEBHOOK_PATH}
     interval: 1m
     client:

--- a/kubernetes/apps/observability/gatus/external/vmrule.yaml
+++ b/kubernetes/apps/observability/gatus/external/vmrule.yaml
@@ -1,5 +1,5 @@
----
 # yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/operator.victoriametrics.com/vmrule_v1beta1.json
+---
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMRule
 metadata:
@@ -10,10 +10,10 @@ spec:
       rules:
         - alert: GatusEndpointDown
           expr: |
-            gatus_results_endpoint_success{group=~"public"} == 0
+            gatus_results_endpoint_success == 0
           for: 5m
           annotations:
             summary: >-
-              The {{ $labels.name }} endpoint is down
+              The {{ $labels.group }}/{{ $labels.name }} endpoint is down
           labels:
             severity: critical

--- a/kubernetes/apps/observability/gatus/private/helmrelease.yaml
+++ b/kubernetes/apps/observability/gatus/private/helmrelease.yaml
@@ -34,8 +34,6 @@ spec:
               - --enable-service
               - --gateway-name=internal
               - --gateway-name=tailscale
-              - --prefix-httproute=route/
-              - --prefix-service=svc/
             resources: &resources
               requests:
                 cpu: 10m

--- a/kubernetes/apps/observability/gatus/private/vmrule.yaml
+++ b/kubernetes/apps/observability/gatus/private/vmrule.yaml
@@ -1,5 +1,5 @@
----
 # yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/operator.victoriametrics.com/vmrule_v1beta1.json
+---
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMRule
 metadata:
@@ -10,10 +10,10 @@ spec:
       rules:
         - alert: GatusEndpointDown
           expr: |
-            gatus_results_endpoint_success{group=~"internal|private|cluster|buddy"} == 0
+            gatus_results_endpoint_success == 0
           for: 5m
           annotations:
             summary: >-
-              The {{ $labels.name }} endpoint is down
+              The {{ $labels.group }}/{{ $labels.name }} endpoint is down
           labels:
             severity: critical

--- a/kubernetes/apps/observability/kromgo/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kromgo/app/helmrelease.yaml
@@ -68,6 +68,8 @@ spec:
       app:
         annotations:
           gatus.home-operations.com/endpoint: |
+            name: "{{ .Release.Name }}"
+            group: "{{ .Release.Namespace }}"
             path: /talos_version
         hostnames:
           - "{{ .Release.Name }}.zebernst.dev"

--- a/kubernetes/apps/observability/scanopy/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/scanopy/app/helmrelease.yaml
@@ -73,6 +73,8 @@ spec:
       scanopy:
         annotations:
           gatus.home-operations.com/endpoint: |
+            name: "{{ .Release.Name }}"
+            group: "{{ .Release.Namespace }}"
             path: /api/health
         hostnames:
           - scanopy.zebernst.dev

--- a/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
@@ -195,6 +195,10 @@ spec:
         enabled: true
         apiVersion: gateway.networking.k8s.io/v1
         kind: HTTPRoute
+        annotations:
+          gatus.home-operations.com/endpoint: |
+            name: victoria-metrics
+            group: observability
         hostnames:
           - victoria-metrics.zebernst.dev
         parentRefs:

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -195,6 +195,10 @@ spec:
           region: us-east-1
       route:
         enabled: true
+        annotations:
+          gatus.home-operations.com/endpoint: |
+            name: s3
+            group: rook-ceph
         host:
           name: s3.zebernst.dev
           path: /

--- a/kubernetes/apps/self-hosted/atuin/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/atuin/app/helmrelease.yaml
@@ -79,6 +79,10 @@ spec:
             port: *metricsPort
     route:
       app:
+        annotations:
+          gatus.home-operations.com/endpoint: |
+            name: "{{ .Release.Name }}"
+            group: "{{ .Release.Namespace }}"
         hostnames:
           - sh.zebernst.dev
         parentRefs:

--- a/kubernetes/apps/self-hosted/dawarich/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/dawarich/app/helmrelease.yaml
@@ -144,6 +144,10 @@ spec:
 
     route:
       app:
+        annotations:
+          gatus.home-operations.com/endpoint: |
+            name: "{{ .Release.Name }}"
+            group: "{{ .Release.Namespace }}"
         hostnames:
           - timeline.zebernst.dev
         parentRefs:

--- a/kubernetes/apps/self-hosted/glance/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/glance/app/helmrelease.yaml
@@ -92,6 +92,10 @@ spec:
             port: 8080
     route:
       glance:
+        annotations:
+          gatus.home-operations.com/endpoint: |
+            name: "{{ .Release.Name }}"
+            group: "{{ .Release.Namespace }}"
         hostnames:
           - glance.zebernst.dev
         parentRefs:

--- a/kubernetes/apps/self-hosted/rxresume/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/rxresume/app/helmrelease.yaml
@@ -94,6 +94,10 @@ spec:
             port: &port 3000
     route:
       app:
+        annotations:
+          gatus.home-operations.com/endpoint: |
+            name: "{{ .Release.Name }}"
+            group: "{{ .Release.Namespace }}"
         hostnames:
           - "{{ .Release.Name }}.zebernst.dev"
         parentRefs:
@@ -101,6 +105,10 @@ spec:
             namespace: kube-system
             sectionName: https
       cv:
+        annotations:
+          gatus.home-operations.com/endpoint: |
+            name: cv
+            group: "{{ .Release.Namespace }}"
         hostnames:
           - "cv.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/self-hosted/unwrapped/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/unwrapped/app/helmrelease.yaml
@@ -67,6 +67,10 @@ spec:
             port: *port
     route:
       app:
+        annotations:
+          gatus.home-operations.com/endpoint: |
+            name: "{{ .Release.Name }}"
+            group: "{{ .Release.Namespace }}"
         hostnames:
           - "{{ .Release.Name }}.zebernst.dev"
         parentRefs:


### PR DESCRIPTION
## Summary
- Drop `--prefix-httproute=route/` (and service prefix); endpoint `name`/`group`/`ui`/`path` come from `gatus.home-operations.com/endpoint` ([Gatus endpoint options](https://github.com/TwiN/gatus#endpoints))
- Group by Kubernetes namespace on both instances; remove `public`/`internal`/`private` from Gateway annotations (tier = which Gatus instance)
- Public companion hostname: `gatus-ext.jptr.zebernst.dev` (keep apex vanity `status.zebernst.dev`)
- VMRules alert on all endpoints per instance; static flux-webhook → `flux-system`, minecraft → `games`

## Test plan
- [ ] Both Gatus UIs show endpoints grouped by namespace (no `route/` names)
- [ ] `https://gatus-ext.jptr.zebernst.dev` resolves on tailnet; `status.zebernst.dev` unchanged publicly
- [ ] Spot-check plex/seerr/kromgo still probe custom paths
- [ ] Down alert fires with `group/name` in summary


Made with [Cursor](https://cursor.com)