### PR TITLE
feat(nominatim): move DB + flatnode to openebs-hostpath on europa

### DIFF
--- a/kubernetes/apps/self-hosted/nominatim-db/app/cluster.yaml
+++ b/kubernetes/apps/self-hosted/nominatim-db/app/cluster.yaml
@@ -13,7 +13,9 @@ spec:
     name: nominatim-db-secret
   storage:
     size: 400Gi
-    storageClass: ceph-block
+    # Local NVMe via OpenEBS. Existing ceph-block PVC is NOT rewritten by this
+    # change — cut over with Barman recovery onto a new Cluster (see PR).
+    storageClass: openebs-hostpath
   resources:
     requests:
       cpu: "2"
@@ -21,16 +23,9 @@ spec:
     limits:
       memory: 28Gi
   affinity:
-    # Prefer same node as Nominatim API/flatnode (not UI / import Jobs).
-    additionalPodAffinity:
-      preferredDuringSchedulingIgnoredDuringExecution:
-        - weight: 100
-          podAffinityTerm:
-            labelSelector:
-              matchLabels:
-                app.kubernetes.io/name: nominatim
-                app.kubernetes.io/controller: nominatim
-            topologyKey: kubernetes.io/hostname
+    # Pin with Nominatim API + flatnode (hostpath is node-local).
+    nodeSelector:
+      kubernetes.io/hostname: europa
   postgresql:
     # Nominatim tuning: https://nominatim.org/release-docs/latest/admin/Installation/#tuning-the-postgresql-database
     # Deliberately omitted: wal_level=minimal / max_wal_senders=0 (incompatible with CNPG WAL archiving + Barman).

--- a/kubernetes/apps/self-hosted/nominatim-db/migrate/cluster-recovery-hostpath.yaml
+++ b/kubernetes/apps/self-hosted/nominatim-db/migrate/cluster-recovery-hostpath.yaml
@@ -1,0 +1,81 @@
+# Temporary Cluster bootstrap used ONLY during cutover — NOT wired into Flux.
+# After recovery succeeds and the live Cluster matches GitOps again, delete this file's
+# applied object (Flux owns kubernetes/apps/self-hosted/nominatim-db/app/cluster.yaml).
+#
+# Usage outline (see PR):
+#   1. Stop region-import Job + scale Nominatim API to 0
+#   2. Take a fresh CNPG Backup; wait until completed
+#   3. Delete the live Cluster (PVCs go with it unless retention is configured)
+#   4. kubectl apply -f this file  (same name/secrets → app DSN unchanged)
+#   5. Wait for Cluster Ready + WAL replay
+#   6. Let Flux reconcile the GitOps Cluster (initdb bootstrap + hostpath + europa)
+#      — bootstrap is creation-only; Flux will not re-init an existing healthy Cluster
+#
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/postgresql.cnpg.io/cluster_v1.json
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: nominatim-db
+  namespace: self-hosted
+  labels:
+    app.kubernetes.io/name: nominatim-db
+    app.kubernetes.io/component: database-migration
+spec:
+  instances: 1
+  imageName: ghcr.io/cloudnative-pg/postgis:16-3.4
+  primaryUpdateStrategy: unsupervised
+  enableSuperuserAccess: true
+  superuserSecret:
+    name: nominatim-db-secret
+  storage:
+    size: 400Gi
+    storageClass: openebs-hostpath
+  resources:
+    requests:
+      cpu: "2"
+      memory: 24Gi
+    limits:
+      memory: 28Gi
+  affinity:
+    nodeSelector:
+      kubernetes.io/hostname: europa
+  postgresql:
+    parameters:
+      max_connections: "100"
+      shared_buffers: 2GB
+      maintenance_work_mem: 4GB
+      autovacuum_work_mem: 1GB
+      effective_cache_size: 12GB
+      work_mem: 50MB
+      synchronous_commit: "off"
+      checkpoint_timeout: 10min
+      checkpoint_completion_target: "0.9"
+      max_wal_size: 1GB
+      random_page_cost: "1.0"
+  bootstrap:
+    recovery:
+      source: nominatim-db-backup
+  externalClusters:
+    - name: nominatim-db-backup
+      plugin:
+        name: barman-cloud.cloudnative-pg.io
+        parameters:
+          barmanObjectName: nominatim-db-backup
+          serverName: nominatim-db-v1
+  managed:
+    roles:
+      - name: nominatim
+        ensure: present
+        login: true
+        comment: Nominatim application role
+        passwordSecret:
+          name: nominatim-db-app-user
+  plugins:
+    - name: barman-cloud.cloudnative-pg.io
+      isWALArchiver: true
+      parameters:
+        barmanObjectName: nominatim-db-backup
+        serverName: nominatim-db-v1
+  monitoring:
+    enablePodMonitor: true

