### PR TITLE
feat(gateway): HTTP→HTTPS redirect on Tailscale

### DIFF
--- a/kubernetes/apps/kube-system/cilium/gateway/redirect.yaml
+++ b/kubernetes/apps/kube-system/cilium/gateway/redirect.yaml
@@ -13,6 +13,9 @@ spec:
     - name: lan
       namespace: kube-system
       sectionName: http
+    - name: tailscale
+      namespace: kube-system
+      sectionName: http
   rules:
     - filters:
         - requestRedirect:

--- a/kubernetes/apps/kube-system/cilium/gateway/tailscale.yaml
+++ b/kubernetes/apps/kube-system/cilium/gateway/tailscale.yaml
@@ -38,6 +38,13 @@ spec:
     annotations:
       tailscale.com/hostname: cilium-gateway
   listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      hostname: "*.jptr.zebernst.dev"
+      allowedRoutes:
+        namespaces:
+          from: Same
     - name: https-canon
       protocol: HTTPS
       port: 443


### PR DESCRIPTION
## Summary
- Add `http` listener (`*.jptr.zebernst.dev`:80, `allowedRoutes: Same`) on the `tailscale` Gateway
- Parent `https-redirect` to `tailscale/http` alongside `lan` and `external`

## Test plan
- [ ] `kubectl -n kube-system get gateway tailscale -o yaml` shows `http` + `https-canon` listeners, both Programmed
- [ ] `https-redirect` Accepted on all three parents
- [ ] From tailnet: `curl -sI http://gatus.jptr.zebernst.dev/` → `301` with `Location: https://...`
- [ ] HTTPS jptr routes still work
- [ ] `GatewayInsecureListener` stays quiet (`listener_name!="http"` already covers this)


Made with [Cursor](https://cursor.com)