### PR TITLE
fix(gatus): point tailscale probes at coredns-gateway and scope down alerts

### DIFF
--- a/kubernetes/apps/kube-system/cilium/gateway/tailscale.yaml
+++ b/kubernetes/apps/kube-system/cilium/gateway/tailscale.yaml
@@ -27,7 +27,7 @@ metadata:
   annotations:
     gatus.home-operations.com/endpoint: |
       client:
-        dns-resolver: tcp://dns-jptr.network.svc.cluster.local:53
+        dns-resolver: tcp://coredns-gateway.network.svc.cluster.local:53
       conditions:
         - "[STATUS] == 200"
   labels:

--- a/kubernetes/apps/observability/gatus/external/vmrule.yaml
+++ b/kubernetes/apps/observability/gatus/external/vmrule.yaml
@@ -10,7 +10,7 @@ spec:
       rules:
         - alert: GatusEndpointDown
           expr: |
-            gatus_results_endpoint_success == 0
+            gatus_results_endpoint_success{job="gatus-external"} == 0
           for: 5m
           annotations:
             summary: >-

--- a/kubernetes/apps/observability/gatus/private/vmrule.yaml
+++ b/kubernetes/apps/observability/gatus/private/vmrule.yaml
@@ -10,7 +10,7 @@ spec:
       rules:
         - alert: GatusEndpointDown
           expr: |
-            gatus_results_endpoint_success == 0
+            gatus_results_endpoint_success{job="gatus"} == 0
           for: 5m
           annotations:
             summary: >-


### PR DESCRIPTION
## Summary

Tailscale Gatus probes were failing DNS after `dns-jptr` was renamed to `coredns-gateway`, which made healthy endpoints like `ollama-ts` and `echo-server` look down. Point the Gateway annotation at the new Service, and scope each `GatusEndpointDown` rule to its own scrape job so private and external failures stop double-firing.

## Test plan
- [ ] After Flux reconcile, confirm Gateway `tailscale` annotation uses `coredns-gateway.network.svc.cluster.local`
- [ ] Confirm `ai/ollama-ts` and `network/echo-server` succeed in private Gatus (or clear once DNS works)
- [ ] Confirm a single failing endpoint fires only one `GatusEndpointDown` (matching job), not both rule groups
