### PR TITLE
fix(fission): expose router as ClusterIP

### DIFF
--- a/kubernetes/apps/fission/app/helmrelease.yaml
+++ b/kubernetes/apps/fission/app/helmrelease.yaml
@@ -18,7 +18,7 @@ spec:
   values:
     defaultNamespace: fission
     pullPolicy: Always
-    routerServiceType: LoadBalancer
+    routerServiceType: ClusterIP
     analytics: false
     persistence:
       enabled: true


### PR DESCRIPTION
## Summary
- Change Fission `routerServiceType` from `LoadBalancer` to `ClusterIP`
- Only HTTPTrigger today (`ics-proxy`) is exposed via Gateway API on `fn.zebernst.dev`; the router VIP was unused

## Test plan
- [ ] Flux reconciles the HelmRelease
- [ ] `fission/router` becomes `ClusterIP` and drops the LAN VIP
- [ ] `https://fn.zebernst.dev/ics/proxy` still returns 400 without `?calendar=`


Made with [Cursor](https://cursor.com)