### PR TITLE
fix(observability): narrow kube-state-metrics label allowlist

### DIFF
--- a/docs/runbooks/observability-label-taxonomy.md
+++ b/docs/runbooks/observability-label-taxonomy.md
@@ -83,20 +83,32 @@ remote write, so stored metrics keep sample identity. Do not rely on
 ## kube-state-metrics label allowlist
 
 `kube_pod_labels` / `kube_deployment_labels` / `kube_persistentvolumeclaim_labels`
-only export an allowlisted set of Kubernetes labels (not `[*]`). The allowlist
-matches the taxonomy plus Flux ownership and CNPG PVC cluster identity:
+only export an allowlisted set of Kubernetes labels (not `[*]`).
 
-- `app.kubernetes.io/name`, `app.kubernetes.io/instance`,
-  `app.kubernetes.io/component`, `app.kubernetes.io/part-of`
-- `app`, `k8s-app` (pods/deployments)
-- `helm.toolkit.fluxcd.io/name`, `kustomize.toolkit.fluxcd.io/name`
-- `cnpg.io/cluster` (PVCs)
+**Keep**
 
-High-cardinality controller hashes and UIDs (`pod-template-hash`,
-`controller-uid`, job UIDs, per-pod StatefulSet names, …) are intentionally
-omitted. Join workload ownership through these allowlisted `label_*` fields (or
-use the experimental Service metrics gate / log taxonomy) rather than expecting
-every Kubernetes label on the series.
+- Taxonomy: `app.kubernetes.io/{name,instance,component,part-of}`, `app`, `k8s-app`
+- Chart/pkg: `app.kubernetes.io/{managed-by,version,created-by,controller}`,
+  `helm.sh/chart`, `chart`, `release`
+- Flux: `helm.toolkit.fluxcd.io/{name,namespace}`,
+  `kustomize.toolkit.fluxcd.io/{name,namespace}`,
+  `fluxcd.controlplane.io/{name,namespace}`
+- CNPG: `cnpg.io/cluster`, `instanceName`, `instanceRole`, `podRole` / `pvcRole`
+- Rook/Ceph: `rook_cluster`, `rook-version`, `ceph_daemon_type`, `ceph-version`,
+  `rook.io/operator-namespace`, `rook_file_system`, `rook_object_store`,
+  `device-class`, `failure-domain`
+- Other useful one-offs: `role`, `component`, `tier`, `svc`, Tailscale parent
+  labels, Fission `functionName` / `functionNamespace` / env name+ns,
+  `io.cilium/app`, OpenEBS component, a few control-plane helpers
+- PVCs also: `volsync.backube/cleanup`, Prometheus Operator PVC labels
+
+**Drop (still)**
+
+High-cardinality controller noise and IDs: `pod-template-hash`,
+`controller-revision-hash`, `controller-uid`, batch/job UIDs,
+`apps.kubernetes.io/pod-index`, `statefulset.kubernetes.io/pod-name`,
+`functionUid`, `environmentUid`, `ceph_daemon_id` / `ceph-osd-id`,
+`topology-location-*`, Helm `heritage`, and other one-off churn keys.
 
 Kubelet scrapes separately drop `uid` / container `id` labels — leave those
 drops in place when editing VictoriaMetrics values.

--- a/docs/runbooks/observability-label-taxonomy.md
+++ b/docs/runbooks/observability-label-taxonomy.md
@@ -80,6 +80,27 @@ restores `exported_<label>` → `<label>` for the taxonomy identity set before
 remote write, so stored metrics keep sample identity. Do not rely on
 `exported_namespace` / `exported_pod` / etc. in alerts or dashboards.
 
+## kube-state-metrics label allowlist
+
+`kube_pod_labels` / `kube_deployment_labels` / `kube_persistentvolumeclaim_labels`
+only export an allowlisted set of Kubernetes labels (not `[*]`). The allowlist
+matches the taxonomy plus Flux ownership and CNPG PVC cluster identity:
+
+- `app.kubernetes.io/name`, `app.kubernetes.io/instance`,
+  `app.kubernetes.io/component`, `app.kubernetes.io/part-of`
+- `app`, `k8s-app` (pods/deployments)
+- `helm.toolkit.fluxcd.io/name`, `kustomize.toolkit.fluxcd.io/name`
+- `cnpg.io/cluster` (PVCs)
+
+High-cardinality controller hashes and UIDs (`pod-template-hash`,
+`controller-uid`, job UIDs, per-pod StatefulSet names, …) are intentionally
+omitted. Join workload ownership through these allowlisted `label_*` fields (or
+use the experimental Service metrics gate / log taxonomy) rather than expecting
+every Kubernetes label on the series.
+
+Kubelet scrapes separately drop `uid` / container `id` labels — leave those
+drops in place when editing VictoriaMetrics values.
+
 ## Incident queries
 
 In Grafana Explore, select the VictoriaLogs datasource and use LogsQL stream

