### PR TITLE
feat(observability): provision logs taxonomy dashboard and Correlations

### DIFF
--- a/docs/runbooks/observability-label-taxonomy.md
+++ b/docs/runbooks/observability-label-taxonomy.md
@@ -130,15 +130,32 @@ Do not assume `flux_kustomization` exists on these Helm-rendered Services.
 Native cAdvisor metrics are outside the experimental gate and should continue
 to use their native labels, as in the container CPU query above.
 
+## Grafana logs dashboard
+
+The **Logs taxonomy** dashboard (folder `Logs`, uid `logs-taxonomy`) is
+provisioned via ConfigMap `grafana-logs-taxonomy-dashboard` and the Grafana
+dashboard sidecar. Variables cascade on canonical stream fields only:
+
+`namespace` → `app` → `pod` / `container` / `stream`, plus an optional
+textbox `search` appended as a LogsQL fragment (leave empty for no extra
+filter).
+
+Panel queries use `{namespace="$namespace", app="$app", …}` (VictoriaLogs
+expands multi-value variables via `in(...)`) — never Fluent Bit intermediate
+`k_*` paths.
+
 ## Grafana Correlations (logs ↔ metrics)
 
 Grafana [Correlations](https://grafana.com/docs/grafana/latest/administration/correlations/)
-turn a field on one Explore result into a query (or URL) on another datasource.
-Use them to jump between VictoriaLogs and Prometheus on the taxonomy labels
-that are routinely present after the Fluent Bit rename: `app`, `namespace`,
-`pod`, and `container`.
+turn a field on one Explore result into a query on another datasource. They are
+provisioned on the Prometheus and VictoriaLogs datasources in
+`kubernetes/apps/observability/grafana/app/helmrelease.yaml` for the taxonomy
+labels that are routinely present after the Fluent Bit rename: `app`,
+`namespace`, and `pod`. Links only appear when every `${var}` in the target
+query is present on the clicked row — do not require `helmrelease` /
+`flux_kustomization` on log rows.
 
-Provisioned datasource UIDs in this cluster:
+Provisioned datasource UIDs:
 
 | Datasource   | UID           |
 |--------------|---------------|
@@ -147,59 +164,24 @@ Provisioned datasource UIDs in this cluster:
 
 ### Preferred links
 
-| Direction | Source field(s) | Target idea |
-|-----------|-----------------|-------------|
-| Logs → metrics | `app`, with `namespace` / `pod` / `container` when present | PromQL on cAdvisor or a flagged app series filtered by those labels |
-| Metrics → logs | `namespace`, `pod`, and/or `app` | LogsQL stream filter such as `{namespace="…", app="…"}` or `{namespace="…", pod="…"}` |
+| Direction | Source field | Target |
+|-----------|--------------|--------|
+| Logs → metrics | `pod` | cAdvisor CPU for `${namespace}` / `${pod}` |
+| Logs → metrics | `app` | `up{namespace, app}` (flagged Services) |
+| Logs → metrics | `namespace` | `up{namespace, app!=""}` |
+| Metrics → logs | `pod` / `app` / `namespace` | LogsQL stream filter on those labels |
 
-### Create in the UI
+### Verify in Explore
 
-1. Open Grafana → **Administration** → **Plugins and data** → **Correlations**
-   (or use the Correlations editor in **Explore**).
-2. **Source**: VictoriaLogs (`victorialogs`) or Prometheus (`prometheus`).
-3. **Results field**: the taxonomy label to click (for example `app` or `pod`).
-4. **Type**: Query.
-5. **Target**: the other datasource UID from the table above.
-6. **Target query**: substitute the clicked field with `${app}` / `${namespace}`
-   / `${pod}` (Grafana exposes source fields as variables). Keep the Explore
-   time range.
+1. Open **Explore** → VictoriaLogs, run `{app="atuin"}` (or any app with
+   recent logs).
+2. Expand a log line and use the correlation link on `pod` / `app` /
+   `namespace` (opens split Explore on Prometheus).
+3. From a Prometheus table/series with those labels, use the reverse links
+   into VictoriaLogs.
 
-Example **logs → metrics** target (cAdvisor CPU for the clicked row — match
-filters to fields present on that row):
-
-```promql
-sum by (pod, container) (
-  rate(container_cpu_usage_seconds_total{
-    cluster="jupiter",
-    namespace="${namespace}",
-    pod="${pod}",
-    container!="",
-    container!="POD"
-  }[5m])
-)
-```
-
-Example **metrics → logs** target:
-
-```text
-{namespace="${namespace}", pod="${pod}"}
-```
-
-When the metric series has `app` (flagged Services):
-
-```text
-{namespace="${namespace}", app="${app}"}
-```
-
-After saving, open **Explore**, run a query that returns those fields, expand a
-log line or table row, and use the correlation link (opens split Explore).
-
-### Provisioning later
-
-Correlations can also be declared under a provisioned datasource’s
-`jsonData.correlations` (or the datasource `correlations:` list in Grafana
-provisioning). Prefer Git-managed provisioning once the UI shapes are proven;
-the runbook contract (which fields → which query) stays the same either way.
+To change the links, edit the datasource `correlations:` blocks in Git rather
+than recreating them only in the UI.
 
 ## VictoriaLogs alert rules (vmalert)
 

--- a/kubernetes/apps/observability/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/grafana/app/helmrelease.yaml
@@ -109,6 +109,42 @@ spec:
             access: proxy
             url: http://vmsingle-vmks.observability.svc.cluster.local:8428
             isDefault: true
+            # Explore Correlations: metrics → logs on taxonomy labels.
+            # Links only render when every ${var} is present on the clicked row.
+            correlations:
+              - targetUID: victorialogs
+                label: Logs for pod
+                description: Open VictoriaLogs filtered by namespace and pod
+                type: query
+                config:
+                  field: pod
+                  target:
+                    refId: A
+                    editorMode: code
+                    queryType: instant
+                    expr: '{namespace="${namespace}", pod="${pod}"}'
+              - targetUID: victorialogs
+                label: Logs for app
+                description: Open VictoriaLogs filtered by namespace and app
+                type: query
+                config:
+                  field: app
+                  target:
+                    refId: A
+                    editorMode: code
+                    queryType: instant
+                    expr: '{namespace="${namespace}", app="${app}"}'
+              - targetUID: victorialogs
+                label: Logs for namespace
+                description: Open VictoriaLogs filtered by namespace
+                type: query
+                config:
+                  field: namespace
+                  target:
+                    refId: A
+                    editorMode: code
+                    queryType: instant
+                    expr: '{namespace="${namespace}"}'
           - name: VictoriaLogs
             type: victoriametrics-logs-datasource
             uid: victorialogs
@@ -116,6 +152,44 @@ spec:
             url: http://victoria-logs-server.observability.svc.cluster.local:9428
             jsonData:
               maxLines: 250
+            # Explore Correlations: logs → metrics on taxonomy labels.
+            correlations:
+              - targetUID: prometheus
+                label: Container CPU
+                description: cAdvisor CPU for the log row's namespace/pod
+                type: query
+                config:
+                  field: pod
+                  target:
+                    refId: A
+                    expr: |
+                      sum by (pod, container) (
+                        rate(container_cpu_usage_seconds_total{
+                          cluster="jupiter",
+                          namespace="${namespace}",
+                          pod="${pod}",
+                          container!="",
+                          container!="POD"
+                        }[5m])
+                      )
+              - targetUID: prometheus
+                label: Metrics for app
+                description: Application up{} series for the log row's namespace/app
+                type: query
+                config:
+                  field: app
+                  target:
+                    refId: A
+                    expr: 'up{cluster="jupiter", namespace="${namespace}", app="${app}"}'
+              - targetUID: prometheus
+                label: Metrics for namespace
+                description: Application up{} series for the log row's namespace
+                type: query
+                config:
+                  field: namespace
+                  target:
+                    refId: A
+                    expr: 'up{cluster="jupiter", namespace="${namespace}", app!=""}'
           - name: Alertmanager
             type: alertmanager
             uid: alertmanager

--- a/kubernetes/apps/observability/grafana/app/kustomization.yaml
+++ b/kubernetes/apps/observability/grafana/app/kustomization.yaml
@@ -6,3 +6,14 @@ resources:
   - externalsecret.yaml
   - helmrelease.yaml
   - httproute.yaml
+configMapGenerator:
+  - name: grafana-logs-taxonomy-dashboard
+    files:
+      - logs-taxonomy.json=resources/logs-taxonomy.json
+    options:
+      annotations:
+        grafana_folder: "Logs"
+      labels:
+        grafana_dashboard: "true"
+generatorOptions:
+  disableNameSuffixHash: true

--- a/kubernetes/apps/observability/grafana/app/resources/logs-taxonomy.json
+++ b/kubernetes/apps/observability/grafana/app/resources/logs-taxonomy.json
@@ -1,0 +1,255 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Container logs filtered by the cluster label taxonomy (namespace, app, pod, container, stream).",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "doc",
+      "includeVars": false,
+      "keepTime": false,
+      "tags": [],
+      "targetBlank": true,
+      "title": "Taxonomy runbook",
+      "tooltip": "",
+      "type": "link",
+      "url": "https://github.com/zebernst/homelab/blob/main/docs/runbooks/observability-label-taxonomy.md"
+    }
+  ],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "id": 1,
+      "panels": [],
+      "title": "Volume",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victorialogs" },
+      "description": "Log volume by pod for the selected taxonomy filters.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "normal" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 1 },
+      "id": 2,
+      "options": {
+        "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "hideZeros": false, "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victorialogs" },
+          "editorMode": "code",
+          "expr": "{namespace=\"$namespace\", app=\"$app\", pod=\"$pod\", container=\"$container\", stream=\"$stream\"} $search | stats by (pod) count() as logs",
+          "legendFormat": "{{pod}}",
+          "queryType": "statsRange",
+          "refId": "A"
+        }
+      ],
+      "title": "Log volume by pod",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 9 },
+      "id": 3,
+      "panels": [],
+      "title": "Logs",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victorialogs" },
+      "description": "Raw log lines. Use Explore Correlations on app/namespace/pod to jump to metrics.",
+      "gridPos": { "h": 16, "w": 24, "x": 0, "y": 10 },
+      "id": 4,
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": false,
+        "showCommonLabels": false,
+        "showLabels": true,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victorialogs" },
+          "editorMode": "code",
+          "expr": "{namespace=\"$namespace\", app=\"$app\", pod=\"$pod\", container=\"$container\", stream=\"$stream\"} $search",
+          "maxLines": 250,
+          "queryType": "instant",
+          "refId": "A"
+        }
+      ],
+      "title": "Container logs",
+      "type": "logs"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["logs", "taxonomy", "victorialogs"],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victorialogs" },
+        "definition": "",
+        "includeAll": true,
+        "label": "Namespace",
+        "multi": true,
+        "name": "namespace",
+        "options": [],
+        "query": {
+          "field": "namespace",
+          "refId": "VictoriaLogsVariableQueryEditor-VariableQuery",
+          "type": "fieldValue"
+        },
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victorialogs" },
+        "definition": "",
+        "includeAll": true,
+        "label": "App",
+        "multi": true,
+        "name": "app",
+        "options": [],
+        "query": {
+          "field": "app",
+          "query": "{namespace=\"$namespace\"}",
+          "refId": "VictoriaLogsVariableQueryEditor-VariableQuery",
+          "type": "fieldValue"
+        },
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victorialogs" },
+        "definition": "",
+        "includeAll": true,
+        "label": "Pod",
+        "multi": true,
+        "name": "pod",
+        "options": [],
+        "query": {
+          "field": "pod",
+          "query": "{namespace=\"$namespace\", app=\"$app\"}",
+          "refId": "VictoriaLogsVariableQueryEditor-VariableQuery",
+          "type": "fieldValue"
+        },
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victorialogs" },
+        "definition": "",
+        "includeAll": true,
+        "label": "Container",
+        "multi": true,
+        "name": "container",
+        "options": [],
+        "query": {
+          "field": "container",
+          "query": "{namespace=\"$namespace\", app=\"$app\", pod=\"$pod\"}",
+          "refId": "VictoriaLogsVariableQueryEditor-VariableQuery",
+          "type": "fieldValue"
+        },
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victorialogs" },
+        "definition": "",
+        "includeAll": true,
+        "label": "Stream",
+        "multi": true,
+        "name": "stream",
+        "options": [],
+        "query": {
+          "field": "stream",
+          "query": "{namespace=\"$namespace\", app=\"$app\"}",
+          "refId": "VictoriaLogsVariableQueryEditor-VariableQuery",
+          "type": "fieldValue"
+        },
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": { "selected": false, "text": "", "value": "" },
+        "label": "Search",
+        "name": "search",
+        "options": [{ "selected": true, "text": "", "value": "" }],
+        "query": "",
+        "type": "textbox"
+      }
+    ]
+  },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Logs taxonomy",
+  "uid": "logs-taxonomy",
+  "version": 1
+}


### PR DESCRIPTION
## Summary

Grafana can filter container logs by the shared taxonomy (`namespace` / `app` / `pod` / `container` / `stream`) from a provisioned **Logs taxonomy** dashboard, and Explore can jump logs↔metrics on those fields via Git-managed Correlations — without depending on Fluent Bit `k_*` paths or Flux labels on Pod logs.

## Test plan

- [ ] After Flux reconciles Grafana, open dashboard **Logs → Logs taxonomy** (`uid: logs-taxonomy`) and confirm cascading variables return values
- [ ] Narrow to an app with recent logs (e.g. `atuin`) and verify the logs + volume panels populate
- [ ] Explore → VictoriaLogs `{app="atuin"}` → expand a line → correlation links on `pod`/`app`/`namespace` open Prometheus
- [ ] Explore → Prometheus `up{namespace="self-hosted",app="atuin"}` → correlation into VictoriaLogs

Related: beads `homelab-1vb.5`
