### PR TITLE
feat(observability): Gateway API state metrics, dashboards, and alerts

### DIFF
--- a/kubernetes/apps/observability/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/grafana/app/helmrelease.yaml
@@ -212,6 +212,42 @@ spec:
           revision: 1
           datasource:
             - { name: DS_AFRANET_PROMETHEUS, value: Prometheus }
+        # Kuadrant gateway-api-state-metrics (kube-state-metrics CustomResourceState)
+        gateway-api-gatewayclasses:
+          # renovate: depName="Gateway API State / GatewayClasses"
+          gnetId: 19432
+          revision: 2
+          datasource: Prometheus
+        gateway-api-gateways:
+          # renovate: depName="Gateway API State / Gateways"
+          gnetId: 19433
+          revision: 2
+          datasource: Prometheus
+        gateway-api-httproutes:
+          # renovate: depName="Gateway API State / HTTPRoutes"
+          gnetId: 19434
+          revision: 2
+          datasource: Prometheus
+        gateway-api-grpcroutes:
+          # renovate: depName="Gateway API State / GRPCRoutes"
+          gnetId: 19570
+          revision: 1
+          datasource: Prometheus
+        gateway-api-tcproutes:
+          # renovate: depName="Gateway API State / TCPRoutes"
+          gnetId: 19571
+          revision: 1
+          datasource: Prometheus
+        gateway-api-tlsroutes:
+          # renovate: depName="Gateway API State / TLSRoutes"
+          gnetId: 19572
+          revision: 1
+          datasource: Prometheus
+        gateway-api-udproutes:
+          # renovate: depName="Gateway API State / UDPRoutes"
+          gnetId: 19573
+          revision: 1
+          datasource: Prometheus
         hubble:
           url: https://raw.githubusercontent.com/cilium/cilium/refs/heads/main/install/kubernetes/cilium/files/hubble/dashboards/hubble-dashboard.json
           datasource:

--- a/kubernetes/apps/observability/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/grafana/app/helmrelease.yaml
@@ -190,6 +190,13 @@ spec:
           gnetId: 15038
           revision: 3
           datasource: Prometheus
+        # Community Cilium overview — complements the upstream agent/operator dashboards
+        cilium-network:
+          # renovate: depName="Cilium Network Monitoring"
+          gnetId: 24056
+          revision: 1
+          datasource:
+            - { name: DS_PROMETHEUS, value: Prometheus }
         cilium-agent:
           url: https://raw.githubusercontent.com/cilium/cilium/refs/heads/main/install/kubernetes/cilium/files/cilium-agent/dashboards/cilium-dashboard.json
           datasource:
@@ -198,6 +205,13 @@ spec:
           url: https://raw.githubusercontent.com/cilium/cilium/refs/heads/main/install/kubernetes/cilium/files/cilium-operator/dashboards/cilium-operator-dashboard.json
           datasource:
             - { name: DS_PROMETHEUS, value: Prometheus }
+        # Cilium Gateway API / L7 terminates in cilium-envoy; scrape already enabled
+        cilium-envoy:
+          # renovate: depName="Envoy Proxy Monitoring gRPC"
+          gnetId: 23239
+          revision: 1
+          datasource:
+            - { name: DS_AFRANET_PROMETHEUS, value: Prometheus }
         hubble:
           url: https://raw.githubusercontent.com/cilium/cilium/refs/heads/main/install/kubernetes/cilium/files/hubble/dashboards/hubble-dashboard.json
           datasource:

