### PR TITLE
feat(task): add targeted ExternalSecret force-sync task

### DIFF
--- a/.taskfiles/kubernetes/Taskfile.yaml
+++ b/.taskfiles/kubernetes/Taskfile.yaml
@@ -29,8 +29,17 @@ tasks:
       - kubectl node-shell --version
       - which kubectl
 
+  sync-secret:
+    desc: Force-sync an ExternalSecret [NS=required] [APP=required]
+    cmd: kubectl --namespace {{.NS}} annotate externalsecret {{.APP}} force-sync="{{now | unixEpoch}}" --overwrite
+    requires:
+      vars: [NS, APP]
+    preconditions:
+      - kubectl --namespace {{.NS}} get externalsecret {{.APP}}
+      - which kubectl
+
   sync-secrets:
-    desc: Sync all ExternalSecrets
+    desc: Force-sync all ExternalSecrets
     cmds:
       - for: { var: SECRETS, split: "\n" }
         cmd: kubectl --namespace {{splitList "," .ITEM | first}} annotate externalsecret {{splitList "," .ITEM | last}} force-sync="{{now | unixEpoch}}" --overwrite


### PR DESCRIPTION
## Summary
After editing a secret in 1Password, you can force ESO to reconcile just that ExternalSecret instead of waiting on `refreshInterval` or blasting every secret in the cluster.

```bash
task kubernetes:sync-secret NS=<namespace> APP=<externalsecret-name>
```

`task kubernetes:sync-secrets` still force-syncs everything; its description was clarified to match.

## Test plan
- [ ] `task --list` shows `kubernetes:sync-secret`
- [ ] `task kubernetes:sync-secret NS=<ns> APP=<name>` annotates the ExternalSecret and ESO refreshes the target Secret
- [ ] Missing `NS`/`APP` or a nonexistent ExternalSecret fails the precondition
