### PR TITLE
feat(observability): default-on canonical labels for Service scrapes

### DIFF
--- a/docs/runbooks/observability-label-taxonomy.md
+++ b/docs/runbooks/observability-label-taxonomy.md
@@ -41,23 +41,28 @@ do not imply a collector failure.
   automatically copied into Pod templates, so `flux_kustomization` and
   `helmrelease` are commonly unavailable on container-log Pods.
 
-## Experimental metrics target labels
+## Metrics target labels (Service scrapes)
 
-Application metrics taxonomy labels are gated by the experimental Service flag
-`experimental.homelab.zebernst.dev/canonical-labels: "true"`. Flagged Services
-today:
+Application metrics taxonomy enrichment is **default-on** for Service-backed
+scrapes. vmagent promotes discovery metadata onto taxonomy labels whenever
+`__meta_kubernetes_service_name` is present, unless the Service opts out with:
+
+```yaml
+observability.homelab.zebernst.dev/canonical-labels: "false"
+```
+
+Current opt-outs (exporter Services whose identity is the scraper, not the
+series subject):
 
 | Namespace | Services |
 |-----------|----------|
-| `self-hosted` | `atuin`, `paperless`, `dawarich` |
-| `observability` | `gatus`, `gatus-external` |
-| `downloads` | `autobrr`, `bazarr`, `bazarr-uhd`, `lidarr`, `prowlarr`, `qui`, `radarr`, `radarr-uhd`, `sonarr`, `sonarr-uhd`, `unpackerr` |
+| `observability` | `kube-state-metrics`, `node-exporter` |
 
-Static `VMProbe` targets, kubelet and cAdvisor, kube-state-metrics,
-node-exporter, and every Service without that flag remain unaffected.
+Static `VMProbe` targets, kubelet, and cAdvisor are not Service scrapes, so they
+remain unaffected by this path.
 
-For flagged Service-backed targets, vmagent promotes metadata that exists at
-discovery time:
+For Service-backed targets (without opt-out), vmagent promotes metadata that
+exists at discovery time:
 
 - `namespace` from the Kubernetes namespace.
 - `pod` and `container` from Pod discovery metadata, when present.