--- a/kubernetes/apps/observability/victoria-metrics/app/gateway-api-state-metrics.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/gateway-api-state-metrics.yaml
@@ -1,0 +1,524 @@
+# yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.14.0/configmap.json
+---
+# Kuadrant gateway-api-state-metrics CustomResourceState for kube-state-metrics.
+# Source: https://github.com/Kuadrant/gateway-api-state-metrics (config/default)
+# GVKs adjusted to versions served by this cluster.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kube-state-metrics-gateway-api
+data:
+  config.yaml: |
+    kind: CustomResourceStateMetrics
+    spec:
+      resources:
+        - groupVersionKind:
+            group: gateway.networking.k8s.io
+            kind: "Gateway"
+            version: "v1"
+          metricNamePrefix: gatewayapi_gateway
+          labelsFromPath:
+            name:
+            - metadata
+            - name
+            namespace:
+            - metadata
+            - namespace
+          metrics:
+          - name: "info"
+            help: "Gateway information"
+            each:
+              type: Info
+              info:
+                labelsFromPath:
+                  gatewayclass_name: [spec, gatewayClassName]
+          - name: "labels"
+            help: "Kubernetes labels converted to Prometheus labels."
+            each:
+              type: Info
+              info:
+                path: [metadata]
+                labelsFromPath:
+                  "*": [labels]
+          - name: "created"
+            help: "created timestamp"
+            each:
+              type: Gauge
+              gauge:
+                path: [metadata, creationTimestamp]
+          - name: "deleted"
+            help: "deletion timestamp"
+            each:
+              type: Gauge
+              gauge:
+                path: [metadata, deletionTimestamp]
+                nilIsZero: true
+          - name: "listener_info"
+            help: "Gateway listener information"
+            each:
+              type: Info
+              info:
+                path: [spec, listeners]
+                labelsFromPath:
+                  listener_name: ["name"]
+                  port: ["port"]
+                  protocol: ["protocol"]
+                  hostname: ["hostname"]
+                  tls_mode: ["tls","mode"]
+                  allowed_routes_namespaces_from: ["allowedRoutes", "namespaces", "from"]
+          - name: "status"
+            help: "status condition"
+            each:
+              type: Gauge
+              gauge:
+                path: [status, conditions]
+                labelsFromPath:
+                  type: ["type"]
+                valueFrom: ["status"]
+          - name: "status_listener_attached_routes"
+            help: "Number of attached routes for a listener"
+            each:
+              type: Gauge
+              gauge:
+                path: [status, listeners]
+                labelsFromPath:
+                  listener_name: ["name"]
+                valueFrom: ["attachedRoutes"]
+          - name: "status_address_info"
+            help: "Gateway address types and values"
+            each:
+              type: Info
+              info:
+                path: [status, addresses]
+                labelsFromPath:
+                  type: ["type"]
+                  value: ["value"]
+        - groupVersionKind:
+            group: gateway.networking.k8s.io
+            kind: "GatewayClass"
+            version: "v1"
+          metricNamePrefix: gatewayapi_gatewayclass
+          labelsFromPath:
+            name:
+            - metadata
+            - name
+          metrics:
+          - name: "info"
+            help: "GatewayClass information"
+            each:
+              type: Info
+              info:
+                labelsFromPath:
+                  controller_name: [spec, controllerName]
+          - name: "labels"
+            help: "Kubernetes labels converted to Prometheus labels."
+            each:
+              type: Info
+              info:
+                path: [metadata]
+                labelsFromPath:
+                  "*": [labels]
+          - name: "created"
+            help: "created timestamp"
+            each:
+              type: Gauge
+              gauge:
+                path: [metadata, creationTimestamp]
+          - name: "deleted"
+            help: "deletion timestamp"
+            each:
+              type: Gauge
+              gauge:
+                path: [metadata, deletionTimestamp]
+                nilIsZero: true
+          - name: "status"
+            help: "status condition"
+            each:
+              type: Gauge
+              gauge:
+                path: [status, conditions]
+                labelsFromPath:
+                  type: ["type"]
+                valueFrom: ["status"]
+          - name: "status_supported_features"
+            help: "List of supported features for the GatewayClass"
+            each:
+              type: Info
+              info:
+                path: [status, supportedFeatures]
+                labelsFromPath:
+                  features: []
+        - groupVersionKind:
+            group: gateway.networking.k8s.io
+            kind: "HTTPRoute"
+            version: "v1"
+          metricNamePrefix: gatewayapi_httproute
+          labelsFromPath:
+            name:
+            - metadata
+            - name
+            namespace:
+            - metadata
+            - namespace
+          metrics:
+          - name: "labels"
+            help: "Kubernetes labels converted to Prometheus labels."
+            each:
+              type: Info
+              info:
+                path: [metadata]
+                labelsFromPath:
+                  "*": [labels]
+          - name: "created"
+            help: "created timestamp"
+            each:
+              type: Gauge
+              gauge:
+                path: [metadata, creationTimestamp]
+          - name: "deleted"
+            help: "deletion timestamp"
+            each:
+              type: Gauge
+              gauge:
+                path: [metadata, deletionTimestamp]
+                nilIsZero: true
+          - name: "hostname_info"
+            help: "Hostname information"
+            each:
+              type: Info
+              info:
+                path: [spec, hostnames]
+                labelsFromPath:
+                  hostname: []
+          - name: "parent_info"
+            help: "Parent references that the httproute wants to be attached to"
+            each:
+              type: Info
+              info:
+                path: [spec, parentRefs]
+                labelsFromPath:
+                  parent_group: ["group"]
+                  parent_kind: ["kind"]
+                  parent_name: ["name"]
+                  parent_namespace: ["namespace"]
+                  parent_section_name: ["sectionName"]
+                  parent_port: ["port"]
+          - name: "status_parent_info"
+            help: "Parent references that the httproute is attached to"
+            each:
+              type: Info
+              info:
+                path: [status, parents]
+                labelsFromPath:
+                  controller_name: ["controllerName"]
+                  parent_group: ["parentRef", "group"]
+                  parent_kind: ["parentRef", "kind"]
+                  parent_name: ["parentRef", "name"]
+                  parent_namespace: ["parentRef", "namespace"]
+                  parent_section_name: ["parentRef", "sectionName"]
+                  parent_port: ["parentRef", "port"]
+        - groupVersionKind:
+            group: gateway.networking.k8s.io
+            kind: "GRPCRoute"
+            version: "v1"
+          metricNamePrefix: gatewayapi_grpcroute
+          labelsFromPath:
+            name:
+            - metadata
+            - name
+            namespace:
+            - metadata
+            - namespace
+          metrics:
+          - name: "labels"
+            help: "Kubernetes labels converted to Prometheus labels."
+            each:
+              type: Info
+              info:
+                path: [metadata]
+                labelsFromPath:
+                  "*": [labels]
+          - name: "created"
+            help: "created timestamp"
+            each:
+              type: Gauge
+              gauge:
+                path: [metadata, creationTimestamp]
+          - name: "deleted"
+            help: "deletion timestamp"
+            each:
+              type: Gauge
+              gauge:
+                path: [metadata, deletionTimestamp]
+                nilIsZero: true
+          - name: "hostname_info"
+            help: "Hostname information"
+            each:
+              type: Info
+              info:
+                path: [spec, hostnames]
+                labelsFromPath:
+                  hostname: []
+          - name: "parent_info"
+            help: "Parent references that the grpcroute wants to be attached to"
+            each:
+              type: Info
+              info:
+                path: [spec, parentRefs]
+                labelsFromPath:
+                  parent_group: ["group"]
+                  parent_kind: ["kind"]
+                  parent_name: ["name"]
+                  parent_namespace: ["namespace"]
+                  parent_section_name: ["sectionName"]
+                  parent_port: ["port"]
+          - name: "status_parent_info"
+            help: "Parent references that the grpcroute is attached to"
+            each:
+              type: Info
+              info:
+                path: [status, parents]
+                labelsFromPath:
+                  controller_name: ["controllerName"]
+                  parent_group: ["parentRef", "group"]
+                  parent_kind: ["parentRef", "kind"]
+                  parent_name: ["parentRef", "name"]
+                  parent_namespace: ["parentRef", "namespace"]
+                  parent_section_name: ["parentRef", "sectionName"]
+                  parent_port: ["parentRef", "port"]
+        - groupVersionKind:
+            group: gateway.networking.k8s.io
+            kind: "TCPRoute"
+            version: "v1alpha2"
+          metricNamePrefix: gatewayapi_tcproute
+          labelsFromPath:
+            name:
+            - metadata
+            - name
+            namespace:
+            - metadata
+            - namespace
+          metrics:
+          - name: "labels"
+            help: "Kubernetes labels converted to Prometheus labels."
+            each:
+              type: Info
+              info:
+                path: [metadata]
+                labelsFromPath:
+                  "*": [labels]
+          - name: "created"
+            help: "created timestamp"
+            each:
+              type: Gauge
+              gauge:
+                path: [metadata, creationTimestamp]
+          - name: "deleted"
+            help: "deletion timestamp"
+            each:
+              type: Gauge
+              gauge:
+                path: [metadata, deletionTimestamp]
+                nilIsZero: true
+          - name: "parent_info"
+            help: "Parent references that the tcproute wants to be attached to"
+            each:
+              type: Info
+              info:
+                path: [spec, parentRefs]
+                labelsFromPath:
+                  parent_group: ["group"]
+                  parent_kind: ["kind"]
+                  parent_name: ["name"]
+                  parent_namespace: ["namespace"]
+                  parent_section_name: ["sectionName"]
+                  parent_port: ["port"]
+          - name: "status_parent_info"
+            help: "Parent references that the tcproute is attached to"
+            each:
+              type: Info
+              info:
+                path: [status, parents]
+                labelsFromPath:
+                  controller_name: ["controllerName"]
+                  parent_group: ["parentRef", "group"]
+                  parent_kind: ["parentRef", "kind"]
+                  parent_name: ["parentRef", "name"]
+                  parent_namespace: ["parentRef", "namespace"]
+                  parent_section_name: ["parentRef", "sectionName"]
+                  parent_port: ["parentRef", "port"]
+        - groupVersionKind:
+            group: gateway.networking.k8s.io
+            kind: "TLSRoute"
+            version: "v1alpha2"
+          metricNamePrefix: gatewayapi_tlsroute
+          labelsFromPath:
+            name:
+            - metadata
+            - name
+            namespace:
+            - metadata
+            - namespace
+          metrics:
+          - name: "labels"
+            help: "Kubernetes labels converted to Prometheus labels."
+            each:
+              type: Info
+              info:
+                path: [metadata]
+                labelsFromPath:
+                  "*": [labels]
+          - name: "created"
+            help: "created timestamp"
+            each:
+              type: Gauge
+              gauge:
+                path: [metadata, creationTimestamp]
+          - name: "deleted"
+            help: "deletion timestamp"
+            each:
+              type: Gauge
+              gauge:
+                path: [metadata, deletionTimestamp]
+                nilIsZero: true
+          - name: "hostname_info"
+            help: "Hostname information"
+            each:
+              type: Info
+              info:
+                path: [spec, hostnames]
+                labelsFromPath:
+                  hostname: []
+          - name: "parent_info"
+            help: "Parent references that the tlsroute wants to be attached to"
+            each:
+              type: Info
+              info:
+                path: [spec, parentRefs]
+                labelsFromPath:
+                  parent_group: ["group"]
+                  parent_kind: ["kind"]
+                  parent_name: ["name"]
+                  parent_namespace: ["namespace"]
+                  parent_section_name: ["sectionName"]
+                  parent_port: ["port"]
+          - name: "status_parent_info"
+            help: "Parent references that the tlsroute is attached to"
+            each:
+              type: Info
+              info:
+                path: [status, parents]
+                labelsFromPath:
+                  controller_name: ["controllerName"]
+                  parent_group: ["parentRef", "group"]
+                  parent_kind: ["parentRef", "kind"]
+                  parent_name: ["parentRef", "name"]
+                  parent_namespace: ["parentRef", "namespace"]
+                  parent_section_name: ["parentRef", "sectionName"]
+                  parent_port: ["parentRef", "port"]
+        - groupVersionKind:
+            group: gateway.networking.k8s.io
+            kind: "UDPRoute"
+            version: "v1alpha2"
+          metricNamePrefix: gatewayapi_udproute
+          labelsFromPath:
+            name:
+            - metadata
+            - name
+            namespace:
+            - metadata
+            - namespace
+          metrics:
+          - name: "labels"
+            help: "Kubernetes labels converted to Prometheus labels."
+            each:
+              type: Info
+              info:
+                path: [metadata]
+                labelsFromPath:
+                  "*": [labels]
+          - name: "created"
+            help: "created timestamp"
+            each:
+              type: Gauge
+              gauge:
+                path: [metadata, creationTimestamp]
+          - name: "deleted"
+            help: "deletion timestamp"
+            each:
+              type: Gauge
+              gauge:
+                path: [metadata, deletionTimestamp]
+                nilIsZero: true
+          - name: "parent_info"
+            help: "Parent references that the udproute wants to be attached to"
+            each:
+              type: Info
+              info:
+                path: [spec, parentRefs]
+                labelsFromPath:
+                  parent_group: ["group"]
+                  parent_kind: ["kind"]
+                  parent_name: ["name"]
+                  parent_namespace: ["namespace"]
+                  parent_section_name: ["sectionName"]
+                  parent_port: ["port"]
+          - name: "status_parent_info"
+            help: "Parent references that the udproute is attached to"
+            each:
+              type: Info
+              info:
+                path: [status, parents]
+                labelsFromPath:
+                  controller_name: ["controllerName"]
+                  parent_group: ["parentRef", "group"]
+                  parent_kind: ["parentRef", "kind"]
+                  parent_name: ["parentRef", "name"]
+                  parent_namespace: ["parentRef", "namespace"]
+                  parent_section_name: ["parentRef", "sectionName"]
+                  parent_port: ["parentRef", "port"]
+        - groupVersionKind:
+            group: gateway.networking.k8s.io
+            kind: "BackendTLSPolicy"
+            version: "v1alpha3"
+          metricNamePrefix: gatewayapi_backendtlspolicy
+          labelsFromPath:
+            name:
+            - metadata
+            - name
+            namespace:
+            - metadata
+            - namespace
+          metrics:
+          - name: "labels"
+            help: "Kubernetes labels converted to Prometheus labels."
+            each:
+              type: Info
+              info:
+                path: [metadata]
+                labelsFromPath:
+                  "*": [labels]
+          - name: "created"
+            help: "created timestamp"
+            each:
+              type: Gauge
+              gauge:
+                path: [metadata, creationTimestamp]
+          - name: "deleted"
+            help: "deletion timestamp"
+            each:
+              type: Gauge
+              gauge:
+                path: [metadata, deletionTimestamp]
+                nilIsZero: true
+          - name: "target_info"
+            help: "Target references that the backendtlspolicy wants to be attached to"
+            each:
+              type: Info
+              info:
+                path: [spec, targetRef]
+                labelsFromPath:
+                  target_group: ["group"]
+                  target_kind: ["kind"]
+                  target_name: ["name"]
+                  target_namespace: ["namespace"]

