### PR TITLE
fix(observability): align VictoriaLogs alerts with label taxonomy

### DIFF
--- a/docs/runbooks/observability-label-taxonomy.md
+++ b/docs/runbooks/observability-label-taxonomy.md
@@ -194,6 +194,37 @@ Correlations can also be declared under a provisioned datasource’s
 provisioning). Prefer Git-managed provisioning once the UI shapes are proven;
 the runbook contract (which fields → which query) stays the same either way.
 
+## VictoriaLogs alert rules (vmalert)
+
+Log-based rules live in ConfigMaps labeled `vmalert.io/rule: "true"` and are
+loaded by the logs `vmalert` instance (`--rule.defaultRuleType=vlogs`). Still
+set the group field explicitly:
+
+```yaml
+groups:
+  - name: example
+    type: vlogs
+    rules:
+      - alert: ExampleAppError
+        expr: |
+          sum by (app) (count_over_time({app="example"} |~ "(?i)error"[5m])) > 0
+        labels:
+          severity: critical
+          category: vlogs
+        annotations:
+          summary: "{{ $labels.app }} is logging errors"
+```
+
+Conventions:
+
+- Prefer stream filters on canonical labels (`app`, `namespace`, `container`,
+  `pod`), not Fluent Bit intermediate paths (`k_*` / nested record keys).
+- Aggregate (`sum by` / `stats by`) only on labels you need in annotations.
+  After `sum by (app)`, only `$labels.app` exists — do not reference
+  `$labels.container` or other dropped dimensions.
+- Use `category: vlogs` (not `category: logs`) so log alerts stay distinct from
+  metrics rules in Alertmanager routing and silence filters.
+
 ## Scope boundaries
 
 This taxonomy does not cover tracing, synthesized workload or controller

--- a/kubernetes/apps/downloads/autobrr/app/alert-rules.yaml
+++ b/kubernetes/apps/downloads/autobrr/app/alert-rules.yaml
@@ -1,6 +1,7 @@
 ---
 groups:
   - name: autobrr
+    type: vlogs
     rules:
       - alert: AutobrrNetworkUnhealthy
         expr: |
@@ -8,7 +9,7 @@ groups:
         for: 2m
         labels:
           severity: critical
-          category: logs
+          category: vlogs
         annotations:
           app: "{{ $labels.app }}"
           summary: "{{ $labels.app }} has a unhealthy network"

--- a/kubernetes/apps/downloads/cross-seed/app/resources/alert-rules.yaml
+++ b/kubernetes/apps/downloads/cross-seed/app/resources/alert-rules.yaml
@@ -1,6 +1,7 @@
 ---
 groups:
   - name: cross-seed
+    type: vlogs
     rules:
       - alert: CrossSeedDatabaseMalformed
         expr: |
@@ -8,17 +9,17 @@ groups:
         for: 2m
         labels:
           severity: critical
-          category: logs
+          category: vlogs
         annotations:
-          app: "{{ $labels.container }}"
-          summary: "{{ $labels.container }} is experiencing database issues"
+          app: "{{ $labels.app }}"
+          summary: "{{ $labels.app }} is experiencing database issues"
       - alert: CrossSeedFailedToInject
         expr: |
           sum by (app) (count_over_time({app="cross-seed"} |~ "(?i)failed to inject"[1h])) > 0
         for: 2m
         labels:
           severity: critical
-          category: logs
+          category: vlogs
         annotations:
-          app: "{{ $labels.container }}"
-          summary: "{{ $labels.container }} failed to inject a torrent"
+          app: "{{ $labels.app }}"
+          summary: "{{ $labels.app }} failed to inject a torrent"

--- a/kubernetes/apps/downloads/qbittorrent/app/resources/alert-rules.yaml
+++ b/kubernetes/apps/downloads/qbittorrent/app/resources/alert-rules.yaml
@@ -11,5 +11,5 @@ groups:
           severity: critical
           category: vlogs
         annotations:
-          app: "{{ $labels.container }}"
-          summary: "{{ $labels.container }} has a torrent with fast resume rejected"
+          app: "{{ $labels.app }}"
+          summary: "{{ $labels.app }} has a torrent with fast resume rejected"


### PR DESCRIPTION
## Summary

Log-based alerts that fired with empty `container` annotations (or were tagged `category: logs`) now use the taxonomy labels they actually preserve after aggregation, and declare `type: vlogs` / `category: vlogs` consistently with the rest of the downloads/media rules.

## Test plan

- [ ] After merge, confirm Flux syncs the updated ConfigMaps (`autobrr-vmalert-rules`, `cross-seed-vmalert-rules`, `qbittorrent-vmalert-rules`)
- [ ] Spot-check one rule group in the logs vmalert UI/API for `type: vlogs` and `category: vlogs`
- [ ] If a matching log line appears, confirm the firing alert summary uses the app name (not an empty container)

Related: beads `homelab-1vb.3`