--- a/docs/superpowers/plans/2026-07-26-canonical-labels-default.md
+++ b/docs/superpowers/plans/2026-07-26-canonical-labels-default.md
@@ -1,0 +1,263 @@
+# Canonical Labels Default-On Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Service-scrape taxonomy enrichment default-on, with an explicit opt-out on kube-state-metrics and node-exporter, and remove all experimental opt-in flags.
+
+**Architecture:** Replace the experimental Service label gate in `vmagent` `globalScrapeRelabelConfigs` with `__meta_kubernetes_service_name` plus opt-out label `observability.homelab.zebernst.dev/canonical-labels` matching `(|true)`. Opt out the two exporter Services via chart values. Delete the sixteen application opt-in flags. Update runbook and epic tracking.
+
+**Tech Stack:** Flux GitOps, VictoriaMetrics k8s-stack HelmRelease, kube-state-metrics / prometheus-node-exporter subcharts, PromQL live validation.
+
+**Spec:** `docs/superpowers/specs/2026-07-26-canonical-labels-default-design.md`
+
+## Global Constraints
+
+- Enrich only Service-backed scrapes (`__meta_kubernetes_service_name` non-empty).
+- Opt-out label: `observability.homelab.zebernst.dev/canonical-labels: "false"` (meta key `observability_homelab_zebernst_dev_canonical_labels`).
+- Enrichment regex: `(.+);(|true);(.+)` with value replacement `$3`.
+- Required opt-outs: kube-state-metrics (`customLabels`) and node-exporter (`service.labels`).
+- Do not change remote-write sample-wins restore or Fluent Bit log taxonomy.
+- Work from a fresh branch/worktree off `main`; do not commit unless the user asks (or a later task explicitly says to after user approval).
+
+---
+
+## File map
+
+| File | Responsibility |
+|------|----------------|
+| `kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml` | Relabel gate change + KSM/node-exporter opt-out labels |
+| Sixteen app `helmrelease.yaml` files listed in Task 2 | Remove experimental opt-in Service labels |
+| `docs/runbooks/observability-label-taxonomy.md` | Document default-on + opt-out |
+| `docs/superpowers/specs/2026-07-26-canonical-labels-default-design.md` | Already written; include in PR if uncommitted |
+| Beads `homelab-1vb` / new child | Track work; update epic design bullets |
+
+---
+
+### Task 1: Switch vmagent gate + platform opt-outs
+
+**Files:**
+- Modify: `kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml` (`vmagent.spec.globalScrapeRelabelConfigs`, `kube-state-metrics`, `prometheus-node-exporter`)
+
+**Interfaces:**
+- Consumes: existing enrichment target labels (`namespace`, `pod`, `container`, `app`, `app_instance`, `component`, `part_of`, `helmrelease`, `flux_kustomization`) and precedence order
+- Produces: default-on Service enrichment; opt-out meta label present on KSM and node-exporter Services
+
+- [ ] **Step 1: Create branch/worktree from main**
+
+```bash
+cd /Users/zach/Developer/homelab
+git fetch origin main
+# Prefer worktree if using-git-worktrees skill; otherwise:
+git checkout -b feat/canonical-labels-default origin/main
+```
+
+- [ ] **Step 2: Replace every experimental gate in `globalScrapeRelabelConfigs`**
+
+For each enrichment rule currently shaped like:
+
+```yaml
+- action: replace
+  sourceLabels:
+    - __meta_kubernetes_service_label_experimental_homelab_zebernst_dev_canonical_labels
+    - <DISCOVERY_LABEL>
+  regex: true;(.+)
+  replacement: $1
+  targetLabel: <TARGET>
+```
+
+change to:
+
+```yaml
+- action: replace
+  sourceLabels:
+    - __meta_kubernetes_service_name
+    - __meta_kubernetes_service_label_observability_homelab_zebernst_dev_canonical_labels
+    - <DISCOVERY_LABEL>
+  regex: (.+);(|true);(.+)
+  replacement: $3
+  targetLabel: <TARGET>
+```
+
+Apply to all rules in that block (namespace, app precedence chain, app_instance, component, part_of, helmrelease, flux_kustomization, pod, container, and Pod-level app overrides). Leave `inlineRelabelConfig` (exported_* restore) untouched.
+
+- [ ] **Step 3: Opt out kube-state-metrics and node-exporter Services**
+
+Under `kube-state-metrics:` add:
+
+```yaml
+customLabels:
+  observability.homelab.zebernst.dev/canonical-labels: "false"
+```
+
+Under `prometheus-node-exporter:` add:
+
+```yaml
+service:
+  labels:
+    observability.homelab.zebernst.dev/canonical-labels: "false"
+```
+
+(If `service:` already exists for node-exporter, merge `labels` into it.)
+
+- [ ] **Step 4: Sanity-check the YAML locally**
+
+```bash
+rg -n 'experimental_homelab_zebernst_dev_canonical_labels|observability_homelab_zebernst_dev_canonical_labels|canonical-labels' \
+  kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
+```
+
+Expected:
+- Zero matches for `experimental_homelab_...`
+- Many `observability_homelab_...` in `globalScrapeRelabelConfigs`
+- Two `"false"` opt-outs under KSM `customLabels` and node-exporter `service.labels`
+
+- [ ] **Step 5: Commit this task only if the user asked for commits; otherwise leave staged/unstaged for a single PR commit later**
+
+Suggested message if committing:
+
+```text
+feat(observability): default-on canonical labels for Service scrapes
+```
+
+---
+
+### Task 2: Remove experimental flags from application Services
+
+**Files:**
+- Modify (remove the label key entirely from Service labels):
+  - `kubernetes/apps/self-hosted/atuin/app/helmrelease.yaml`
+  - `kubernetes/apps/self-hosted/paperless/app/helmrelease.yaml`
+  - `kubernetes/apps/self-hosted/dawarich/app/helmrelease.yaml`
+  - `kubernetes/apps/observability/gatus/private/helmrelease.yaml`
+  - `kubernetes/apps/observability/gatus/external/helmrelease.yaml`
+  - `kubernetes/apps/downloads/autobrr/app/helmrelease.yaml`
+  - `kubernetes/apps/downloads/bazarr/hd/helmrelease.yaml`
+  - `kubernetes/apps/downloads/bazarr/uhd/helmrelease.yaml`
+  - `kubernetes/apps/downloads/lidarr/app/helmrelease.yaml`
+  - `kubernetes/apps/downloads/prowlarr/app/helmrelease.yaml`
+  - `kubernetes/apps/downloads/qui/app/helmrelease.yaml`
+  - `kubernetes/apps/downloads/radarr/app/hd/helmrelease.yaml`
+  - `kubernetes/apps/downloads/radarr/app/uhd/helmrelease.yaml`
+  - `kubernetes/apps/downloads/sonarr/app/hd/helmrelease.yaml`
+  - `kubernetes/apps/downloads/sonarr/app/uhd/helmrelease.yaml`
+  - `kubernetes/apps/downloads/unpackerr/app/helmrelease.yaml`
+
+**Interfaces:**
+- Consumes: Task 1 default-on gate (apps no longer need opt-in)
+- Produces: repo with zero experimental canonical-labels flags
+
+- [ ] **Step 1: Delete the experimental label from each Service**
+
+Remove this line wherever it appears under Service labels:
+
+```yaml
+experimental.homelab.zebernst.dev/canonical-labels: "true"
+```
+
+Do not leave an empty `labels:` map if it becomes empty solely because of this key — keep any remaining labels; if `labels:` would be empty, remove the whole `labels:` block only when that matches surrounding chart structure.
+
+- [ ] **Step 2: Verify repo-wide cleanup**
+
+```bash
+rg -n 'experimental\.homelab\.zebernst\.dev/canonical-labels' kubernetes docs || true
+```
+
+Expected: no matches (except possibly historical notes in agent transcripts outside the repo).
+
+---
+
+### Task 3: Update runbook + beads
+
+**Files:**
+- Modify: `docs/runbooks/observability-label-taxonomy.md` (section currently titled “Experimental metrics target labels”)
+- Beads: create/close child under `homelab-1vb`; update epic design bullet
+
+**Interfaces:**
+- Consumes: policy from the design spec
+- Produces: operator-facing docs matching live behavior
+
+- [ ] **Step 1: Rewrite the metrics section**
+
+Replace the experimental / flagged-Services table with:
+
+- Title: “Metrics target labels (Service scrapes)”
+- Default: all Service-backed scrapes get taxonomy enrichment
+- Opt-out: `observability.homelab.zebernst.dev/canonical-labels: "false"` on the Service
+- Current opt-outs: `kube-state-metrics`, `node-exporter`
+- Non-Service scrapes (kubelet, cAdvisor, static VMProbe) remain unaffected
+- Keep the existing precedence / Flux / sample-wins paragraphs (still accurate)
+
+- [ ] **Step 2: Create and track the bead**
+
+```bash
+mise x -- bd create "Default-on canonical metrics labels (Service scrapes)" \
+  --type task --priority 2 --parent homelab-1vb
+# note the new id, e.g. homelab-1vb.9
+```
+
+Update epic `homelab-1vb` description: change the metrics enrichment bullet from experimental opt-in to default-on + opt-out.
+
+- [ ] **Step 3: Commit docs/beads with the code change when opening the PR (user-approved commit)**
+
+---
+
+### Task 4: PR, merge follow-up, live validate
+
+**Files:** none beyond prior tasks
+
+- [ ] **Step 1: Open PR**
+
+Include design spec path in the PR body. Summary bullets:
+
+- Default-on canonical labels for Service scrapes
+- Opt-out on kube-state-metrics + node-exporter
+- Remove experimental flags from 16 apps
+- Runbook update
+
+- [ ] **Step 2: After merge + Flux upgrades vmagent / Services, validate**
+
+```bash
+QUERY_URL="http://vmsingle-vmks.observability.svc:8428"
+# helper: kubectl run curl pod as in prior sessions
+
+# Former pilot still labeled
+query 'count(up{app="paperless"})'
+
+# Unflagged Service scrape should now be able to carry app when discovery has it
+# Pick any ServiceMonitor/VMServiceScrape app that never had the experimental flag
+query 'count(up{namespace="cert-manager",app!=""})'
+
+# KSM must NOT stamp app=kube-state-metrics onto kube_* series
+query 'count(kube_pod_info{app="kube-state-metrics"}) or vector(0)'
+# expect 0 (or only if sample itself had that label — should be ~0)
+
+# node-exporter inert for taxonomy app
+query 'count(node_cpu_seconds_total{app!=""}) or vector(0)'
+
+# Live Services carry opt-out
+kubectl -n observability get svc kube-state-metrics node-exporter \
+  -o jsonpath='{range .items[*]}{.metadata.name}{" "}{.metadata.labels.observability\.homelab\.zebernst\.dev/canonical-labels}{"\n"}{end}'
+# expect: false / false
+```
+
+- [ ] **Step 3: Close the bead** with merge + validation notes
+
+---
+
+## Spec coverage checklist
+
+| Spec requirement | Task |
+|------------------|------|
+| Service-name gate + opt-out regex | Task 1 |
+| Opt-out on KSM + node-exporter | Task 1 |
+| Delete 16 experimental flags | Task 2 |
+| Runbook rewrite | Task 3 |
+| Epic/bead tracking | Task 3 |
+| Live validation queries | Task 4 |
+| Unchanged restore / log taxonomy / KSM allowlist | Task 1 leaves them alone |
+
+## Self-review notes
+
+- No TBD/placeholders.
+- Replacement `$3` matches three sourceLabels; do not leave `$1` from the old two-label rules.
+- Node-exporter chart key is `prometheus-node-exporter.service.labels`; KSM is `kube-state-metrics.customLabels`.