--- a/kubernetes/apps/self-hosted/nominatim/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/nominatim/app/helmrelease.yaml
@@ -139,16 +139,9 @@ spec:
               limits:
                 memory: 24Gi
         pod:
-          # Prefer same node as nominatim-db (CNPG has the reverse preference).
-          affinity:
-            podAffinity:
-              preferredDuringSchedulingIgnoredDuringExecution:
-                - weight: 100
-                  podAffinityTerm:
-                    labelSelector:
-                      matchLabels:
-                        cnpg.io/cluster: nominatim-db
-                    topologyKey: kubernetes.io/hostname
+          # Pin with nominatim-db + flatnode (openebs-hostpath is node-local).
+          nodeSelector:
+            kubernetes.io/hostname: europa
       ui:
         annotations:
           reloader.stakater.com/auto: "true"
@@ -267,7 +260,9 @@ spec:
         type: persistentVolumeClaim
         accessMode: ReadWriteOnce
         size: 250Gi
-        storageClass: ceph-block
+        # Local NVMe via OpenEBS. Existing ceph-block PVC is NOT rewritten by this
+        # change — cut over with an offline rsync Job onto a new claim (see PR).
+        storageClass: openebs-hostpath
         advancedMounts:
           nominatim:
             nominatim:

--- a/kubernetes/apps/self-hosted/nominatim/migrate/flatnode-to-hostpath.yaml
+++ b/kubernetes/apps/self-hosted/nominatim/migrate/flatnode-to-hostpath.yaml
@@ -1,18 +1,35 @@
-# One-shot cutover helper — NOT wired into kustomization/Flux.
-# Apply manually during the hostpath migration window (see PR description).
+# One-shot VolSync rsyncTLS copy of nominatim-flatnode (Ceph) → hostpath on europa.
+# Not wired into Flux — apply manually during cutover.
 #
-# Copies Ceph flatnode → OpenEBS hostpath on europa while Nominatim is scaled down.
+# Why VolSync (not a Job):
+#   - Source uses copyMethod: Snapshot → Ceph VolumeSnapshot + restore PVC (frozen PiT)
+#   - Destination is openebs-hostpath (no snapshots) via destinationPVC + Direct
+#   - Same-namespace ClusterIP; rsyncTLS preferred over deprecated SSH rsync
 #
-# After the Job succeeds, swap claims (PVCs cannot be renamed):
-#   1. PV=$(kubectl -n self-hosted get pvc nominatim-flatnode-hostpath -o jsonpath='{.spec.volumeName}')
-#   2. kubectl patch pv "$PV" -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
-#   3. kubectl -n self-hosted delete pvc nominatim-flatnode-hostpath nominatim-flatnode
-#   4. kubectl patch pv "$PV" --type merge -p '{"spec":{"claimRef":null}}'
-#   5. Create PVC nominatim-flatnode (openebs-hostpath, 250Gi) with volumeName: $PV
-#      so Flux/Helm keep using the nominatim-flatnode claim name without a second copy.
-#   6. Scale Nominatim back up on europa
+# Prerequisites / cutover:
+#   1. Scale nominatim Deployment to 0 (and finish/cancel any import Job using flatnode)
+#   2. Create PSK once (stunnel format identity:hex — key must be named psk.txt):
+#        KEY="1:$(openssl rand -hex 32)"
+#        kubectl -n self-hosted create secret generic nominatim-flatnode-mig-psk \
+#          --from-literal=psk.txt="$KEY"
+#   3. Apply this file (PVC + ReplicationDestination + ReplicationSource)
+#   4. Wait for destination endpoint, then wire source address from status:
+#        ADDR=$(kubectl -n self-hosted get replicationdestination nominatim-flatnode-hostpath \
+#          -o jsonpath='{.status.rsyncTLS.address}')
+#        kubectl -n self-hosted patch replicationsource nominatim-flatnode-ceph --type merge \
+#          -p "{\"spec\":{\"rsyncTLS\":{\"address\":\"${ADDR}\"}}}"
+#   5. Trigger sync:
+#        kubectl -n self-hosted annotate replicationsource nominatim-flatnode-ceph \
+#          volsync.backube/manual="$(date +%s)" --overwrite
+#   6. Wait for LatestMoverStatus Successful / lastSyncTime on the ReplicationSource
+#   7. Rebind so the app claim name stays nominatim-flatnode:
+#        - Delete ReplicationSource + ReplicationDestination (stop movers)
+#        - Patch both PVs reclaimPolicy=Retain; delete claim nominatim-flatnode
+#          and nominatim-flatnode-hostpath; recreate nominatim-flatnode bound to
+#          the hostpath PV (volumeName); delete/release old Ceph PV when done
+#   8. Scale nominatim back up (API already nodeSelector europa + flatnode SC hostpath)
 #
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/v1/persistentvolumeclaim.json
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/volsync.backube/replicationdestination_v1alpha1.json
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -21,69 +38,68 @@ metadata:
   namespace: self-hosted
   labels:
     app.kubernetes.io/name: nominatim