--- a/kubernetes/apps/observability/victoria-metrics/app/gateway-api-state-metrics.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/gateway-api-state-metrics.yaml
@@ -84,6 +84,36 @@ data:
                 labelsFromPath:
                   listener_name: ["name"]
                 valueFrom: ["attachedRoutes"]
+          # Local addition (not upstream): per-listener condition gauges. A Gateway
+          # can be Programmed while an individual listener fails, e.g. a missing
+          # TLS certificate Secret sets ResolvedRefs=False on that listener only.
+          - name: "status_listener_accepted"
+            help: "Accepted condition of each Gateway listener (1 = True)"
+            each:
+              type: Gauge
+              gauge:
+                path: [status, listeners]
+                labelsFromPath:
+                  listener_name: ["name"]
+                valueFrom: ["conditions", "[type=Accepted]", "status"]
+          - name: "status_listener_programmed"
+            help: "Programmed condition of each Gateway listener (1 = True)"
+            each:
+              type: Gauge
+              gauge:
+                path: [status, listeners]
+                labelsFromPath:
+                  listener_name: ["name"]
+                valueFrom: ["conditions", "[type=Programmed]", "status"]
+          - name: "status_listener_resolved_refs"
+            help: "ResolvedRefs condition of each Gateway listener (1 = True)"
+            each:
+              type: Gauge
+              gauge:
+                path: [status, listeners]
+                labelsFromPath:
+                  listener_name: ["name"]
+                valueFrom: ["conditions", "[type=ResolvedRefs]", "status"]
           - name: "status_address_info"
             help: "Gateway address types and values"
             each:

--- a/kubernetes/apps/observability/victoria-metrics/app/gateway-api-state-metrics.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/gateway-api-state-metrics.yaml
@@ -217,6 +217,38 @@ data:
                   parent_namespace: ["parentRef", "namespace"]
                   parent_section_name: ["parentRef", "sectionName"]
                   parent_port: ["parentRef", "port"]
+          # Local addition (not upstream): per-parent condition gauges so route
+          # attachment failures are alertable, not just observable.
+          - name: "status_parent_accepted"
+            help: "Accepted condition of the httproute for each parent reference (1 = True)"
+            each:
+              type: Gauge
+              gauge:
+                path: [status, parents]
+                labelsFromPath:
+                  controller_name: ["controllerName"]
+                  parent_group: ["parentRef", "group"]
+                  parent_kind: ["parentRef", "kind"]
+                  parent_name: ["parentRef", "name"]
+                  parent_namespace: ["parentRef", "namespace"]
+                  parent_section_name: ["parentRef", "sectionName"]
+                  parent_port: ["parentRef", "port"]
+                valueFrom: ["conditions", "[type=Accepted]", "status"]
+          - name: "status_parent_resolved_refs"
+            help: "ResolvedRefs condition of the httproute for each parent reference (1 = True)"
+            each:
+              type: Gauge
+              gauge:
+                path: [status, parents]
+                labelsFromPath:
+                  controller_name: ["controllerName"]
+                  parent_group: ["parentRef", "group"]
+                  parent_kind: ["parentRef", "kind"]
+                  parent_name: ["parentRef", "name"]
+                  parent_namespace: ["parentRef", "namespace"]
+                  parent_section_name: ["parentRef", "sectionName"]
+                  parent_port: ["parentRef", "port"]
+                valueFrom: ["conditions", "[type=ResolvedRefs]", "status"]
         - groupVersionKind:
             group: gateway.networking.k8s.io
             kind: "GRPCRoute"