--- a/docs/superpowers/specs/2026-07-26-canonical-labels-default-design.md
+++ b/docs/superpowers/specs/2026-07-26-canonical-labels-default-design.md
@@ -1,0 +1,122 @@
+# Canonical metrics labels as Service-scrape default
+
+Date: 2026-07-26  
+Status: approved for implementation  
+Related: epic `homelab-1vb`, runbook `docs/runbooks/observability-label-taxonomy.md`
+
+## Goal
+
+Make application metrics taxonomy enrichment the **default** for Service-backed
+scrapes. Remove the experimental opt-in Service flag. Keep kubelet, cAdvisor,
+static VMProbes, and exporter Services that describe *other* subjects (notably
+kube-state-metrics) from being incorrectly stamped.
+
+## Non-goals
+
+- Pod-level Flux provenance on logs (still deferred as `homelab-1vb.8`)
+- Changing Fluent Bit / VictoriaLogs taxonomy
+- Changing remote-write sample-wins restore (`exported_*` → identity labels)
+- Annotating every application Service
+
+## Current behavior
+
+`vmagent` `globalScrapeRelabelConfigs` promote discovery metadata onto taxonomy
+labels only when the scraped Service has:
+
+```yaml
+experimental.homelab.zebernst.dev/canonical-labels: "true"
+```
+
+Sixteen application Services carry that flag today. Platform scrapes without it
+are inert.
+
+## Design
+
+### Policy
+
+| Scrape kind | Enrichment |
+|-------------|------------|
+| Service-backed scrape, no opt-out | **On** (default) |
+| Service-backed scrape with opt-out `"false"` | Off |
+| Non-Service scrapes (kubelet, cAdvisor, static VMProbe, etc.) | Off (no `__meta_kubernetes_service_name`) |
+
+### Gate + opt-out
+
+Each enrichment rule uses three source labels:
+
+1. `__meta_kubernetes_service_name` — must be non-empty (Service scrape)
+2. `__meta_kubernetes_service_label_observability_homelab_zebernst_dev_canonical_labels` — must be empty or `true` (not `false`)
+3. The discovery value to copy (unchanged from today)
+
+Regex shape (RE2):
+
+```text
+(.+);(|true);(.+)
+```
+
+Replacement for the copied value: `$3`.
+
+Stable opt-out label on the Service:
+
+```yaml
+observability.homelab.zebernst.dev/canonical-labels: "false"
+```
+
+No opt-in label. Delete all
+`experimental.homelab.zebernst.dev/canonical-labels` annotations/labels from
+application HelmReleases.
+
+### Required opt-outs
+
+Set the opt-out on Services whose identity is the *scraper*, not the series
+subject:
+
+- `kube-state-metrics` (otherwise every `kube_*` series would get
+  `app=kube-state-metrics`)
+- `node-exporter` (keep current inert behavior for node scrapes)
+
+Apply via `victoria-metrics-k8s-stack` Helm values (`customLabels` /
+`service.labels` — whichever the chart wires onto the Service).
+
+Other VictoriaMetrics / app Services may keep default-on; stamping
+`app=vmsingle` (etc.) on their own metrics is correct.
+
+### Unchanged
+
+- App precedence: Service then Pod, `app.kubernetes.io/name` > `app` > `k8s-app`
+- Flux: `helmrelease` / `flux_kustomization` from native toolkit Service labels
+  only when present
+- `inlineRelabelConfig` remote-write restore + `exported_*` labeldrop
+- KSM `metricLabelsAllowlist` and kubelet uid/id drops
+
+## Docs / tracking
+
+- Rewrite runbook section “Experimental metrics target labels” → default Service
+  scrape enrichment + opt-out table
+- Update epic `homelab-1vb` design bullets (opt-in → default-on + opt-out)
+- New bead under the epic for this change; close when merged and live-validated
+
+## Validation
+
+After Flux upgrades `vmagent`:
+
+1. A former pilot (e.g. `up{app="paperless"}`) still has taxonomy labels without
+   the experimental Service flag.
+2. A previously unflagged Service-backed app scrape gains `app` / Flux labels
+   when discovery metadata exists.
+3. `kube_pod_labels` / `kube_*` series do **not** all carry
+   `app="kube-state-metrics"`.
+4. `node_cpu_*` (or equivalent) do not pick up unexpected taxonomy `app` from
+   enrichment.
+5. Kubelet/cAdvisor series remain without forged Flux labels from this path.
+6. Grep the repo: no remaining `experimental.homelab.zebernst.dev/canonical-labels`.
+
+## Rollout
+
+Single PR from a fresh branch off `main`:
+
+1. Relabel gate change + KSM/node-exporter opt-out in
+   `kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml`
+2. Remove experimental flags from the sixteen app HelmReleases
+3. Runbook (+ epic/bead) updates
+4. Merge, live-validate, close bead