-    app.kubernetes.io/component: flatnode-migration
+    app.kubernetes.io/component: flatnode-migrate
 spec:
   accessModes: ["ReadWriteOnce"]
   storageClassName: openebs-hostpath
   resources:
     requests:
-      storage: 250Gi
+      storage: 50Gi
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/batch/job_v1.json
-apiVersion: batch/v1
-kind: Job
+apiVersion: volsync.backube/v1alpha1
+kind: ReplicationDestination
 metadata:
-  name: nominatim-flatnode-to-hostpath
+  name: nominatim-flatnode-hostpath
   namespace: self-hosted
   labels:
     app.kubernetes.io/name: nominatim
-    app.kubernetes.io/component: flatnode-migration
+    app.kubernetes.io/component: flatnode-migrate
 spec:
-  backoffLimit: 1
-  ttlSecondsAfterFinished: 86400
-  template:
-    metadata:
-      labels:
-        app.kubernetes.io/name: nominatim
-        app.kubernetes.io/component: flatnode-migration
-    spec:
-      restartPolicy: Never
-      nodeSelector:
-        kubernetes.io/hostname: europa
-      tolerations:
-        - key: nvidia.com/gpu
-          operator: Exists
-          effect: PreferNoSchedule
-      containers:
-        - name: rsync
-          image: docker.io/library/alpine:3.24.1
-          command:
-            - /bin/sh
-            - -ec
-            - |
-              apk add --no-cache rsync
-              echo "source=$(du -sh /src | awk '{print $1}')"
-              rsync -aHAX --info=progress2 /src/ /dst/
-              echo "dest=$(du -sh /dst | awk '{print $1}')"
-              # Expect flatnode.file under subPath layout used by the HelmRelease.
-              ls -lh /dst/flatnode /dst/flatnode/flatnode.file
-          volumeMounts:
-            - name: src
-              mountPath: /src
-              readOnly: true
-            - name: dst
-              mountPath: /dst
-          resources:
-            requests:
-              cpu: "1"
-              memory: 1Gi
-            limits:
-              memory: 2Gi
-      volumes:
-        - name: src
-          persistentVolumeClaim:
-            claimName: nominatim-flatnode
-            readOnly: true
-        - name: dst
-          persistentVolumeClaim:
-            claimName: nominatim-flatnode-hostpath
+  rsyncTLS:
+    # Pre-created hostpath PVC (WaitForFirstConsumer → binds when mover lands on europa)
+    destinationPVC: nominatim-flatnode-hostpath
+    copyMethod: Direct
+    keySecret: nominatim-flatnode-mig-psk
+    serviceType: ClusterIP
+    moverAffinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: kubernetes.io/hostname
+                  operator: In
+                  values: ["europa"]
+    # Match project VolSync movers; chown flatnode after cutover if nominatim UID differs
+    moverSecurityContext:
+      runAsUser: 1000
+      runAsGroup: 1000
+      fsGroup: 1000
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/volsync.backube/replicationsource_v1alpha1.json
+apiVersion: volsync.backube/v1alpha1
+kind: ReplicationSource
+metadata:
+  name: nominatim-flatnode-ceph
+  namespace: self-hosted
+  labels:
+    app.kubernetes.io/name: nominatim
+    app.kubernetes.io/component: flatnode-migrate
+spec:
+  sourcePVC: nominatim-flatnode
+  # Manual only — annotate to fire (see header). Patch .spec.rsyncTLS.address first.
+  trigger:
+    manual: "0"
+  rsyncTLS:
+    # Frozen source: Ceph CSI snapshot → temp restore PVC → rsync
+    copyMethod: Snapshot
+    volumeSnapshotClassName: csi-ceph-block
+    storageClassName: ceph-block
+    accessModes: ["ReadWriteOnce"]
+    capacity: 50Gi
+    keySecret: nominatim-flatnode-mig-psk
+    # address: set from ReplicationDestination.status.rsyncTLS.address (step 4)
+    # Source snapshot PVC is Ceph (any node). Leave mover unpinned.
+    moverSecurityContext:
+      runAsUser: 1000
+      runAsGroup: 1000
+      fsGroup: 1000

