### PR TITLE
feat(gateway): cut over to jptr-only; drop Tailscale Ingresses

### DIFF
--- a/kubernetes/apps/auth/pocket-id/app/helmrelease.yaml
+++ b/kubernetes/apps/auth/pocket-id/app/helmrelease.yaml
@@ -107,20 +107,6 @@ spec:
           metrics:
             port: *metricsPort
 
-    ingress:
-      tailscale:
-        className: tailscale
-        hosts:
-          - host: &tsHost "pocket-id.kite-harmonic.ts.net"
-            paths:
-              - path: /
-                service:
-                  identifier: *app
-                  port: http
-        tls:
-          - hosts:
-              - *tsHost
-
     route:
       internal:
         annotations:
@@ -167,7 +153,6 @@ spec:
           - backendRefs:
               - name: *app
                 port: *port
-
 
     serviceMonitor:
       app:

--- a/kubernetes/apps/downloads/autobrr/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/autobrr/app/helmrelease.yaml
@@ -74,19 +74,6 @@ spec:
             port: *port
           metrics:
             port: *promPort
-    ingress:
-      tailscale:
-        className: tailscale
-        hosts:
-          - host: &tsHost "{{ .Release.Name }}.kite-harmonic.ts.net"
-            paths:
-              - path: /
-                service:
-                  identifier: *app
-                  port: http
-        tls:
-          - hosts:
-              - *tsHost
     route:
       canonical:
         annotations:

--- a/kubernetes/apps/downloads/bazarr/hd/helmrelease.yaml
+++ b/kubernetes/apps/downloads/bazarr/hd/helmrelease.yaml
@@ -109,19 +109,6 @@ spec:
             port: *port
           metrics:
             port: *metricsPort
-    ingress:
-      tailscale:
-        className: tailscale
-        hosts:
-          - host: &tsHost "{{ .Release.Name }}.kite-harmonic.ts.net"
-            paths:
-              - path: /
-                service:
-                  identifier: *app
-                  port: http
-        tls:
-          - hosts:
-              - *tsHost
     route:
       canonical:
         annotations:

--- a/kubernetes/apps/downloads/bazarr/uhd/helmrelease.yaml
+++ b/kubernetes/apps/downloads/bazarr/uhd/helmrelease.yaml
@@ -109,19 +109,6 @@ spec:
             port: *port
           metrics:
             port: *metricsPort
-    ingress:
-      tailscale:
-        className: tailscale
-        hosts:
-          - host: &tsHost "{{ .Release.Name }}.kite-harmonic.ts.net"
-            paths:
-              - path: /
-                service:
-                  identifier: *app
-                  port: http
-        tls:
-          - hosts:
-              - *tsHost
     route:
       canonical:
         annotations:

--- a/kubernetes/apps/downloads/lidarr/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/lidarr/app/helmrelease.yaml
@@ -109,19 +109,6 @@ spec:
             port: *port
           metrics:
             port: *metricsPort
-    ingress:
-      tailscale:
-        className: tailscale
-        hosts:
-          - host: &tsHost "{{ .Release.Name }}.kite-harmonic.ts.net"
-            paths:
-              - path: /
-                service:
-                  identifier: *app
-                  port: http
-        tls:
-          - hosts:
-              - *tsHost
     route:
       canonical:
         annotations:

--- a/kubernetes/apps/downloads/openbooks/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/openbooks/app/helmrelease.yaml
@@ -48,19 +48,6 @@ spec:
         ports:
           http:
             port: *port
-    ingress:
-      tailscale:
-        className: tailscale
-        hosts:
-          - host: &tsHost "{{ .Release.Name }}.kite-harmonic.ts.net"
-            paths:
-              - path: /
-                service:
-                  identifier: *app
-                  port: http
-        tls:
-          - hosts:
-              - *tsHost
     route:
       canonical:
         annotations:

--- a/kubernetes/apps/downloads/prowlarr/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/prowlarr/app/helmrelease.yaml
@@ -107,19 +107,6 @@ spec:
             port: *port
           metrics:
             port: *metricsPort
-    ingress:
-      tailscale:
-        className: tailscale
-        hosts:
-          - host: &tsHost "{{ .Release.Name }}.kite-harmonic.ts.net"
-            paths:
-              - path: /
-                service:
-                  identifier: *app
-                  port: http
-        tls:
-          - hosts:
-              - *tsHost
     route:
       canonical:
         annotations:

--- a/kubernetes/apps/downloads/qui/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/qui/app/helmrelease.yaml
@@ -27,7 +27,7 @@ spec:
               QUI__PORT: &port 80
               QUI__OIDC_ENABLED: true
               QUI__OIDC_ISSUER: https://id.zebernst.dev/
-              QUI__OIDC_REDIRECT_URL: https://qui.zebernst.dev/api/auth/oidc/callback
+              QUI__OIDC_REDIRECT_URL: https://qui.jptr.zebernst.dev/api/auth/oidc/callback
               QUI__OIDC_DISABLE_BUILT_IN_LOGIN: true
               QUI__METRICS_ENABLED: true
               QUI__METRICS_HOST: 0.0.0.0
@@ -83,19 +83,6 @@ spec:
             port: *port
           metrics:
             port: *metricsPort
-    ingress:
-      tailscale:
-        className: tailscale
-        hosts:
-          - host: &tsHost "{{ .Release.Name }}.kite-harmonic.ts.net"
-            paths:
-              - path: /
-                service:
-                  identifier: *app
-                  port: http
-        tls:
-          - hosts:
-              - *tsHost
     serviceMonitor:
       qui:
         serviceName: *app
@@ -106,22 +93,10 @@ spec:
             interval: 1m
             scrapeTimeout: 10s
     route:
-      # Staged OIDC cutover: LAN stays primary redirect; Pocket ID must allow both callbacks
-      qui:
-        annotations:
-          gatus.home-operations.com/endpoint: |
-            name: "{{ .Release.Name }}"
-            group: "{{ .Release.Namespace }}"
-        hostnames:
-          - "{{ .Release.Name }}.zebernst.dev"
-        parentRefs:
-          - name: internal
-            namespace: kube-system
-            sectionName: https
       canonical:
         annotations:
           gatus.home-operations.com/endpoint: |
-            name: "{{ .Release.Name }}-jptr"
+            name: "{{ .Release.Name }}"
             group: "{{ .Release.Namespace }}"
         hostnames:
           - "{{ .Release.Name }}.jptr.zebernst.dev"

--- a/kubernetes/apps/downloads/radarr/app/hd/helmrelease.yaml
+++ b/kubernetes/apps/downloads/radarr/app/hd/helmrelease.yaml
@@ -110,19 +110,6 @@ spec:
             port: *port
           metrics:
             port: *metricsPort
-    ingress:
-      tailscale:
-        className: tailscale
-        hosts:
-          - host: &tsHost "{{ .Release.Name }}.kite-harmonic.ts.net"
-            paths:
-              - path: /
-                service:
-                  identifier: *app
-                  port: http
-        tls:
-          - hosts:
-              - *tsHost
     route:
       canonical:
         annotations:

--- a/kubernetes/apps/downloads/radarr/app/uhd/helmrelease.yaml
+++ b/kubernetes/apps/downloads/radarr/app/uhd/helmrelease.yaml
@@ -110,19 +110,6 @@ spec:
             port: *port
           metrics:
             port: *metricsPort
-    ingress:
-      tailscale:
-        className: tailscale
-        hosts:
-          - host: &tsHost "{{ .Release.Name }}.kite-harmonic.ts.net"
-            paths:
-              - path: /
-                service:
-                  identifier: *app
-                  port: http
-        tls:
-          - hosts:
-              - *tsHost
     route:
       canonical:
         annotations:

--- a/kubernetes/apps/downloads/sonarr/app/hd/helmrelease.yaml
+++ b/kubernetes/apps/downloads/sonarr/app/hd/helmrelease.yaml
@@ -108,19 +108,6 @@ spec:
             port: *port
           metrics:
             port: *metricsPort
-    ingress:
-      tailscale:
-        className: tailscale
-        hosts:
-          - host: &tsHost "{{ .Release.Name }}.kite-harmonic.ts.net"
-            paths:
-              - path: /
-                service:
-                  identifier: *app
-                  port: http
-        tls:
-          - hosts:
-              - *tsHost
     route:
       canonical:
         annotations:

--- a/kubernetes/apps/downloads/sonarr/app/uhd/helmrelease.yaml
+++ b/kubernetes/apps/downloads/sonarr/app/uhd/helmrelease.yaml
@@ -108,19 +108,6 @@ spec:
             port: *port
           metrics:
             port: *metricsPort
-    ingress:
-      tailscale:
-        className: tailscale
-        hosts:
-          - host: &tsHost "{{ .Release.Name }}.kite-harmonic.ts.net"
-            paths:
-              - path: /
-                service:
-                  identifier: *app
-                  port: http
-        tls:
-          - hosts:
-              - *tsHost
     route:
       canonical:
         annotations:

--- a/kubernetes/apps/downloads/whisparr/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/whisparr/app/helmrelease.yaml
@@ -73,19 +73,6 @@ spec:
         ports:
           http:
             port: *port
-    ingress:
-      tailscale:
-        className: tailscale
-        hosts:
-          - host: &tsHost "{{ .Release.Name }}.kite-harmonic.ts.net"
-            paths:
-              - path: /
-                service:
-                  identifier: *app
-                  port: http
-        tls:
-          - hosts:
-              - *tsHost
     route:
       canonical:
         annotations:

--- a/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
@@ -53,11 +53,6 @@ spec:
       ui:
         enabled: true
         rollOutPods: true
-        ingress:
-          className: tailscale
-          hosts: [&host "{{ .Release.Name }}.kite-harmonic.ts.net"]
-          tls:
-            - hosts: [*host]
     operator:
       prometheus:
         enabled: true

--- a/kubernetes/apps/media/maintainerr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/maintainerr/app/helmrelease.yaml
@@ -53,19 +53,6 @@ spec:
         ports:
           http:
             port: 6246
-    ingress:
-      tailscale:
-        className: tailscale
-        hosts:
-          - host: &tsHost "{{ .Release.Name }}.kite-harmonic.ts.net"
-            paths:
-              - path: /
-                service:
-                  identifier: *app
-                  port: http
-        tls:
-          - hosts:
-              - *tsHost
     route:
       canonical:
         annotations:

--- a/kubernetes/apps/media/stash/app/helmrelease.yaml
+++ b/kubernetes/apps/media/stash/app/helmrelease.yaml
@@ -84,19 +84,6 @@ spec:
         ports:
           http:
             port: *port
-    ingress:
-      tailscale:
-        className: tailscale
-        hosts:
-          - host: &tsHost "{{ .Release.Name }}.kite-harmonic.ts.net"
-            paths:
-              - path: /
-                service:
-                  identifier: *app
-                  port: http
-        tls:
-          - hosts:
-              - *tsHost
     route:
       canonical:
         annotations:

--- a/kubernetes/apps/media/steam/app/helmrelease.yaml
+++ b/kubernetes/apps/media/steam/app/helmrelease.yaml
@@ -92,19 +92,6 @@ spec:
           s-u3:
             port: 48000
             protocol: UDP
-    ingress:
-      tailscale:
-        className: tailscale
-        hosts:
-          - host: &tsHost "{{ .Release.Name }}.kite-harmonic.ts.net"
-            paths:
-              - path: /
-                service:
-                  identifier: *app
-                  port: http
-        tls:
-          - hosts:
-              - *tsHost
     route:
       canonical:
         annotations:

--- a/kubernetes/apps/media/tautulli/app/helmrelease.yaml
+++ b/kubernetes/apps/media/tautulli/app/helmrelease.yaml
@@ -65,19 +65,6 @@ spec:
         ports:
           http:
             port: *port
-    ingress:
-      tailscale:
-        className: tailscale
-        hosts:
-          - host: &tsHost "{{ .Release.Name }}.kite-harmonic.ts.net"
-            paths:
-              - path: /
-                service:
-                  identifier: *app
-                  port: http
-        tls:
-          - hosts:
-              - *tsHost
     route:
       canonical:
         annotations:

--- a/kubernetes/apps/observability/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/grafana/app/helmrelease.yaml
@@ -380,11 +380,7 @@ spec:
     serviceMonitor:
       enabled: true
     ingress:
-      enabled: true
-      ingressClassName: tailscale
-      hosts: [&host grafana.kite-harmonic.ts.net]
-      tls:
-        - hosts: [*host]
+      enabled: false
     persistence:
       enabled: false
     testFramework:

--- a/kubernetes/apps/observability/karma/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/karma/app/helmrelease.yaml
@@ -50,19 +50,6 @@ spec:
         runAsNonRoot: true
         runAsUser: 568
         runAsGroup: 568
-    ingress:
-      tailscale:
-        className: tailscale
-        hosts:
-          - host: &tsHost karma.kite-harmonic.ts.net
-            paths:
-              - path: /
-                service:
-                  identifier: *app
-                  port: http
-        tls:
-          - hosts:
-              - *tsHost
     route:
       canonical:
         annotations:

--- a/kubernetes/apps/observability/scanopy/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/scanopy/app/helmrelease.yaml
@@ -32,8 +32,7 @@ spec:
             env:
               TZ: America/Chicago
               SCANOPY_LOG_LEVEL: info
-              # Staged OIDC cutover: LAN stays primary; Pocket ID must allow both callbacks
-              SCANOPY_PUBLIC_URL: https://scanopy.zebernst.dev
+              SCANOPY_PUBLIC_URL: https://scanopy.jptr.zebernst.dev
               SCANOPY_WEB_EXTERNAL_PATH: /app/static
               SCANOPY_USE_SECURE_SESSION_COOKIES: "true"
               SCANOPY_DISABLE_PASSWORD_LOGIN: "true"
@@ -71,27 +70,10 @@ spec:
           http:
             port: *port
     route:
-      # Staged OIDC cutover: LAN stays primary; Pocket ID must allow both callbacks
-      scanopy:
-        annotations:
-          gatus.home-operations.com/endpoint: |
-            name: "{{ .Release.Name }}"
-            group: "{{ .Release.Namespace }}"
-            path: /api/health
-        hostnames:
-          - scanopy.zebernst.dev
-        parentRefs:
-          - name: internal
-            namespace: kube-system
-            sectionName: https
-        rules:
-          - backendRefs:
-              - name: *app
-                port: *port
       canonical:
         annotations:
           gatus.home-operations.com/endpoint: |
-            name: "{{ .Release.Name }}-jptr"
+            name: "{{ .Release.Name }}"
             group: "{{ .Release.Namespace }}"
             path: /api/health
         hostnames:

--- a/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
@@ -117,13 +117,7 @@ spec:
                 requests:
                   storage: 1Gi
       ingress:
-        enabled: true
-        ingressClassName: tailscale
-        hosts:
-          - alertmanager.kite-harmonic.ts.net
-        tls:
-          - hosts:
-              - alertmanager.kite-harmonic.ts.net
+        enabled: false
 
     vmagent:
       enabled: true
@@ -184,13 +178,7 @@ spec:
             requests:
               storage: 50Gi
       ingress:
-        enabled: true
-        ingressClassName: tailscale
-        hosts:
-          - victoria-metrics.kite-harmonic.ts.net
-        tls:
-          - hosts:
-              - victoria-metrics.kite-harmonic.ts.net
+        enabled: false
 
     vmalert:
       enabled: true

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -20,14 +20,6 @@ spec:
     monitoring:
       enabled: true
       createPrometheusRules: true
-    ingress:
-      dashboard:
-        ingressClassName: tailscale
-        host:
-          name: &host "rook.kite-harmonic.ts.net"
-          path: /
-        tls:
-          - hosts: [ *host ]
     toolbox:
       enabled: true
     cephClusterSpec:

--- a/kubernetes/apps/self-hosted/atuin/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/atuin/app/helmrelease.yaml
@@ -89,19 +89,6 @@ spec:
           - name: tailscale
             namespace: kube-system
             sectionName: https-canon
-    ingress:
-      tailscale:
-        className: tailscale
-        hosts:
-          - host: &tsHost "{{ .Release.Name }}.kite-harmonic.ts.net"
-            paths:
-              - path: /
-                service:
-                  identifier: *app
-                  port: http
-        tls:
-          - hosts:
-              - *tsHost
     serviceMonitor:
       app:
         endpoints:

--- a/kubernetes/apps/self-hosted/dawarich/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/dawarich/app/helmrelease.yaml
@@ -33,7 +33,7 @@ spec:
               RAILS_ENV: production
               RAILS_LOG_TO_STDOUT: "true"
               RAILS_SERVE_STATIC_FILES: "true"
-              APPLICATION_HOSTS: "timeline.zebernst.dev,timeline.jptr.zebernst.dev,localhost,127.0.0.1"
+              APPLICATION_HOSTS: "timeline.jptr.zebernst.dev,localhost,127.0.0.1"
               APPLICATION_PROTOCOL: https
               TIME_ZONE: America/Chicago
               SELF_HOSTED: "true"
@@ -42,8 +42,7 @@ spec:
               SIDEKIQ_METRICS_URL: http://127.0.0.1:9394/metrics
               OIDC_ISSUER: https://id.zebernst.dev
               OIDC_PROVIDER_NAME: Pocket ID
-              # Staged cutover: LAN stays primary; Pocket ID must allow both callbacks
-              OIDC_REDIRECT_URI: https://timeline.zebernst.dev/users/auth/openid_connect/callback
+              OIDC_REDIRECT_URI: https://timeline.jptr.zebernst.dev/users/auth/openid_connect/callback
               OIDC_AUTO_REGISTER: "true"
               ALLOW_EMAIL_PASSWORD_REGISTRATION: "false"
               ALLOW_EMAIL_PASSWORD_LOGIN: "false"
@@ -144,26 +143,10 @@ spec:
             port: 3000
 
     route:
-      # Staged OIDC cutover: LAN stays primary redirect; Pocket ID must allow both callbacks
-      app:
-        annotations:
-          gatus.home-operations.com/endpoint: |
-            name: "{{ .Release.Name }}"
-            group: "{{ .Release.Namespace }}"
-        hostnames:
-          - timeline.zebernst.dev
-        parentRefs:
-          - name: internal
-            namespace: kube-system
-            sectionName: https
-        rules:
-          - backendRefs:
-              - name: *app
-                port: 3000
       canonical:
         annotations:
           gatus.home-operations.com/endpoint: |
-            name: "{{ .Release.Name }}-jptr"
+            name: "{{ .Release.Name }}"
             group: "{{ .Release.Namespace }}"
         hostnames:
           - timeline.jptr.zebernst.dev

--- a/kubernetes/apps/self-hosted/hajimari/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/hajimari/app/helmrelease.yaml
@@ -34,18 +34,6 @@ spec:
       defaultEnable: true
       namespaceSelector:
         any: true
-    ingress:
-      main:
-        enabled: true
-        ingressClassName: tailscale
-        hosts:
-          - host: &tsHost "{{ .Release.Name }}.kite-harmonic.ts.net"
-            paths:
-              - path: /
-                pathType: Prefix
-        tls:
-          - hosts:
-              - *tsHost
     podAnnotations:
       configmap.reloader.stakater.com/reload: hajimari-settings
     persistence:

--- a/kubernetes/apps/self-hosted/it-tools/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/it-tools/app/helmrelease.yaml
@@ -43,19 +43,6 @@ spec:
         ports:
           http:
             port: 8080
-    ingress:
-      tailscale:
-        className: tailscale
-        hosts:
-          - host: &tsHost "{{ .Release.Name }}.kite-harmonic.ts.net"
-            paths:
-              - path: /
-                service:
-                  identifier: *app
-                  port: http
-        tls:
-          - hosts:
-              - *tsHost
     route:
       canonical:
         annotations:

--- a/kubernetes/apps/self-hosted/nocodb/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/nocodb/app/helmrelease.yaml
@@ -55,19 +55,6 @@ spec:
         ports:
           http:
             port: *port
-    ingress:
-      tailscale:
-        className: tailscale
-        hosts:
-          - host: &tsHost "{{ .Release.Name }}.kite-harmonic.ts.net"
-            paths:
-              - path: /
-                service:
-                  identifier: *app
-                  port: http
-        tls:
-          - hosts:
-              - *tsHost
     route:
       canonical:
         annotations:

--- a/kubernetes/apps/self-hosted/paperless/app/externalsecret.yaml
+++ b/kubernetes/apps/self-hosted/paperless/app/externalsecret.yaml
@@ -28,6 +28,26 @@ spec:
         INIT_POSTGRES_USER: *dbUser
         INIT_POSTGRES_PASS: *dbPass
         INIT_POSTGRES_SUPER_PASS: "{{ .POSTGRES_SUPER_PASS }}"
+        # Pocket ID OIDC — add POCKET_ID_CLIENT_ID / POCKET_ID_CLIENT_SECRET to the 1Password paperless item
+        PAPERLESS_SOCIALACCOUNT_PROVIDERS: |
+          {
+            "openid_connect": {
+              "SCOPE": ["openid", "profile", "email", "groups"],
+              "OAUTH_PKCE_ENABLED": true,
+              "APPS": [
+                {
+                  "provider_id": "pocket-id",
+                  "name": "Pocket ID",
+                  "client_id": "{{ .PAPERLESS_POCKET_ID_CLIENT_ID }}",
+                  "secret": "{{ .PAPERLESS_POCKET_ID_CLIENT_SECRET }}",
+                  "settings": {
+                    "server_url": "https://id.zebernst.dev",
+                    "token_auth_method": "client_secret_basic"
+                  }
+                }
+              ]
+            }
+          }
   dataFrom:
     - extract:
         key: paperless

--- a/kubernetes/apps/self-hosted/paperless/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/paperless/app/helmrelease.yaml
@@ -34,20 +34,22 @@ spec:
               tag: 2.20.15
             env:
               # Configure application
-              PAPERLESS_URL: "https://{{ .Release.Name }}.kite-harmonic.ts.net"
-              # Dual-run jptr companion (OIDC / Gateway cutover verification)
-              PAPERLESS_CSRF_TRUSTED_ORIGINS: "https://{{ .Release.Name }}.jptr.zebernst.dev,https://{{ .Release.Name }}.kite-harmonic.ts.net"
-              PAPERLESS_ALLOWED_HOSTS: "{{ .Release.Name }}.jptr.zebernst.dev,{{ .Release.Name }}.kite-harmonic.ts.net"
-              PAPERLESS_CORS_ALLOWED_HOSTS: "https://{{ .Release.Name }}.jptr.zebernst.dev,https://{{ .Release.Name }}.kite-harmonic.ts.net"
+              PAPERLESS_URL: "https://{{ .Release.Name }}.jptr.zebernst.dev"
+              PAPERLESS_CSRF_TRUSTED_ORIGINS: "https://{{ .Release.Name }}.jptr.zebernst.dev"
+              PAPERLESS_ALLOWED_HOSTS: "{{ .Release.Name }}.jptr.zebernst.dev"
+              PAPERLESS_CORS_ALLOWED_HOSTS: "https://{{ .Release.Name }}.jptr.zebernst.dev"
               PAPERLESS_PORT: &port "8000"
               PAPERLESS_TIME_ZONE: "America/Chicago"
               PAPERLESS_WEBSERVER_WORKERS: "2"
               PAPERLESS_TASK_WORKERS: "2"