--- a/kubernetes/apps/downloads/autobrr/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/autobrr/app/helmrelease.yaml
@@ -69,8 +69,6 @@ spec:
     service:
       autobrr:
         controller: *app
-        labels:
-          experimental.homelab.zebernst.dev/canonical-labels: "true"
         ports:
           http:
             port: *port

--- a/kubernetes/apps/downloads/bazarr/hd/helmrelease.yaml
+++ b/kubernetes/apps/downloads/bazarr/hd/helmrelease.yaml
@@ -104,8 +104,6 @@ spec:
       bazarr:
         controller: *app
         forceRename: *app
-        labels:
-          experimental.homelab.zebernst.dev/canonical-labels: "true"
         ports:
           http:
             port: *port

--- a/kubernetes/apps/downloads/bazarr/uhd/helmrelease.yaml
+++ b/kubernetes/apps/downloads/bazarr/uhd/helmrelease.yaml
@@ -104,8 +104,6 @@ spec:
       bazarr-uhd:
         controller: *app
         forceRename: *app
-        labels:
-          experimental.homelab.zebernst.dev/canonical-labels: "true"
         ports:
           http:
             port: *port

--- a/kubernetes/apps/downloads/lidarr/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/lidarr/app/helmrelease.yaml
@@ -104,8 +104,6 @@ spec:
       lidarr:
         controller: *app
         forceRename: *app