--- a/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
@@ -376,10 +376,12 @@ spec:
 
     kube-state-metrics:
       fullnameOverride: kube-state-metrics
+      # Taxonomy + Flux ownership only. Avoid pods=[*]/deployments=[*]/PVC wildcards —
+      # those export high-cardinality hashes/UIDs (pod-template-hash, controller-uid, …).
       metricLabelsAllowlist:
-        - pods=[*]
-        - deployments=[*]
-        - persistentvolumeclaims=[*]
+        - pods=[app.kubernetes.io/name,app.kubernetes.io/instance,app.kubernetes.io/component,app.kubernetes.io/part-of,app,k8s-app,helm.toolkit.fluxcd.io/name,kustomize.toolkit.fluxcd.io/name]
+        - deployments=[app.kubernetes.io/name,app.kubernetes.io/instance,app.kubernetes.io/component,app.kubernetes.io/part-of,app,k8s-app,helm.toolkit.fluxcd.io/name,kustomize.toolkit.fluxcd.io/name]
+        - persistentvolumeclaims=[app.kubernetes.io/name,app.kubernetes.io/instance,app.kubernetes.io/component,app.kubernetes.io/part-of,app,helm.toolkit.fluxcd.io/name,kustomize.toolkit.fluxcd.io/name,cnpg.io/cluster]
       # Gateway API State Metrics (Kuadrant CRS) — feeds Grafana dashboards 19432–19573
       # https://github.com/Kuadrant/gateway-api-state-metrics
       customResourceState:

--- a/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
@@ -376,12 +376,15 @@ spec:
 
     kube-state-metrics:
       fullnameOverride: kube-state-metrics
-      # Taxonomy + Flux ownership only. Avoid pods=[*]/deployments=[*]/PVC wildcards —
-      # those export high-cardinality hashes/UIDs (pod-template-hash, controller-uid, …).
+      # Explicit allowlist (not [*]). Still drops high-cardinality controller noise:
+      # pod-template-hash, controller-revision-hash, controller-uid, job/batch UIDs,
+      # apps.kubernetes.io/pod-index, statefulset.kubernetes.io/pod-name,
+      # functionUid / environmentUid, topology-location-host, etc.
       metricLabelsAllowlist:
