### PR TITLE
fix(qui): drop trailing slash from OIDC issuer URL

### DIFF
--- a/kubernetes/apps/downloads/qui/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/qui/app/helmrelease.yaml
@@ -26,7 +26,7 @@ spec:
               QUI__HOST: 0.0.0.0
               QUI__PORT: &port 80
               QUI__OIDC_ENABLED: true
-              QUI__OIDC_ISSUER: https://id.zebernst.dev/
+              QUI__OIDC_ISSUER: https://id.zebernst.dev
               QUI__OIDC_REDIRECT_URL: https://qui.jptr.zebernst.dev/api/auth/oidc/callback
               QUI__OIDC_DISABLE_BUILT_IN_LOGIN: true
               QUI__METRICS_ENABLED: true


### PR DESCRIPTION
## Summary
- Change \`QUI__OIDC_ISSUER\` from \`https://id.zebernst.dev/\` to \`https://id.zebernst.dev\` to match Pocket ID discovery (\`issuer\` claim)

## Test plan
- [ ] Qui pod restarts without \`issuer URL provided to client did not match\` warn
- [ ] OIDC login works at \`qui.jptr.zebernst.dev\`

Made with [Cursor](https://cursor.com)