@@ -286,6 +318,38 @@ data:
                   parent_namespace: ["parentRef", "namespace"]
                   parent_section_name: ["parentRef", "sectionName"]
                   parent_port: ["parentRef", "port"]
+          # Local addition (not upstream): per-parent condition gauges so route
+          # attachment failures are alertable, not just observable.
+          - name: "status_parent_accepted"
+            help: "Accepted condition of the grpcroute for each parent reference (1 = True)"
+            each:
+              type: Gauge
+              gauge:
+                path: [status, parents]
+                labelsFromPath:
+                  controller_name: ["controllerName"]
+                  parent_group: ["parentRef", "group"]
+                  parent_kind: ["parentRef", "kind"]
+                  parent_name: ["parentRef", "name"]
+                  parent_namespace: ["parentRef", "namespace"]
+                  parent_section_name: ["parentRef", "sectionName"]
+                  parent_port: ["parentRef", "port"]
+                valueFrom: ["conditions", "[type=Accepted]", "status"]
+          - name: "status_parent_resolved_refs"
+            help: "ResolvedRefs condition of the grpcroute for each parent reference (1 = True)"
+            each:
+              type: Gauge
+              gauge:
+                path: [status, parents]
+                labelsFromPath:
+                  controller_name: ["controllerName"]
+                  parent_group: ["parentRef", "group"]
+                  parent_kind: ["parentRef", "kind"]
+                  parent_name: ["parentRef", "name"]
+                  parent_namespace: ["parentRef", "namespace"]
+                  parent_section_name: ["parentRef", "sectionName"]
+                  parent_port: ["parentRef", "port"]
+                valueFrom: ["conditions", "[type=ResolvedRefs]", "status"]
         - groupVersionKind:
             group: gateway.networking.k8s.io
             kind: "TCPRoute"
@@ -347,6 +411,38 @@ data:
                   parent_namespace: ["parentRef", "namespace"]
                   parent_section_name: ["parentRef", "sectionName"]
                   parent_port: ["parentRef", "port"]
