### PR TITLE
feat(observability): add truthful static labels to VMProbes

### DIFF
--- a/docs/runbooks/observability-label-taxonomy.md
+++ b/docs/runbooks/observability-label-taxonomy.md
@@ -32,9 +32,11 @@ do not imply a collector failure.
 - Metrics from Services without the experimental flag remain exporter- and
   target-specific. No canonical labels are added unless the discovered Service
   carries the experimental flag described below.
-- Static `VMProbe` targets do not have Kubernetes discovery metadata. Only
-  explicitly configured target labels and the metrics-wide `cluster` label are
-  reliable for those targets.
+- Static `VMProbe` targets do not have Kubernetes discovery metadata. App
+  probes set truthful `targets.static.labels` (`namespace`, `app`) in Git.
+  Heterogeneous probes (e.g. `devices`, `nfs`) set `namespace` only — never
+  invent `pod`/`container` or Flux provenance. The metrics-wide `cluster`
+  label still applies.
 - Flux-native labels exist only on top-level Flux-managed objects. They are not
   automatically copied into Pod templates, so `flux_kustomization` and
   `helmrelease` are commonly unavailable on container-log Pods.

--- a/kubernetes/apps/ai/ollama/app/vmprobe.yaml
+++ b/kubernetes/apps/ai/ollama/app/vmprobe.yaml
@@ -11,5 +11,8 @@ spec:
     url: blackbox-exporter.observability.svc.cluster.local:9115
   targets:
     static:
+      labels:
+        namespace: ai
+        app: ollama
       targets:
         - http://ollama.ai.svc.cluster.local:11434/api/tags

--- a/kubernetes/apps/ai/open-webui/app/vmprobe.yaml
+++ b/kubernetes/apps/ai/open-webui/app/vmprobe.yaml
@@ -11,5 +11,8 @@ spec:
     url: blackbox-exporter.observability.svc.cluster.local:9115
   targets:
     static:
+      labels:
+        namespace: ai
+        app: open-webui
       targets:
         - http://open-webui.ai.svc.cluster.local/health

--- a/kubernetes/apps/auth/tinyauth/app/vmprobe.yaml
+++ b/kubernetes/apps/auth/tinyauth/app/vmprobe.yaml
@@ -11,5 +11,8 @@ spec:
     url: blackbox-exporter.observability.svc.cluster.local:9115
   targets:
     static:
+      labels:
+        namespace: auth
+        app: tinyauth
       targets:
         - http://tinyauth.auth.svc.cluster.local:3000/

--- a/kubernetes/apps/downloads/cross-seed/app/vmprobe.yaml
+++ b/kubernetes/apps/downloads/cross-seed/app/vmprobe.yaml
@@ -11,5 +11,8 @@ spec:
     url: blackbox-exporter.observability.svc.cluster.local:9115
   targets:
     static:
+      labels:
+        namespace: downloads
+        app: cross-seed
       targets:
         - http://cross-seed.downloads.svc.cluster.local/api/ping

--- a/kubernetes/apps/downloads/flaresolverr/app/vmprobe.yaml
+++ b/kubernetes/apps/downloads/flaresolverr/app/vmprobe.yaml
@@ -11,5 +11,8 @@ spec:
     url: blackbox-exporter.observability.svc.cluster.local:9115
   targets:
     static:
+      labels:
+        namespace: downloads
+        app: flaresolverr
       targets:
         - flaresolverr.downloads.svc.cluster.local:8191

--- a/kubernetes/apps/downloads/omegabrr/app/vmprobe.yaml
+++ b/kubernetes/apps/downloads/omegabrr/app/vmprobe.yaml
@@ -11,5 +11,8 @@ spec:
     url: blackbox-exporter.observability.svc.cluster.local:9115
   targets:
     static:
+      labels:
+        namespace: downloads
+        app: omegabrr
       targets:
         - omegabrr.downloads.svc.cluster.local:80

--- a/kubernetes/apps/downloads/openbooks/app/vmprobe.yaml
+++ b/kubernetes/apps/downloads/openbooks/app/vmprobe.yaml
@@ -11,5 +11,8 @@ spec:
     url: blackbox-exporter.observability.svc.cluster.local:9115
   targets:
     static:
+      labels:
+        namespace: downloads
+        app: openbooks
       targets:
         - http://openbooks.downloads.svc.cluster.local/

--- a/kubernetes/apps/downloads/qbittorrent/app/vmprobe.yaml
+++ b/kubernetes/apps/downloads/qbittorrent/app/vmprobe.yaml
@@ -11,5 +11,8 @@ spec:
     url: blackbox-exporter.observability.svc.cluster.local:9115
   targets:
     static:
+      labels:
+        namespace: downloads
+        app: qbittorrent
       targets:
         - http://qbittorrent.downloads.svc.cluster.local/api/v2/app/version

--- a/kubernetes/apps/downloads/seasonpackarr/app/vmprobe.yaml
+++ b/kubernetes/apps/downloads/seasonpackarr/app/vmprobe.yaml
@@ -11,5 +11,8 @@ spec:
     url: blackbox-exporter.observability.svc.cluster.local:9115
   targets:
     static:
+      labels:
+        namespace: downloads
+        app: seasonpackarr
       targets:
         - http://seasonpackarr.downloads.svc.cluster.local/api/healthz/readiness

--- a/kubernetes/apps/downloads/whisparr/app/vmprobe.yaml
+++ b/kubernetes/apps/downloads/whisparr/app/vmprobe.yaml
@@ -11,5 +11,8 @@ spec:
     url: blackbox-exporter.observability.svc.cluster.local:9115
   targets:
     static:
+      labels:
+        namespace: downloads
+        app: whisparr
       targets:
         - http://whisparr.downloads.svc.cluster.local/ping

--- a/kubernetes/apps/external-secrets/onepassword/app/vmprobe.yaml
+++ b/kubernetes/apps/external-secrets/onepassword/app/vmprobe.yaml
@@ -11,5 +11,8 @@ spec:
     url: blackbox-exporter.observability.svc.cluster.local:9115
   targets:
     static:
+      labels:
+        namespace: external-secrets
+        app: onepassword
       targets:
         - http://onepassword.external-secrets.svc.cluster.local/health

--- a/kubernetes/apps/media/agregarr/app/vmprobe.yaml
+++ b/kubernetes/apps/media/agregarr/app/vmprobe.yaml
@@ -11,5 +11,8 @@ spec:
     url: blackbox-exporter.observability.svc.cluster.local:9115
   targets:
     static:
+      labels:
+        namespace: media
+        app: agregarr
       targets:
         - http://agregarr.media.svc.cluster.local/api/v1/status

--- a/kubernetes/apps/media/booklore/app/vmprobe.yaml
+++ b/kubernetes/apps/media/booklore/app/vmprobe.yaml
@@ -11,5 +11,8 @@ spec:
     url: blackbox-exporter.observability.svc.cluster.local:9115
   targets:
     static:
+      labels:
+        namespace: media
+        app: booklore
       targets:
         - booklore.media.svc.cluster.local:6060

--- a/kubernetes/apps/media/capacitarr/app/vmprobe.yaml
+++ b/kubernetes/apps/media/capacitarr/app/vmprobe.yaml
@@ -11,5 +11,8 @@ spec:
     url: blackbox-exporter.observability.svc.cluster.local:9115
   targets:
     static:
+      labels:
+        namespace: media
+        app: capacitarr
       targets:
         - http://capacitarr.media.svc.cluster.local:2187/api/v1/health

--- a/kubernetes/apps/media/maintainerr/app/vmprobe.yaml
+++ b/kubernetes/apps/media/maintainerr/app/vmprobe.yaml
@@ -11,5 +11,8 @@ spec:
     url: blackbox-exporter.observability.svc.cluster.local:9115
   targets:
     static:
+      labels:
+        namespace: media
+        app: maintainerr
       targets:
         - http://maintainerr.media.svc.cluster.local:6246/

--- a/kubernetes/apps/media/shelfmark/app/vmprobe.yaml
+++ b/kubernetes/apps/media/shelfmark/app/vmprobe.yaml
@@ -11,5 +11,8 @@ spec:
     url: blackbox-exporter.observability.svc.cluster.local:9115
   targets:
     static:
+      labels:
+        namespace: media
+        app: shelfmark
       targets:
         - http://shelfmark.media.svc.cluster.local:8084/

--- a/kubernetes/apps/media/stash/app/vmprobe.yaml
+++ b/kubernetes/apps/media/stash/app/vmprobe.yaml
@@ -11,5 +11,8 @@ spec:
     url: blackbox-exporter.observability.svc.cluster.local:9115
   targets:
     static:
+      labels:
+        namespace: media
+        app: stash
       targets:
         - http://stash.media.svc.cluster.local:9999/

--- a/kubernetes/apps/media/steam/app/vmprobe.yaml
+++ b/kubernetes/apps/media/steam/app/vmprobe.yaml
@@ -11,5 +11,8 @@ spec:
     url: blackbox-exporter.observability.svc.cluster.local:9115
   targets:
     static:
+      labels:
+        namespace: media
+        app: steam
       targets:
         - http://steam.media.svc.cluster.local:8083/

