### PR TITLE
feat(apps): dual-run grafana and paperless on jptr

### DIFF
--- a/kubernetes/apps/observability/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/grafana/app/helmrelease.yaml
@@ -26,6 +26,7 @@ spec:
       GF_EXPLORE_ENABLED: true
       GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS: natel-discrete-panel,pr0ps-trackmap-panel,panodata-map-panel
       GF_SECURITY_ANGULAR_SUPPORT_ENABLED: true
+      # Dual-run: keep ts.net root until OIDC cutover; jptr HTTPRoute is companion
       GF_SERVER_ROOT_URL: https://grafana.kite-harmonic.ts.net
     grafana.ini:
       analytics:

--- a/kubernetes/apps/observability/grafana/app/httproute.yaml
+++ b/kubernetes/apps/observability/grafana/app/httproute.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: grafana-canonical
+  annotations:
+    gatus.home-operations.com/endpoint: |
+      name: grafana
+      group: observability
+spec:
+  hostnames:
+    - grafana.jptr.zebernst.dev
+  parentRefs:
+    - name: tailscale
+      namespace: kube-system
+      sectionName: https-canon
+  rules:
+    - backendRefs:
+        - name: grafana
+          port: 80

--- a/kubernetes/apps/observability/grafana/app/kustomization.yaml
+++ b/kubernetes/apps/observability/grafana/app/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - externalsecret.yaml
   - helmrelease.yaml
+  - httproute.yaml

--- a/kubernetes/apps/self-hosted/paperless/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/paperless/app/helmrelease.yaml
@@ -35,6 +35,10 @@ spec:
             env:
               # Configure application
               PAPERLESS_URL: "https://{{ .Release.Name }}.kite-harmonic.ts.net"
+              # Dual-run jptr companion (OIDC / Gateway cutover verification)
+              PAPERLESS_CSRF_TRUSTED_ORIGINS: "https://{{ .Release.Name }}.jptr.zebernst.dev,https://{{ .Release.Name }}.kite-harmonic.ts.net"
+              PAPERLESS_ALLOWED_HOSTS: "{{ .Release.Name }}.jptr.zebernst.dev,{{ .Release.Name }}.kite-harmonic.ts.net"
+              PAPERLESS_CORS_ALLOWED_HOSTS: "https://{{ .Release.Name }}.jptr.zebernst.dev,https://{{ .Release.Name }}.kite-harmonic.ts.net"
               PAPERLESS_PORT: &port "8000"
               PAPERLESS_TIME_ZONE: "America/Chicago"
               PAPERLESS_WEBSERVER_WORKERS: "2"
@@ -136,6 +140,19 @@ spec:
           - hosts:
               - *tsHost
 
+    route:
+      # Dual-run with Tailscale Ingress until OIDC cutover drops ts.net
+      canonical:
+        annotations:
+          gatus.home-operations.com/endpoint: |
+            name: "{{ .Release.Name }}"
+            group: "{{ .Release.Namespace }}"
+        hostnames:
+          - "{{ .Release.Name }}.jptr.zebernst.dev"
+        parentRefs:
+          - name: tailscale
+            namespace: kube-system
+            sectionName: https-canon
 
     serviceMonitor:
       app:


### PR DESCRIPTION
## Summary
- Add `grafana.jptr.zebernst.dev` HTTPRoute on the Tailscale `https-canon` listener
- Add `paperless.jptr.zebernst.dev` canonical route; allow CSRF/hosts for both jptr and ts.net
- Keep existing Tailscale Ingresses and `GF_SERVER_ROOT_URL` / `PAPERLESS_URL` on ts.net for dual-run

## Notes
Both apps still use Tailscale identity headers (`auth.proxy` / remote user), not Pocket ID OIDC. Gateway jptr access will not inject those headers (Grafana anonymous Viewer still works).

## Test plan
- [ ] `dig grafana.jptr.zebernst.dev` and `dig paperless.jptr.zebernst.dev` resolve to the Tailscale Gateway IP
- [ ] `curl -I https://grafana.jptr.zebernst.dev/` returns 200
- [ ] Paperless loads at `https://paperless.jptr.zebernst.dev/` without CSRF/host errors
- [ ] Existing `*.kite-harmonic.ts.net` Ingress URLs still work


Made with [Cursor](https://cursor.com)