+          # Local addition (not upstream): per-parent condition gauges so route
+          # attachment failures are alertable, not just observable.
+          - name: "status_parent_accepted"
+            help: "Accepted condition of the tcproute for each parent reference (1 = True)"
+            each:
+              type: Gauge
+              gauge:
+                path: [status, parents]
+                labelsFromPath:
+                  controller_name: ["controllerName"]
+                  parent_group: ["parentRef", "group"]
+                  parent_kind: ["parentRef", "kind"]
+                  parent_name: ["parentRef", "name"]
+                  parent_namespace: ["parentRef", "namespace"]
+                  parent_section_name: ["parentRef", "sectionName"]
+                  parent_port: ["parentRef", "port"]
+                valueFrom: ["conditions", "[type=Accepted]", "status"]
+          - name: "status_parent_resolved_refs"
+            help: "ResolvedRefs condition of the tcproute for each parent reference (1 = True)"
+            each:
+              type: Gauge
+              gauge:
+                path: [status, parents]
+                labelsFromPath:
+                  controller_name: ["controllerName"]
+                  parent_group: ["parentRef", "group"]
+                  parent_kind: ["parentRef", "kind"]
+                  parent_name: ["parentRef", "name"]
+                  parent_namespace: ["parentRef", "namespace"]
+                  parent_section_name: ["parentRef", "sectionName"]
+                  parent_port: ["parentRef", "port"]
+                valueFrom: ["conditions", "[type=ResolvedRefs]", "status"]
         - groupVersionKind:
             group: gateway.networking.k8s.io
             kind: "TLSRoute"
@@ -416,6 +512,38 @@ data:
                   parent_namespace: ["parentRef", "namespace"]
                   parent_section_name: ["parentRef", "sectionName"]
                   parent_port: ["parentRef", "port"]
+          # Local addition (not upstream): per-parent condition gauges so route
+          # attachment failures are alertable, not just observable.
+          - name: "status_parent_accepted"
+            help: "Accepted condition of the tlsroute for each parent reference (1 = True)"
+            each:
+              type: Gauge
+              gauge:
+                path: [status, parents]
+                labelsFromPath:
+                  controller_name: ["controllerName"]
+                  parent_group: ["parentRef", "group"]
+                  parent_kind: ["parentRef", "kind"]
+                  parent_name: ["parentRef", "name"]
+                  parent_namespace: ["parentRef", "namespace"]
+                  parent_section_name: ["parentRef", "sectionName"]
+                  parent_port: ["parentRef", "port"]
+                valueFrom: ["conditions", "[type=Accepted]", "status"]
+          - name: "status_parent_resolved_refs"
+            help: "ResolvedRefs condition of the tlsroute for each parent reference (1 = True)"
+            each:
+              type: Gauge
+              gauge:
+                path: [status, parents]
+                labelsFromPath:
+                  controller_name: ["controllerName"]
+                  parent_group: ["parentRef", "group"]
+                  parent_kind: ["parentRef", "kind"]
+                  parent_name: ["parentRef", "name"]
+                  parent_namespace: ["parentRef", "namespace"]
+                  parent_section_name: ["parentRef", "sectionName"]
+                  parent_port: ["parentRef", "port"]
+                valueFrom: ["conditions", "[type=ResolvedRefs]", "status"]
         - groupVersionKind:
             group: gateway.networking.k8s.io
             kind: "UDPRoute"
@@ -477,6 +605,38 @@ data:
                   parent_namespace: ["parentRef", "namespace"]
                   parent_section_name: ["parentRef", "sectionName"]
                   parent_port: ["parentRef", "port"]
+          # Local addition (not upstream): per-parent condition gauges so route
+          # attachment failures are alertable, not just observable.
+          - name: "status_parent_accepted"
+            help: "Accepted condition of the udproute for each parent reference (1 = True)"
+            each:
+              type: Gauge
+              gauge:
+                path: [status, parents]
+                labelsFromPath:
+                  controller_name: ["controllerName"]
+                  parent_group: ["parentRef", "group"]
+                  parent_kind: ["parentRef", "kind"]
+                  parent_name: ["parentRef", "name"]
+                  parent_namespace: ["parentRef", "namespace"]
+                  parent_section_name: ["parentRef", "sectionName"]
+                  parent_port: ["parentRef", "port"]
+                valueFrom: ["conditions", "[type=Accepted]", "status"]
+          - name: "status_parent_resolved_refs"
+            help: "ResolvedRefs condition of the udproute for each parent reference (1 = True)"
+            each:
+              type: Gauge
+              gauge:
+                path: [status, parents]
+                labelsFromPath:
+                  controller_name: ["controllerName"]
+                  parent_group: ["parentRef", "group"]
+                  parent_kind: ["parentRef", "kind"]
+                  parent_name: ["parentRef", "name"]
+                  parent_namespace: ["parentRef", "namespace"]
+                  parent_section_name: ["parentRef", "sectionName"]
+                  parent_port: ["parentRef", "port"]
+                valueFrom: ["conditions", "[type=ResolvedRefs]", "status"]
         - groupVersionKind:
             group: gateway.networking.k8s.io
             kind: "BackendTLSPolicy"

--- a/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
@@ -215,6 +215,25 @@ spec:
         - pods=[*]
         - deployments=[*]
         - persistentvolumeclaims=[*]
