### PR TITLE
fix(gatus): probe rook dashboard via ClusterIP

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/httproute.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/httproute.yaml
@@ -5,9 +5,14 @@ kind: HTTPRoute
 metadata:
   name: rook-ceph-dashboard-canonical
   annotations:
+    # Probe the ClusterIP: Cilium Envoy same-node hairpin to this hostNetwork
+    # mgr backend times out (upstream connect timeout → 503). Vanity URL still
+    # works for Tailscale clients and for in-cluster clients on other nodes.
+    # See cilium/cilium#44529.
     gatus.home-operations.com/endpoint: |
       name: rook
       group: rook-ceph
+      url: http://rook-ceph-mgr-dashboard.rook-ceph.svc:7000
 spec:
   hostnames:
     - rook.jptr.zebernst.dev


### PR DESCRIPTION
## Summary

In-cluster probes of `rook.jptr.zebernst.dev` false-alert: Cilium Envoy on the same node as the hostNetwork Ceph mgr cannot reach `192.168.10.10:7000` (upstream connect timeout → 503). Cross-node and Tailscale clients are fine. Point Gatus at the dashboard ClusterIP so the alert tracks backend health without that hairpin; the vanity HTTPRoute is unchanged for real clients.

Reproduced 100% same-node vs cross-node; tracked upstream as [cilium/cilium#44529](https://github.com/cilium/cilium/issues/44529).

## Test plan
- [ ] After Flux reconcile, private Gatus endpoint `rook-ceph/rook` probes `http://rook-ceph-mgr-dashboard.rook-ceph.svc:7000`
- [ ] `GatusEndpointDown` for rook clears
- [ ] `https://rook.jptr.zebernst.dev/` still returns 200 from a Tailscale client