-        - pods=[app.kubernetes.io/name,app.kubernetes.io/instance,app.kubernetes.io/component,app.kubernetes.io/part-of,app,k8s-app,helm.toolkit.fluxcd.io/name,kustomize.toolkit.fluxcd.io/name]
-        - deployments=[app.kubernetes.io/name,app.kubernetes.io/instance,app.kubernetes.io/component,app.kubernetes.io/part-of,app,k8s-app,helm.toolkit.fluxcd.io/name,kustomize.toolkit.fluxcd.io/name]
-        - persistentvolumeclaims=[app.kubernetes.io/name,app.kubernetes.io/instance,app.kubernetes.io/component,app.kubernetes.io/part-of,app,helm.toolkit.fluxcd.io/name,kustomize.toolkit.fluxcd.io/name,cnpg.io/cluster]
+        # taxonomy + chart/pkg + Flux + CNPG/Rook/Tailscale/Fission/Cilium one-offs
+        - pods=[app.kubernetes.io/name,app.kubernetes.io/instance,app.kubernetes.io/component,app.kubernetes.io/part-of,app.kubernetes.io/managed-by,app.kubernetes.io/version,app.kubernetes.io/created-by,app.kubernetes.io/controller,app,k8s-app,helm.sh/chart,chart,release,helm.toolkit.fluxcd.io/name,helm.toolkit.fluxcd.io/namespace,kustomize.toolkit.fluxcd.io/name,kustomize.toolkit.fluxcd.io/namespace,fluxcd.controlplane.io/name,fluxcd.controlplane.io/namespace,cnpg.io/cluster,cnpg.io/instanceName,cnpg.io/instanceRole,cnpg.io/podRole,rook_cluster,rook-version,ceph_daemon_type,ceph-version,rook.io/operator-namespace,rook_file_system,rook_object_store,device-class,failure-domain,role,component,name,tier,svc,application,control-plane,version,io.cilium/app,tailscale.com/managed,tailscale.com/parent-resource,tailscale.com/parent-resource-ns,tailscale.com/parent-resource-type,functionName,functionNamespace,executorType,environmentName,environmentNamespace,fission.io/served,application.giantswarm.io/team,openebs.io/component-name,kubernetes.io/name,kubernetes.io/cluster-service]
+        - deployments=[app.kubernetes.io/name,app.kubernetes.io/instance,app.kubernetes.io/component,app.kubernetes.io/part-of,app.kubernetes.io/managed-by,app.kubernetes.io/version,app.kubernetes.io/created-by,app.kubernetes.io/controller,app,k8s-app,helm.sh/chart,chart,release,helm.toolkit.fluxcd.io/name,helm.toolkit.fluxcd.io/namespace,kustomize.toolkit.fluxcd.io/name,kustomize.toolkit.fluxcd.io/namespace,fluxcd.controlplane.io/name,fluxcd.controlplane.io/namespace,rook_cluster,rook-version,ceph_daemon_type,ceph-version,rook.io/operator-namespace,rook_file_system,rook_object_store,device-class,failure-domain,role,component,name,tier,svc,application,control-plane,version,io.cilium/app,application.giantswarm.io/team,openebs.io/component-name,kubernetes.io/name,kubernetes.io/cluster-service]
+        - persistentvolumeclaims=[app.kubernetes.io/name,app.kubernetes.io/instance,app.kubernetes.io/component,app.kubernetes.io/part-of,app.kubernetes.io/managed-by,app.kubernetes.io/version,app.kubernetes.io/created-by,app,helm.sh/chart,chart,release,managed-by,helm.toolkit.fluxcd.io/name,helm.toolkit.fluxcd.io/namespace,kustomize.toolkit.fluxcd.io/name,kustomize.toolkit.fluxcd.io/namespace,cnpg.io/cluster,cnpg.io/instanceName,cnpg.io/instanceRole,cnpg.io/pvcRole,volsync.backube/cleanup,role,alertmanager,prometheus,operator.prometheus.io/name,operator.prometheus.io/shard]
       # Gateway API State Metrics (Kuadrant CRS) — feeds Grafana dashboards 19432–19573
       # https://github.com/Kuadrant/gateway-api-state-metrics
       customResourceState:


### PR DESCRIPTION
## Summary

`kube_*_labels` no longer use `[*]`. High-cardinality controller noise (hashes, UIDs, per-pod names) stays dropped, while chart/Flux metadata and useful operator labels (CNPG, Rook/Ceph, Tailscale, Fission, Cilium, VolSync, a few control-plane one-offs) remain joinable.

## Keep vs drop

**Keep:** taxonomy + `app.kubernetes.io/{managed-by,version,created-by,controller}`, Helm chart/release, Flux name+namespace, CNPG roles, Rook/Ceph type/cluster/version/device-class, Tailscale parent labels, Fission function/env names (not UIDs), assorted low-card one-offs (`role`, `tier`, `svc`, …).

**Drop:** `pod-template-hash`, `controller-*-hash/uid`, batch/job UIDs, StatefulSet pod index/name, `functionUid`/`environmentUid`, `ceph_daemon_id`/`ceph-osd-id`, `topology-location-*`, Helm `heritage`.

## Test plan

- [ ] After Flux upgrades KSM, `label_app_kubernetes_io_name` and `label_helm_sh_chart` still present on `kube_pod_labels` / `kube_deployment_labels`
- [ ] `count({__name__="kube_pod_labels",label_pod_template_hash!=""}) or vector(0)` → `0`
- [ ] CNPG/Rook joins still work via allowlisted keys (camelCase CNPG labels)
- [ ] Kubelet `uid` / container `id` labeldrops unchanged

Related: beads `homelab-1vb.7`