-              # Configure Remote User auth
+              # Pocket ID OIDC (django-allauth); client id/secret from paperless-secret
+              PAPERLESS_APPS: allauth.socialaccount.providers.openid_connect
               PAPERLESS_ACCOUNT_ALLOW_SIGNUPS: "false"
-              PAPERLESS_SOCIALACCOUNT_ALLOW_SIGNUPS: "false"
-              PAPERLESS_ENABLE_HTTP_REMOTE_USER: "true"
-              PAPERLESS_HTTP_REMOTE_USER_HEADER_NAME: HTTP_TAILSCALE_USER_LOGIN
+              PAPERLESS_SOCIALACCOUNT_ALLOW_SIGNUPS: "true"
+              PAPERLESS_SOCIAL_AUTO_SIGNUP: "true"
+              PAPERLESS_DISABLE_REGULAR_LOGIN: "true"
+              PAPERLESS_REDIRECT_LOGIN_TO_SSO: "true"
+              PAPERLESS_LOGOUT_REDIRECT_URL: https://id.zebernst.dev/api/oidc/end-session
               # Configure folders
               PAPERLESS_CONSUMPTION_DIR: /data/nas/incoming
               PAPERLESS_DATA_DIR: /data/local/data
@@ -126,22 +128,7 @@ spec:
           metrics:
             port: *metricsPort
 
-    ingress:
-      tailscale:
-        className: tailscale
-        hosts:
-          - host: &tsHost "{{ .Release.Name }}.kite-harmonic.ts.net"
-            paths:
-              - path: /
-                service:
-                  identifier: *app
-                  port: http
-        tls:
-          - hosts:
-              - *tsHost
-
     route:
-      # Dual-run with Tailscale Ingress until OIDC cutover drops ts.net
       canonical:
         annotations:
           gatus.home-operations.com/endpoint: |


### PR DESCRIPTION
## Summary
- Delete every `*.kite-harmonic.ts.net` Tailscale Ingress (arr stack, grafana, paperless, pocket-id companion, hubble, rook, victoria, etc.) — all already have `*.jptr.zebernst.dev` HTTPS routes
- **Paperless**: flip URL/hosts to jptr; replace Tailscale remote-user auth with Pocket ID OIDC (django-allauth); `PAPERLESS_SOCIALACCOUNT_PROVIDERS` rendered from ExternalSecret
- **qui / dawarich / scanopy**: flip OIDC redirect / public URL to jptr; drop LAN `internal` HTTPRoutes
- **Keep LAN**: `pocket-id` (`id.zebernst.dev`) and `mc-router`

## Manual step (required before paperless reconciles)
Add to the 1Password `paperless` item:
- `POCKET_ID_CLIENT_ID`
- `POCKET_ID_CLIENT_SECRET`

Pocket ID callback (provider_id `pocket-id`):
`https://paperless.jptr.zebernst.dev/accounts/oidc/pocket-id/login/callback/`

## Test plan
- [ ] `flate test hr` / `ks` green (verified locally)
- [ ] Grafana login still works at `grafana.jptr.zebernst.dev` (Ingress gone)
- [ ] After 1P fields exist: paperless SSO login at jptr
- [ ] qui / timeline / scanopy OIDC against jptr callbacks
- [ ] Confirm no remaining Tailscale Ingresses: `kubectl get ingress -A`
- [ ] pocket-id still reachable on LAN; mc-router unchanged

Made with [Cursor](https://cursor.com)