+      # Gateway API State Metrics (Kuadrant CRS) — feeds Grafana dashboards 19432–19573
+      customResourceState:
+        enabled: true
+        create: false
+        name: kube-state-metrics-gateway-api
+        key: config.yaml
+      rbac:
+        extraRules:
+          - apiGroups: ["gateway.networking.k8s.io"]
+            resources:
+              - gateways
+              - gatewayclasses
+              - httproutes
+              - grpcroutes
+              - tcproutes
+              - tlsroutes
+              - udproutes
+              - backendtlspolicies
+            verbs: ["list", "watch"]
       vmScrape:
         enabled: true
         spec:

--- a/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
@@ -216,6 +216,7 @@ spec:
         - deployments=[*]
         - persistentvolumeclaims=[*]
       # Gateway API State Metrics (Kuadrant CRS) — feeds Grafana dashboards 19432–19573
+      # https://github.com/Kuadrant/gateway-api-state-metrics
       customResourceState:
         enabled: true
         create: false

--- a/kubernetes/apps/observability/victoria-metrics/app/kustomization.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - externalsecret.yaml
+  - gateway-api-state-metrics.yaml
   - helmrelease.yaml
   - httproute.yaml
   - vmalertmanagerconfig.yaml

--- a/kubernetes/apps/observability/victoria-metrics/app/kustomization.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - helmrelease.yaml
   - httproute.yaml
   - vmalertmanagerconfig.yaml
+  - vmrule.yaml

--- a/kubernetes/apps/observability/victoria-metrics/app/vmrule.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/vmrule.yaml
@@ -1,0 +1,33 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/operator.victoriametrics.com/vmrule_v1beta1.json
+# Adapted from Kuadrant gateway-api-state-metrics example alert rules
+# (config/examples/rules/alert-rules.yaml)
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMRule
+metadata:
+  name: gateway-api
+spec:
+  groups:
+    - name: gateway-api.rules
+      rules:
+        - alert: GatewayUnhealthy
+          expr: |
+            (gatewayapi_gateway_status{type="Accepted"} == 0) or (gatewayapi_gateway_status{type="Programmed"} == 0)
+          for: 10m
+          labels:
+            severity: critical
+          annotations:
+            summary: >-
+              Gateway {{ $labels.namespace }}/{{ $labels.name }} is unhealthy — Accepted or Programmed condition is not True
+
+        - alert: GatewayInsecureListener
+          # http/http-internal listeners are intentional: they only serve the
+          # https-redirect HTTPRoute. Alert on any other plaintext listener.
+          expr: |
+            gatewayapi_gateway_listener_info{protocol="HTTP", listener_name!~"http|http-internal"}
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: >-
+              Gateway {{ $labels.namespace }}/{{ $labels.name }} has an unexpected plaintext listener {{ $labels.listener_name }} ({{ $labels.protocol }}/{{ $labels.port }})

--- a/kubernetes/apps/observability/victoria-metrics/app/vmrule.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/vmrule.yaml
@@ -1,7 +1,7 @@
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/operator.victoriametrics.com/vmrule_v1beta1.json
-# Adapted from Kuadrant gateway-api-state-metrics example alert rules
-# (config/examples/rules/alert-rules.yaml)
+# Adapted from Kuadrant gateway-api-state-metrics example alert rules:
+# https://github.com/Kuadrant/gateway-api-state-metrics/blob/main/config/examples/rules/alert-rules.yaml
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMRule
 metadata:

--- a/kubernetes/apps/observability/victoria-metrics/app/vmrule.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/vmrule.yaml
@@ -31,3 +31,41 @@ spec:
           annotations:
             summary: >-
               Gateway {{ $labels.namespace }}/{{ $labels.name }} has an unexpected plaintext listener {{ $labels.listener_name }} ({{ $labels.protocol }}/{{ $labels.port }})
+
+        # Route-level alerts rely on the per-parent condition gauges added
+        # locally to the CustomResourceState config; upstream only exposes
+        # status_parent_info, which cannot distinguish attached from rejected.
+        - alert: GatewayRouteNotAccepted
+          expr: |
+            {__name__=~"gatewayapi_.+route_status_parent_accepted"} == 0
+          for: 10m
+          labels:
+            severity: critical
+          annotations:
+            summary: >-
+              {{ $labels.customresource_kind }} {{ $labels.namespace }}/{{ $labels.name }} was rejected by Gateway {{ $labels.parent_namespace }}/{{ $labels.parent_name }} (listener {{ $labels.parent_section_name }}) — the hostname or listener does not match
+
+        - alert: GatewayRouteUnresolvedRefs
+          expr: |
+            {__name__=~"gatewayapi_.+route_status_parent_resolved_refs"} == 0
+          for: 10m
+          labels:
+            severity: critical
+          annotations:
+            summary: >-
+              {{ $labels.customresource_kind }} {{ $labels.namespace }}/{{ $labels.name }} has unresolvable backendRefs — the backing Service is missing or a cross-namespace ReferenceGrant is absent
+
+        - alert: GatewayRouteOrphaned
+          # A parentRef in spec with no matching entry in status means no
+          # controller ever claimed the route (wrong Gateway name/namespace,
+          # or the Gateway does not exist).
+          expr: |
+            {__name__=~"gatewayapi_.+route_parent_info"}
+              unless on (customresource_kind, namespace, name, parent_name, parent_namespace, parent_section_name)
+            {__name__=~"gatewayapi_.+route_status_parent_accepted"}
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: >-
+              {{ $labels.customresource_kind }} {{ $labels.namespace }}/{{ $labels.name }} references Gateway {{ $labels.parent_namespace }}/{{ $labels.parent_name }} but no controller has claimed it