--- a/kubernetes/apps/media/tautulli/app/vmprobe.yaml
+++ b/kubernetes/apps/media/tautulli/app/vmprobe.yaml
@@ -11,5 +11,8 @@ spec:
     url: blackbox-exporter.observability.svc.cluster.local:9115
   targets:
     static:
+      labels:
+        namespace: media
+        app: tautulli
       targets:
         - http://tautulli.media.svc.cluster.local/status

--- a/kubernetes/apps/observability/blackbox-exporter/probes/devices.yaml
+++ b/kubernetes/apps/observability/blackbox-exporter/probes/devices.yaml
@@ -11,6 +11,8 @@ spec:
     url: blackbox-exporter.observability.svc.cluster.local:9115
   targets:
     static:
+      labels:
+        namespace: observability
       targets:
         - unifi
         - nas.internal

--- a/kubernetes/apps/observability/blackbox-exporter/probes/nfs.yaml
+++ b/kubernetes/apps/observability/blackbox-exporter/probes/nfs.yaml
@@ -11,5 +11,7 @@ spec:
     url: blackbox-exporter.observability.svc.cluster.local:9115
   targets:
     static:
+      labels:
+        namespace: observability
       targets:
         - nas.internal:2049

--- a/kubernetes/apps/self-hosted/glance/app/vmprobe.yaml
+++ b/kubernetes/apps/self-hosted/glance/app/vmprobe.yaml
@@ -11,5 +11,8 @@ spec:
     url: blackbox-exporter.observability.svc.cluster.local:9115
   targets:
     static:
+      labels:
+        namespace: self-hosted
+        app: glance
       targets:
         - http://glance.self-hosted.svc.cluster.local/

--- a/kubernetes/apps/self-hosted/hajimari/app/vmprobe.yaml
+++ b/kubernetes/apps/self-hosted/hajimari/app/vmprobe.yaml
@@ -11,5 +11,8 @@ spec:
     url: blackbox-exporter.observability.svc.cluster.local:9115
   targets:
     static:
+      labels:
+        namespace: self-hosted
+        app: hajimari
       targets:
         - http://hajimari.self-hosted.svc.cluster.local:3000/

--- a/kubernetes/apps/self-hosted/it-tools/app/vmprobe.yaml
+++ b/kubernetes/apps/self-hosted/it-tools/app/vmprobe.yaml
@@ -11,5 +11,8 @@ spec:
     url: blackbox-exporter.observability.svc.cluster.local:9115
   targets:
     static:
+      labels:
+        namespace: self-hosted
+        app: it-tools
       targets:
         - http://it-tools.self-hosted.svc.cluster.local:8080/

--- a/kubernetes/apps/self-hosted/nocodb/app/vmprobe.yaml
+++ b/kubernetes/apps/self-hosted/nocodb/app/vmprobe.yaml
@@ -11,5 +11,8 @@ spec:
     url: blackbox-exporter.observability.svc.cluster.local:9115
   targets:
     static:
+      labels:
+        namespace: self-hosted
+        app: nocodb
       targets:
         - http://nocodb.self-hosted.svc.cluster.local:8080/

--- a/kubernetes/apps/self-hosted/nominatim/app/vmprobe.yaml
+++ b/kubernetes/apps/self-hosted/nominatim/app/vmprobe.yaml
@@ -11,5 +11,8 @@ spec:
     url: blackbox-exporter.observability.svc.cluster.local:9115
   targets:
     static:
+      labels:
+        namespace: self-hosted
+        app: nominatim
       targets:
         - http://nominatim.self-hosted.svc.cluster.local/status

--- a/kubernetes/apps/self-hosted/unwrapped/app/vmprobe.yaml
+++ b/kubernetes/apps/self-hosted/unwrapped/app/vmprobe.yaml
@@ -11,5 +11,8 @@ spec:
     url: blackbox-exporter.observability.svc.cluster.local:9115
   targets:
     static:
+      labels:
+        namespace: self-hosted
+        app: unwrapped
       targets:
         - http://unwrapped.self-hosted.svc.cluster.local:8501/_stcore/health


### PR DESCRIPTION
## Summary

Blackbox `VMProbe` metrics can now be filtered with truthful `namespace`/`app` labels (matching the probed Service), without inventing `pod`/`container` or Flux provenance. Heterogeneous probes (`devices`, `nfs`) get `namespace` only.

## Test plan

- [ ] After Flux applies, confirm a probe target shows labels, e.g. `probe_success{namespace="downloads",app="cross-seed"}`
- [ ] Confirm `devices`/`nfs` have `namespace="observability"` and no forged `app`
- [ ] Spot-check that probe modules/URLs are unchanged

Related: beads `homelab-1vb.6`
