### PR TITLE
feat(observability): expand metrics canonical-labels beyond pilot

### DIFF
--- a/docs/runbooks/observability-label-taxonomy.md
+++ b/docs/runbooks/observability-label-taxonomy.md
@@ -2,8 +2,8 @@
 
 Container logs in VictoriaLogs use the normalized labels below. Metrics in
 VictoriaMetrics retain exporter labels by default, with an experimental
-flag-gated pilot that promotes Kubernetes discovery metadata for selected
-application Services.
+Service flag that promotes Kubernetes discovery metadata for selected
+application scrapes.
 
 ## Normalized log labels
 
@@ -29,9 +29,9 @@ do not imply a collector failure.
 - Logs normalize fields from Fluent Bit's Kubernetes-enriched record. Query the
   canonical names above, not Fluent Bit's intermediate nested record paths.
 - The `cluster` vmagent external label is attached to stored metrics.
-- Metrics from Services outside the pilot remain exporter- and target-specific.
-  No canonical labels are added unless the discovered Service carries the
-  experimental flag described below.
+- Metrics from Services without the experimental flag remain exporter- and
+  target-specific. No canonical labels are added unless the discovered Service
+  carries the experimental flag described below.
 - Static `VMProbe` targets do not have Kubernetes discovery metadata. Only
   explicitly configured target labels and the metrics-wide `cluster` label are
   reliable for those targets.
@@ -41,11 +41,18 @@ do not imply a collector failure.
 
 ## Experimental metrics target labels
 
-The application metrics pilot is gated by the experimental Service flag
-`experimental.homelab.zebernst.dev/canonical-labels: "true"`. The current
-pilot Services are `atuin`, `paperless`, `gatus`, and `dawarich`. Static
-`VMProbe` targets, kubelet and cAdvisor, kube-state-metrics, node-exporter,
-and every Service without that flag remain unaffected.
+Application metrics taxonomy labels are gated by the experimental Service flag
+`experimental.homelab.zebernst.dev/canonical-labels: "true"`. Flagged Services
+today:
+
+| Namespace | Services |
+|-----------|----------|
+| `self-hosted` | `atuin`, `paperless`, `dawarich` |
+| `observability` | `gatus`, `gatus-external` |
+| `downloads` | `autobrr`, `bazarr`, `bazarr-uhd`, `lidarr`, `prowlarr`, `qui`, `radarr`, `radarr-uhd`, `sonarr`, `sonarr-uhd`, `unpackerr` |
+
+Static `VMProbe` targets, kubelet and cAdvisor, kube-state-metrics,
+node-exporter, and every Service without that flag remain unaffected.
 
 For flagged Service-backed targets, vmagent promotes metadata that exists at
 discovery time:
@@ -120,8 +127,8 @@ up{
 ```
 
 Do not assume `flux_kustomization` exists on these Helm-rendered Services.
-Native cAdvisor metrics are outside the pilot and should continue to use their
-native labels, as in the container CPU query above.
+Native cAdvisor metrics are outside the experimental gate and should continue
+to use their native labels, as in the container CPU query above.
 
 ## Grafana Correlations (logs ↔ metrics)
 
@@ -178,7 +185,7 @@ Example **metrics → logs** target:
 {namespace="${namespace}", pod="${pod}"}
 ```
 
-When the metric series has `app` (pilot / flagged Services):
+When the metric series has `app` (flagged Services):
 
 ```text
 {namespace="${namespace}", app="${app}"}

--- a/kubernetes/apps/downloads/autobrr/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/autobrr/app/helmrelease.yaml
@@ -69,6 +69,8 @@ spec:
     service:
       autobrr:
         controller: *app
+        labels:
+          experimental.homelab.zebernst.dev/canonical-labels: "true"
         ports:
           http:
             port: *port

--- a/kubernetes/apps/downloads/bazarr/hd/helmrelease.yaml
+++ b/kubernetes/apps/downloads/bazarr/hd/helmrelease.yaml
@@ -104,6 +104,8 @@ spec:
       bazarr:
         controller: *app
         forceRename: *app
+        labels:
+          experimental.homelab.zebernst.dev/canonical-labels: "true"
         ports:
           http:
             port: *port

--- a/kubernetes/apps/downloads/bazarr/uhd/helmrelease.yaml
+++ b/kubernetes/apps/downloads/bazarr/uhd/helmrelease.yaml
@@ -104,6 +104,8 @@ spec:
       bazarr-uhd:
         controller: *app
         forceRename: *app
+        labels:
+          experimental.homelab.zebernst.dev/canonical-labels: "true"
         ports:
           http:
             port: *port

--- a/kubernetes/apps/downloads/lidarr/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/lidarr/app/helmrelease.yaml
@@ -104,6 +104,8 @@ spec:
       lidarr:
         controller: *app
         forceRename: *app
+        labels:
+          experimental.homelab.zebernst.dev/canonical-labels: "true"
         ports:
           http:
             port: *port

--- a/kubernetes/apps/downloads/prowlarr/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/prowlarr/app/helmrelease.yaml
@@ -102,6 +102,8 @@ spec:
       prowlarr:
         controller: *app
         forceRename: *app
+        labels:
+          experimental.homelab.zebernst.dev/canonical-labels: "true"
         ports:
           http:
             port: *port

--- a/kubernetes/apps/downloads/qui/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/qui/app/helmrelease.yaml
@@ -78,6 +78,8 @@ spec:
       qui:
         controller: *app
         forceRename: *app
+        labels:
+          experimental.homelab.zebernst.dev/canonical-labels: "true"
         ports:
           http:
             port: *port

--- a/kubernetes/apps/downloads/radarr/app/hd/helmrelease.yaml
+++ b/kubernetes/apps/downloads/radarr/app/hd/helmrelease.yaml
@@ -105,6 +105,8 @@ spec:
       radarr:
         controller: *app
         forceRename: *app
+        labels:
+          experimental.homelab.zebernst.dev/canonical-labels: "true"
         ports:
           http:
             port: *port

--- a/kubernetes/apps/downloads/radarr/app/uhd/helmrelease.yaml
+++ b/kubernetes/apps/downloads/radarr/app/uhd/helmrelease.yaml
@@ -105,6 +105,8 @@ spec:
       radarr-uhd:
         controller: *app
         forceRename: *app
+        labels:
+          experimental.homelab.zebernst.dev/canonical-labels: "true"
         ports:
           http:
             port: *port

--- a/kubernetes/apps/downloads/sonarr/app/hd/helmrelease.yaml
+++ b/kubernetes/apps/downloads/sonarr/app/hd/helmrelease.yaml
@@ -103,6 +103,8 @@ spec:
       sonarr:
         controller: *app
         forceRename: *app
+        labels:
+          experimental.homelab.zebernst.dev/canonical-labels: "true"
         ports:
           http:
             port: *port

--- a/kubernetes/apps/downloads/sonarr/app/uhd/helmrelease.yaml
+++ b/kubernetes/apps/downloads/sonarr/app/uhd/helmrelease.yaml
@@ -103,6 +103,8 @@ spec:
       sonarr-uhd:
         controller: *app
         forceRename: *app
+        labels:
+          experimental.homelab.zebernst.dev/canonical-labels: "true"
         ports:
           http:
             port: *port

--- a/kubernetes/apps/downloads/unpackerr/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/unpackerr/app/helmrelease.yaml
@@ -67,6 +67,8 @@ spec:
     service:
       unpackerr:
         controller: *app
+        labels:
+          experimental.homelab.zebernst.dev/canonical-labels: "true"
         ports:
           http:
             port: 5656

--- a/kubernetes/apps/observability/gatus/external/helmrelease.yaml
+++ b/kubernetes/apps/observability/gatus/external/helmrelease.yaml
@@ -79,6 +79,8 @@ spec:
         runAsGroup: 568
     service:
       gatus-external:
+        labels:
+          experimental.homelab.zebernst.dev/canonical-labels: "true"
         ports:
           http:
             port: *port


### PR DESCRIPTION
## Summary

Canonical metrics labels (`app`, `helmrelease`, etc.) become available on the whole `downloads` scrape set and `gatus-external`, not just the original four pilot Services — so PromQL can use the same vocabulary as logs without flipping the gate for kube-state / cAdvisor / probes.

## Test plan

- [ ] After Flux reconcile, `kubectl get svc -A -l experimental.homelab.zebernst.dev/canonical-labels=true` includes the new downloads + `gatus-external` Services
- [ ] Confirm a downloads metrics series carries promoted labels, e.g. `up{namespace="downloads",app="sonarr"}` or `helmrelease="sonarr"`
- [ ] Spot-check an unflagged system scrape (e.g. kube-state-metrics / node-exporter) still lacks forged `app`/`helmrelease` from this gate

Related: beads `homelab-1vb.4`