--- a/kubernetes/apps/self-hosted/nominatim/migrate/flatnode-to-hostpath.yaml
+++ b/kubernetes/apps/self-hosted/nominatim/migrate/flatnode-to-hostpath.yaml
@@ -1,0 +1,89 @@
+# One-shot cutover helper — NOT wired into kustomization/Flux.
+# Apply manually during the hostpath migration window (see PR description).
+#
+# Copies Ceph flatnode → OpenEBS hostpath on europa while Nominatim is scaled down.
+#
+# After the Job succeeds, swap claims (PVCs cannot be renamed):
+#   1. PV=$(kubectl -n self-hosted get pvc nominatim-flatnode-hostpath -o jsonpath='{.spec.volumeName}')
+#   2. kubectl patch pv "$PV" -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
+#   3. kubectl -n self-hosted delete pvc nominatim-flatnode-hostpath nominatim-flatnode
+#   4. kubectl patch pv "$PV" --type merge -p '{"spec":{"claimRef":null}}'
+#   5. Create PVC nominatim-flatnode (openebs-hostpath, 250Gi) with volumeName: $PV
+#      so Flux/Helm keep using the nominatim-flatnode claim name without a second copy.
+#   6. Scale Nominatim back up on europa
+#
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/v1/persistentvolumeclaim.json
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: nominatim-flatnode-hostpath
+  namespace: self-hosted
+  labels:
+    app.kubernetes.io/name: nominatim
+    app.kubernetes.io/component: flatnode-migration
+spec:
+  accessModes: ["ReadWriteOnce"]
+  storageClassName: openebs-hostpath
+  resources:
+    requests:
+      storage: 250Gi
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/batch/job_v1.json
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: nominatim-flatnode-to-hostpath
+  namespace: self-hosted
+  labels:
+    app.kubernetes.io/name: nominatim
+    app.kubernetes.io/component: flatnode-migration
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: nominatim
+        app.kubernetes.io/component: flatnode-migration
+    spec:
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: europa
+      tolerations:
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: PreferNoSchedule
+      containers:
+        - name: rsync
+          image: docker.io/library/alpine:3.24.1
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              apk add --no-cache rsync
+              echo "source=$(du -sh /src | awk '{print $1}')"
+              rsync -aHAX --info=progress2 /src/ /dst/
+              echo "dest=$(du -sh /dst | awk '{print $1}')"
+              # Expect flatnode.file under subPath layout used by the HelmRelease.
+              ls -lh /dst/flatnode /dst/flatnode/flatnode.file
+          volumeMounts:
+            - name: src
+              mountPath: /src
+              readOnly: true
+            - name: dst
+              mountPath: /dst
+          resources:
+            requests:
+              cpu: "1"
+              memory: 1Gi
+            limits:
+              memory: 2Gi
+      volumes:
+        - name: src
+          persistentVolumeClaim:
+            claimName: nominatim-flatnode
+            readOnly: true
+        - name: dst
+          persistentVolumeClaim:
+            claimName: nominatim-flatnode-hostpath


### PR DESCRIPTION
## Summary
- Point Nominatim CNPG + flatnode at `openebs-hostpath` and hard-pin API/DB pods to **europa** (4 TB `/var/mnt/extra`, ~2 T free today).
- Replace soft pod-affinity with `nodeSelector: kubernetes.io/hostname=europa`.
- Add **non-Flux** cutover helpers under `migrate/` so we can move data **without an OSM reimport** (reimport stays deferred to nominatim-operator cutover).

Merging alone does **not** rewrite existing Ceph PVCs (storageClass is immutable / ignored for live volumes). Follow the cutover below.

## Why
Canada `add-data` is crawling on Ceph RBD (~5% PBF after 46h). Local NVMe for Postgres + flatnode removes the Ceph tax; it will not make append as fast as a fresh import.

## Capacity check (europa)
- OpenEBS base: `/var/mnt/extra/openebs/local` on 4 TB NVMe
- Free at draft time: ~2.0 T
- Need: 400 Gi DB + 250 Gi flatnode (≈177 Gi + 105 Gi used today)