--- a/kubernetes/apps/observability/victoria-metrics/app/vmrule.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/vmrule.yaml
@@ -20,6 +20,40 @@ spec:
             summary: >-
               Gateway {{ $labels.namespace }}/{{ $labels.name }} is unhealthy — Accepted or Programmed condition is not True
 
+        - alert: GatewayClassNotAccepted
+          expr: |
+            gatewayapi_gatewayclass_status{type="Accepted"} == 0
+          for: 10m
+          labels:
+            severity: critical
+          annotations:
+            summary: >-
+              GatewayClass {{ $labels.name }} is not Accepted — no controller is managing Gateways of this class
+
+        # Listener-level alerts rely on the per-listener condition gauges added
+        # locally to the CustomResourceState config. A Gateway can be Programmed
+        # while one of its listeners is broken, so these are not redundant with
+        # GatewayUnhealthy above.
+        - alert: GatewayListenerNotProgrammed
+          expr: |
+            (gatewayapi_gateway_status_listener_accepted == 0) or (gatewayapi_gateway_status_listener_programmed == 0)
+          for: 10m
+          labels:
+            severity: critical
+          annotations:
+            summary: >-
+              Listener {{ $labels.listener_name }} on Gateway {{ $labels.namespace }}/{{ $labels.name }} is not accepted or not programmed — it is not serving traffic
+
+        - alert: GatewayListenerUnresolvedRefs
+          expr: |
+            gatewayapi_gateway_status_listener_resolved_refs == 0
+          for: 10m
+          labels:
+            severity: critical
+          annotations:
+            summary: >-
+              Listener {{ $labels.listener_name }} on Gateway {{ $labels.namespace }}/{{ $labels.name }} has unresolvable references — the TLS certificate Secret is missing or its ReferenceGrant is absent
+
         - alert: GatewayInsecureListener
           # http/http-internal listeners are intentional: they only serve the
           # https-redirect HTTPRoute. Alert on any other plaintext listener.


### PR DESCRIPTION
## Summary
Replace the orphaned nginx Grafana dashboards with metrics, dashboards, and alerts for the Gateway API resources that now carry all ingress traffic. Rebased onto `main` after #1335 merged.

Built on [Kuadrant/gateway-api-state-metrics](https://github.com/Kuadrant/gateway-api-state-metrics), then extended past what upstream ships:

- **Metrics** — CustomResourceState config mounted into the existing `kube-state-metrics` (not a new exporter), with RBAC for `gateway.networking.k8s.io`. GVKs aligned to the versions this cluster serves.
- **Local enrichment (not upstream):** upstream only exposes `status_parent_info` / `status_listener_attached_routes`, which are info-only and can't distinguish healthy from broken. Added condition **gauges** via the kube-state-metrics `[key=value]` list selector:
  - per-route (HTTP/GRPC/TCP/TLS/UDP): `status_parent_accepted`, `status_parent_resolved_refs`
  - per-listener: `status_listener_accepted`, `status_listener_programmed`, `status_listener_resolved_refs`
- **Dashboards** — Cilium Network Monitoring (24056), Envoy Proxy Monitoring (23239), and Gateway API State Metrics (19432–19434, 19570–19573).
- **Alerts** (new VMRule) — `GatewayUnhealthy`, `GatewayClassNotAccepted`, `GatewayListenerNotProgrammed`, `GatewayListenerUnresolvedRefs`, `GatewayInsecureListener`, `GatewayRouteNotAccepted`, `GatewayRouteUnresolvedRefs`, `GatewayRouteOrphaned`. The two upstream examples were adapted — the insecure-listener alert excludes the intentional `http`/`http-internal` redirect listeners.

### Verification
Ran kube-state-metrics v2.19.1 locally against the live cluster with the real CRS config: 66/66 route/parent pairs and 8/8 listeners produce series, matching `kubectl` exactly, no path-resolution errors. Confirmed the `[key=value]` selector genuinely filters by condition type rather than grabbing the first condition.

## Notes / follow-ups
- Route/listener alerts depend on the locally-added condition gauges; upstream `status_*_info` alone can't drive them.
- Metrics surfaced two zero-route listeners (`internal/https-internal`, `tailscale/https`) — deleted in #1336.

## Test plan
- [x] `flate test` green locally
- [ ] After merge: `gatewayapi_*` series present in VictoriaMetrics; dashboards populate
- [ ] No spurious Gateway* alerts for healthy gateways/routes

Made with [Cursor](https://cursor.com)