### PR TITLE
fix(observability): quiet scaled-to-zero scrapes and info Pushover

### DIFF
--- a/kubernetes/apps/games/minecraft/atm10/app/kustomization.yaml
+++ b/kubernetes/apps/games/minecraft/atm10/app/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - dnsendpoint.yaml
   - externalsecret.yaml
   - helmrelease.yaml
+  - silence.yaml
 generatorOptions:
   disableNameSuffixHash: true
 configMapGenerator:

--- a/kubernetes/apps/games/minecraft/atm10/app/silence.yaml
+++ b/kubernetes/apps/games/minecraft/atm10/app/silence.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.giantswarm.io/silence_v1alpha1.json
+---
+# Silence ScrapePoolHasNoTargets while this server is scaled to zero.
+# scrape_job format from vmagent: serviceScrape/<namespace>/<ServiceMonitor>/<endpointIndex>
+apiVersion: monitoring.giantswarm.io/v1alpha1
+kind: Silence
+metadata:
+  name: ${APP}-autoscaling
+spec:
+  matchers:
+    - name: alertname
+      value: ScrapePoolHasNoTargets
+      isRegex: false
+    - name: scrape_job
+      value: serviceScrape/.*/${APP}/.*
+      isRegex: true

--- a/kubernetes/apps/games/minecraft/atmons/app/kustomization.yaml
+++ b/kubernetes/apps/games/minecraft/atmons/app/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - dnsendpoint.yaml
   - externalsecret.yaml
   - helmrelease.yaml
+  - silence.yaml
 generatorOptions:
   disableNameSuffixHash: true
 configMapGenerator:

--- a/kubernetes/apps/games/minecraft/atmons/app/silence.yaml
+++ b/kubernetes/apps/games/minecraft/atmons/app/silence.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.giantswarm.io/silence_v1alpha1.json
+---
+# Silence ScrapePoolHasNoTargets while this server is scaled to zero.
+# scrape_job format from vmagent: serviceScrape/<namespace>/<ServiceMonitor>/<endpointIndex>
+apiVersion: monitoring.giantswarm.io/v1alpha1
+kind: Silence
+metadata:
+  name: ${APP}-autoscaling
+spec:
+  matchers:
+    - name: alertname
+      value: ScrapePoolHasNoTargets
+      isRegex: false
+    - name: scrape_job
+      value: serviceScrape/.*/${APP}/.*
+      isRegex: true

--- a/kubernetes/apps/observability/victoria-metrics/app/vmalertmanagerconfig.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/vmalertmanagerconfig.yaml
@@ -15,6 +15,9 @@ spec:
       - receiver: blackhole
         matchers:
           - alertname="InfoInhibitor"
+      - receiver: blackhole
+        matchers:
+          - severity="info"
       - receiver: heartbeat
         group_interval: 5m
         group_wait: 0s


### PR DESCRIPTION
## Summary
- Add per-app `${APP}-autoscaling` Silence CRs for atm10/atmons so `ScrapePoolHasNoTargets` is muted while servers are scaled to zero (copy the manifest for future modpacks)
- Blackhole `severity=info` in Alertmanager so info alerts stay visible in Karma/AM but do not notify Pushover

## Test plan
- [ ] After merge, confirm silences `atm10-autoscaling` and `atmons-autoscaling` sync to Alertmanager
- [ ] Confirm `ScrapePoolHasNoTargets` for atm10/atmons no longer hits Pushover while replicas=0
- [ ] Confirm an info alert (e.g. `RecordingRulesNoData`) still appears in Karma but does not push
- [ ] Confirm warning/critical alerts still notify as before


Made with [Cursor](https://cursor.com)