### PR TITLE
fix(paperless): map OIDC username from preferred_username

### DIFF
--- a/kubernetes/apps/self-hosted/paperless/app/externalsecret.yaml
+++ b/kubernetes/apps/self-hosted/paperless/app/externalsecret.yaml
@@ -42,7 +42,10 @@ spec:
                   "secret": "{{ .PAPERLESS_POCKET_ID_CLIENT_SECRET }}",
                   "settings": {
                     "server_url": "https://id.zebernst.dev",
-                    "token_auth_method": "client_secret_basic"
+                    "token_auth_method": "client_secret_basic",
+                    "claims": {
+                      "username": "preferred_username"
+                    }
                   }
                 }
               ]


### PR DESCRIPTION
## Summary
- Set django-allauth OIDC \`claims.username\` to \`preferred_username\` (same as Grafana login mapping)
- Prevents new SSO signups from becoming email-derived non-admin users

## Ops note
Live DB already had Pocket ID linked to non-admin \`zach\`; relink social account → \`zebernst\` (superuser) and drop the orphan.

## Test plan
- [ ] Log out / clear session at paperless.jptr.zebernst.dev
- [ ] SSO login lands as zebernst with admin UI (no 403 on /api/ui_settings/)

Made with [Cursor](https://cursor.com)