## Cutover plan (no OSM reimport)

### 0. Preconditions
- [ ] Cancel / delete the running Canada import Job (`nominatim-import-north-america-canada-*`) — do not migrate mid-`COPY`.
- [ ] Scale Nominatim API to 0: `kubectl -n self-hosted scale deploy/nominatim --replicas=0`
- [ ] Confirm europa still has ≥700 Gi free on `/var/mnt/extra`.
- [ ] Suspend Flux Kustomizations for `nominatim` + `nominatim-db` during the window (avoid reconcile races).

### 1. Database → hostpath via Barman (preserves PG data)
Live cluster uses plugin archiving (`serverName: nominatim-db-v1`). There is currently a long-running/stuck Backup from the import window — take a **fresh** backup after writes stop.

1. Wait for idle DB (no import `COPY`).
2. `kubectl -n self-hosted create backup nominatim-db-pre-hostpath --from-cluster=…` (or apply a Backup CR) and wait until **completed**.
3. Delete the live `Cluster/nominatim-db` (Flux suspended). PVCs for the instance will be removed with the Cluster.
4. Apply recovery bootstrap onto hostpath + europa:
   ```bash
   kubectl apply -f kubernetes/apps/self-hosted/nominatim-db/migrate/cluster-recovery-hostpath.yaml
   ```
5. Wait until Cluster is Ready and WAL replay finishes; smoke-test `psql` / `\dt`.
6. Resume Flux for `nominatim-db`. GitOps Cluster keeps `bootstrap.initdb` + `storageClass: openebs-hostpath` + europa pin — **bootstrap is creation-only**, so Flux will not wipe a healthy recovered Cluster.

### 2. Flatnode → hostpath via VolSync rsyncTLS (Barman does not cover this)
Frozen Ceph source (`copyMethod: Snapshot` + `csi-ceph-block`) → pre-created `openebs-hostpath` PVC on europa (`destinationPVC` + `copyMethod: Direct`, moverAffinity europa). Same-namespace ClusterIP; shared PSK.

1. Create PSK (stunnel `identity:hex`, key name `psk.txt`):
   ```bash
   KEY="1:$(openssl rand -hex 32)"
   kubectl -n self-hosted create secret generic nominatim-flatnode-mig-psk \
     --from-literal=psk.txt="$KEY"
   ```
2. Apply migrate helper (still scaled down):
   ```bash
   kubectl apply -f kubernetes/apps/self-hosted/nominatim/migrate/flatnode-to-hostpath.yaml
   ```
3. Wire source address from destination status, then trigger:
   ```bash
   ADDR=$(kubectl -n self-hosted get replicationdestination nominatim-flatnode-hostpath \
     -o jsonpath='{.status.rsyncTLS.address}')
   kubectl -n self-hosted patch replicationsource nominatim-flatnode-ceph --type merge \
     -p "{\"spec\":{\"rsyncTLS\":{\"address\":\"${ADDR}\"}}}"
   kubectl -n self-hosted annotate replicationsource nominatim-flatnode-ceph \
     volsync.backube/manual="$(date +%s)" --overwrite
   ```
4. Wait for successful sync (`lastSyncTime` / LatestMoverStatus).
5. Swap claims with PV Retain (PVCs cannot be renamed) — steps are commented at the top of that file so the live claim name stays `nominatim-flatnode` for Helm.
6. Resume Flux for `nominatim`, scale API back to 1, confirm pod lands on **europa** and mounts the hostpath flatnode (`df -h /nominatim/flatnode`).

### 3. Verify
- [ ] `nominatim-db-1` and `deploy/nominatim` both on europa
- [ ] PVCs use `openebs-hostpath`
- [ ] `/status` OK; spot-check a geocode
- [ ] Project PVC can stay on Ceph (low I/O)
- [ ] Legacy `persistence.pgdata` left on Ceph for now (unused soak leftover)

### 4. Explicitly not in this PR
- Finishing/abandoning Canada `add-data` strategy beyond “stop before cutover”
- Full multi-region reimport (nominatim-operator)
- Miroir / cluster teardown

## Test plan
- [ ] Dry-read manifests / `helm template` mentally: nodeSelector + storageClass only on API/DB/flatnode
- [ ] Confirm `migrate/` paths are **not** in kustomizations
- [ ] Execute cutover checklist in a maintenance window
- [ ] Post-cutover: pods on europa, hostpath PVs, API healthy

Made with [Cursor](https://cursor.com)