-        labels:
-          experimental.homelab.zebernst.dev/canonical-labels: "true"
         ports:
           http:
             port: *port

--- a/kubernetes/apps/downloads/prowlarr/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/prowlarr/app/helmrelease.yaml
@@ -102,8 +102,6 @@ spec:
       prowlarr:
         controller: *app
         forceRename: *app
-        labels:
-          experimental.homelab.zebernst.dev/canonical-labels: "true"
         ports:
           http:
             port: *port

--- a/kubernetes/apps/downloads/qui/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/qui/app/helmrelease.yaml
@@ -78,8 +78,6 @@ spec:
       qui:
         controller: *app
         forceRename: *app
-        labels:
-          experimental.homelab.zebernst.dev/canonical-labels: "true"
         ports:
           http:
             port: *port

--- a/kubernetes/apps/downloads/radarr/app/hd/helmrelease.yaml
+++ b/kubernetes/apps/downloads/radarr/app/hd/helmrelease.yaml
@@ -105,8 +105,6 @@ spec:
       radarr:
         controller: *app
         forceRename: *app
-        labels:
-          experimental.homelab.zebernst.dev/canonical-labels: "true"
         ports:
           http:
             port: *port

--- a/kubernetes/apps/downloads/radarr/app/uhd/helmrelease.yaml
+++ b/kubernetes/apps/downloads/radarr/app/uhd/helmrelease.yaml
@@ -105,8 +105,6 @@ spec:
       radarr-uhd:
         controller: *app
         forceRename: *app
-        labels:
-          experimental.homelab.zebernst.dev/canonical-labels: "true"
         ports:
           http:
             port: *port

--- a/kubernetes/apps/downloads/sonarr/app/hd/helmrelease.yaml
+++ b/kubernetes/apps/downloads/sonarr/app/hd/helmrelease.yaml
@@ -103,8 +103,6 @@ spec:
       sonarr:
         controller: *app
         forceRename: *app
