### PR TITLE
refactor(pocket-id): collapse vanity httproutes

### DIFF
--- a/kubernetes/apps/auth/pocket-id/app/helmrelease.yaml
+++ b/kubernetes/apps/auth/pocket-id/app/helmrelease.yaml
@@ -108,7 +108,7 @@ spec:
             port: *metricsPort
 
     route:
-      lan:
+      id:
         annotations:
           gatus.home-operations.com/endpoint: |
             name: "{{ .Release.Name }}"
@@ -119,18 +119,6 @@ spec:
           - name: lan
             namespace: kube-system
             sectionName: https
-        rules:
-          - backendRefs:
-              - name: *app
-                port: *port
-      external:
-        annotations:
-          gatus.home-operations.com/endpoint: |
-            name: "{{ .Release.Name }}"
-            group: "{{ .Release.Namespace }}"
-        hostnames:
-          - id.zebernst.dev
-        parentRefs:
           - name: external
             namespace: kube-system
             sectionName: https


### PR DESCRIPTION
## Summary
- Collapse `pocket-id` `lan` + `external` Helm routes into one `id` HTTPRoute with both `parentRefs`
- Same hostname (`id.zebernst.dev`) and backend; only the Gateway differed
- Leave `canonical` (`pocket-id.jptr.zebernst.dev` → `tailscale`) separate — different hostname / listener zone

## Test plan
- [ ] `kubectl -n auth get httproute` shows one route for `id.zebernst.dev` attached to both `lan` and `external`
- [ ] `https://id.zebernst.dev` works on LAN and via Cloudflare
- [ ] `https://pocket-id.jptr.zebernst.dev` still works on tailnet
- [ ] Gatus still probes `id.zebernst.dev` on public and private instances


Made with [Cursor](https://cursor.com)