### PR TITLE
fix(apps): repair victoria-logs jptr backend and plex probe path

### DIFF
--- a/kubernetes/apps/media/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/media/plex/app/helmrelease.yaml
@@ -130,13 +130,13 @@ spec:
                   - name: X-Plex-Device-Name
                     type: RegularExpression
                     value: ".+"
-          # Redirect unidentified root requests to the Plex landing page.
+          # Redirect unidentified root to /web/index.html (Plex's /web hop downgrades to http).
           - filters:
               - type: RequestRedirect
                 requestRedirect:
                   path:
                     type: ReplaceFullPath
-                    replaceFullPath: /web
+                    replaceFullPath: /web/index.html
                   statusCode: 302
             matches:
               - path:
@@ -151,6 +151,7 @@ spec:
           gatus.home-operations.com/endpoint: |
             name: "{{ .Release.Name }}"
             group: "{{ .Release.Namespace }}"
+            path: /web/index.html
         hostnames:
           - "{{ .Release.Name }}.jptr.zebernst.dev"
         parentRefs:

--- a/kubernetes/apps/observability/victoria-logs/app/httproute.yaml
+++ b/kubernetes/apps/observability/victoria-logs/app/httproute.yaml
@@ -17,5 +17,5 @@ spec:
       sectionName: https-canon
   rules:
     - backendRefs:
-        - name: victoria-logs
+        - name: victoria-logs-server
           port: 9428


### PR DESCRIPTION
## Summary

`victoria-logs.jptr` was returning 500 because the canonical HTTPRoute pointed at a Service that does not exist (`victoria-logs` vs `victoria-logs-server`). The plex jptr Gatus probe was hitting `/` and following Plex's `/web` → `http://…/web/index.html` downgrade, so it alerted on a 404 while `/web/index.html` itself is healthy.

Point the logs route at the real Service, probe plex at `/web/index.html` (same as the external route), and land the root redirect there so browsers skip the bad hop.

## Test plan
- [ ] After Flux reconcile, `victoria-logs-canonical` shows `ResolvedRefs=True`
- [ ] `https://victoria-logs.jptr.zebernst.dev/` returns 200 (not 500)
- [ ] `https://plex.jptr.zebernst.dev/` redirects to `https://…/web/index.html` (not `/web`)
- [ ] Private Gatus clears `media/plex` and `observability/victoria-logs` `GatusEndpointDown`