-        labels:
-          experimental.homelab.zebernst.dev/canonical-labels: "true"
         ports:
           http:
             port: *port

--- a/kubernetes/apps/downloads/sonarr/app/uhd/helmrelease.yaml
+++ b/kubernetes/apps/downloads/sonarr/app/uhd/helmrelease.yaml
@@ -103,8 +103,6 @@ spec:
       sonarr-uhd:
         controller: *app
         forceRename: *app
-        labels:
-          experimental.homelab.zebernst.dev/canonical-labels: "true"
         ports:
           http:
             port: *port

--- a/kubernetes/apps/downloads/unpackerr/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/unpackerr/app/helmrelease.yaml
@@ -67,8 +67,6 @@ spec:
     service:
       unpackerr:
         controller: *app
-        labels:
-          experimental.homelab.zebernst.dev/canonical-labels: "true"
         ports:
           http:
             port: 5656

--- a/kubernetes/apps/observability/gatus/external/helmrelease.yaml
+++ b/kubernetes/apps/observability/gatus/external/helmrelease.yaml
@@ -79,8 +79,6 @@ spec:
         runAsGroup: 568
     service:
       gatus-external:
-        labels:
-          experimental.homelab.zebernst.dev/canonical-labels: "true"
         ports:
           http:
             port: *port

--- a/kubernetes/apps/observability/gatus/private/helmrelease.yaml
+++ b/kubernetes/apps/observability/gatus/private/helmrelease.yaml
@@ -81,8 +81,6 @@ spec:
         runAsGroup: 568
     service:
       gatus:
-        labels:
-          experimental.homelab.zebernst.dev/canonical-labels: "true"
         ports:
           http:
             port: *port

--- a/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
@@ -173,124 +173,141 @@ spec:
         globalScrapeRelabelConfigs:
           - action: replace
             sourceLabels:
-              - __meta_kubernetes_service_label_experimental_homelab_zebernst_dev_canonical_labels
+              - __meta_kubernetes_service_name
+              - __meta_kubernetes_service_label_observability_homelab_zebernst_dev_canonical_labels
               - __meta_kubernetes_namespace
-            regex: true;(.+)
-            replacement: $1
+            regex: (.+);(|true);(.+)
+            replacement: $3
             targetLabel: namespace
           # Service app labels are ordered from lowest to highest precedence.
           - action: replace
             sourceLabels:
-              - __meta_kubernetes_service_label_experimental_homelab_zebernst_dev_canonical_labels
+              - __meta_kubernetes_service_name
+              - __meta_kubernetes_service_label_observability_homelab_zebernst_dev_canonical_labels
               - __meta_kubernetes_service_label_k8s_app
-            regex: true;(.+)
-            replacement: $1
+            regex: (.+);(|true);(.+)
+            replacement: $3
             targetLabel: app
           - action: replace
             sourceLabels:
-              - __meta_kubernetes_service_label_experimental_homelab_zebernst_dev_canonical_labels
+              - __meta_kubernetes_service_name
+              - __meta_kubernetes_service_label_observability_homelab_zebernst_dev_canonical_labels
               - __meta_kubernetes_service_label_app
-            regex: true;(.+)
-            replacement: $1
+            regex: (.+);(|true);(.+)
+            replacement: $3
             targetLabel: app
           - action: replace
             sourceLabels:
-              - __meta_kubernetes_service_label_experimental_homelab_zebernst_dev_canonical_labels
+              - __meta_kubernetes_service_name
+              - __meta_kubernetes_service_label_observability_homelab_zebernst_dev_canonical_labels
               - __meta_kubernetes_service_label_app_kubernetes_io_name
-            regex: true;(.+)
-            replacement: $1
+            regex: (.+);(|true);(.+)
+            replacement: $3
             targetLabel: app
           - action: replace
             sourceLabels:
-              - __meta_kubernetes_service_label_experimental_homelab_zebernst_dev_canonical_labels
+              - __meta_kubernetes_service_name
+              - __meta_kubernetes_service_label_observability_homelab_zebernst_dev_canonical_labels
               - __meta_kubernetes_service_label_app_kubernetes_io_instance
-            regex: true;(.+)
-            replacement: $1
+            regex: (.+);(|true);(.+)
+            replacement: $3
             targetLabel: app_instance
           - action: replace
             sourceLabels:
-              - __meta_kubernetes_service_label_experimental_homelab_zebernst_dev_canonical_labels
+              - __meta_kubernetes_service_name
+              - __meta_kubernetes_service_label_observability_homelab_zebernst_dev_canonical_labels
               - __meta_kubernetes_service_label_app_kubernetes_io_component
-            regex: true;(.+)
-            replacement: $1
+            regex: (.+);(|true);(.+)
+            replacement: $3
             targetLabel: component
           - action: replace
             sourceLabels:
-              - __meta_kubernetes_service_label_experimental_homelab_zebernst_dev_canonical_labels
+              - __meta_kubernetes_service_name
+              - __meta_kubernetes_service_label_observability_homelab_zebernst_dev_canonical_labels
               - __meta_kubernetes_service_label_app_kubernetes_io_part_of
-            regex: true;(.+)
-            replacement: $1
+            regex: (.+);(|true);(.+)
+            replacement: $3
             targetLabel: part_of
           - action: replace
             sourceLabels:
-              - __meta_kubernetes_service_label_experimental_homelab_zebernst_dev_canonical_labels
+              - __meta_kubernetes_service_name
+              - __meta_kubernetes_service_label_observability_homelab_zebernst_dev_canonical_labels
               - __meta_kubernetes_service_label_helm_toolkit_fluxcd_io_name
-            regex: true;(.+)
-            replacement: $1
+            regex: (.+);(|true);(.+)
+            replacement: $3
             targetLabel: helmrelease
           - action: replace
             sourceLabels:
-              - __meta_kubernetes_service_label_experimental_homelab_zebernst_dev_canonical_labels
+              - __meta_kubernetes_service_name
+              - __meta_kubernetes_service_label_observability_homelab_zebernst_dev_canonical_labels
               - __meta_kubernetes_service_label_kustomize_toolkit_fluxcd_io_name
-            regex: true;(.+)
-            replacement: $1
+            regex: (.+);(|true);(.+)
+            replacement: $3
             targetLabel: flux_kustomization
           - action: replace
             sourceLabels:
-              - __meta_kubernetes_service_label_experimental_homelab_zebernst_dev_canonical_labels
+              - __meta_kubernetes_service_name
+              - __meta_kubernetes_service_label_observability_homelab_zebernst_dev_canonical_labels
               - __meta_kubernetes_pod_name
-            regex: true;(.+)
-            replacement: $1
+            regex: (.+);(|true);(.+)
+            replacement: $3
             targetLabel: pod
           - action: replace
             sourceLabels:
-              - __meta_kubernetes_service_label_experimental_homelab_zebernst_dev_canonical_labels
+              - __meta_kubernetes_service_name
+              - __meta_kubernetes_service_label_observability_homelab_zebernst_dev_canonical_labels
               - __meta_kubernetes_pod_container_name
-            regex: true;(.+)
-            replacement: $1
+            regex: (.+);(|true);(.+)
+            replacement: $3
             targetLabel: container
           # Pod app labels run after Service labels so Pod metadata wins.
           - action: replace
             sourceLabels:
-              - __meta_kubernetes_service_label_experimental_homelab_zebernst_dev_canonical_labels
+              - __meta_kubernetes_service_name
+              - __meta_kubernetes_service_label_observability_homelab_zebernst_dev_canonical_labels
               - __meta_kubernetes_pod_label_k8s_app
-            regex: true;(.+)
-            replacement: $1
+            regex: (.+);(|true);(.+)
+            replacement: $3
             targetLabel: app
           - action: replace
             sourceLabels:
-              - __meta_kubernetes_service_label_experimental_homelab_zebernst_dev_canonical_labels
+              - __meta_kubernetes_service_name
+              - __meta_kubernetes_service_label_observability_homelab_zebernst_dev_canonical_labels
               - __meta_kubernetes_pod_label_app
-            regex: true;(.+)
-            replacement: $1
+            regex: (.+);(|true);(.+)
+            replacement: $3
             targetLabel: app
           - action: replace
             sourceLabels:
-              - __meta_kubernetes_service_label_experimental_homelab_zebernst_dev_canonical_labels
+              - __meta_kubernetes_service_name
+              - __meta_kubernetes_service_label_observability_homelab_zebernst_dev_canonical_labels
               - __meta_kubernetes_pod_label_app_kubernetes_io_name
-            regex: true;(.+)
-            replacement: $1
+            regex: (.+);(|true);(.+)
+            replacement: $3
             targetLabel: app
           - action: replace
             sourceLabels:
-              - __meta_kubernetes_service_label_experimental_homelab_zebernst_dev_canonical_labels
+              - __meta_kubernetes_service_name
+              - __meta_kubernetes_service_label_observability_homelab_zebernst_dev_canonical_labels
               - __meta_kubernetes_pod_label_app_kubernetes_io_instance
-            regex: true;(.+)
-            replacement: $1
+            regex: (.+);(|true);(.+)
+            replacement: $3
             targetLabel: app_instance
           - action: replace
             sourceLabels:
-              - __meta_kubernetes_service_label_experimental_homelab_zebernst_dev_canonical_labels
+              - __meta_kubernetes_service_name
+              - __meta_kubernetes_service_label_observability_homelab_zebernst_dev_canonical_labels
               - __meta_kubernetes_pod_label_app_kubernetes_io_component
-            regex: true;(.+)
-            replacement: $1
+            regex: (.+);(|true);(.+)
+            replacement: $3
             targetLabel: component
           - action: replace
             sourceLabels:
-              - __meta_kubernetes_service_label_experimental_homelab_zebernst_dev_canonical_labels
+              - __meta_kubernetes_service_name
+              - __meta_kubernetes_service_label_observability_homelab_zebernst_dev_canonical_labels
               - __meta_kubernetes_pod_label_app_kubernetes_io_part_of
-            regex: true;(.+)
-            replacement: $1
+            regex: (.+);(|true);(.+)
+            replacement: $3
             targetLabel: part_of
         extraArgs:
           promscrape.dropOriginalLabels: "true"
@@ -361,6 +378,9 @@ spec:
 
     prometheus-node-exporter:
       fullnameOverride: node-exporter
+      service:
+        labels:
+          observability.homelab.zebernst.dev/canonical-labels: "false"
       vmScrape:
         enabled: true
         spec:
@@ -376,6 +396,8 @@ spec:
 
     kube-state-metrics:
       fullnameOverride: kube-state-metrics
+      customLabels:
+        observability.homelab.zebernst.dev/canonical-labels: "false"
       # Explicit allowlist (not [*]). Still drops high-cardinality controller noise:
       # pod-template-hash, controller-revision-hash, controller-uid, job/batch UIDs,
       # apps.kubernetes.io/pod-index, statefulset.kubernetes.io/pod-name,

--- a/kubernetes/apps/self-hosted/atuin/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/atuin/app/helmrelease.yaml
@@ -71,8 +71,6 @@ spec:
     service:
       atuin:
         controller: *app
-        labels:
-          experimental.homelab.zebernst.dev/canonical-labels: "true"
         ports:
           http:
             primary: true

--- a/kubernetes/apps/self-hosted/dawarich/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/dawarich/app/helmrelease.yaml
@@ -138,8 +138,6 @@ spec:
     service:
       dawarich:
         controller: *app
-        labels:
-          experimental.homelab.zebernst.dev/canonical-labels: "true"
         ports:
           http:
             port: 3000

--- a/kubernetes/apps/self-hosted/paperless/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/paperless/app/helmrelease.yaml
@@ -122,8 +122,6 @@ spec:
     service:
       paperless:
         controller: *app
-        labels:
-          experimental.homelab.zebernst.dev/canonical-labels: "true"
         ports:
           http:
             port: *port


### PR DESCRIPTION
## Summary

- Make metrics taxonomy enrichment **default-on** for Service-backed scrapes (gate on `__meta_kubernetes_service_name`, skip when Service has opt-out `false`)
- Opt out `kube-state-metrics` and `node-exporter` so exporter scrapes are not stamped with scraper identity
- Remove experimental `canonical-labels: "true"` from 16 app Services
- Update runbook; design/plan under `docs/superpowers/`

## Test plan

- [ ] After Flux upgrades vmagent: `up{app="paperless"}` still works without experimental Service flag
- [ ] A previously unflagged Service scrape can carry `app` when discovery has it (e.g. cert-manager)
- [ ] `count(kube_pod_info{app="kube-state-metrics"}) or vector(0)` → ~0
- [ ] node-exporter series not unexpectedly getting taxonomy `app`
- [ ] `kubectl get svc -n observability kube-state-metrics node-exporter` shows opt-out label `false`
- [ ] Repo grep: no `experimental.homelab.zebernst.dev/canonical-labels` under `kubernetes/`

Related: beads `homelab-1vb.9`  
Spec: `docs/superpowers/specs/2026-07-26-canonical-labels-default-design.md`