### PR TITLE
chore(rook-ceph): bump charts to v1.19.7 before 1.20 CSI cutover

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/app/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/app/helmrelease.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: rook-ceph
-      version: v1.19.2
+      version: v1.19.7
       sourceRef:
         kind: HelmRepository
         name: rook-ceph

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -10,7 +10,7 @@ spec:
   chart:
     spec:
       chart: rook-ceph-cluster
-      version: v1.19.2
+      version: v1.19.7
       sourceRef:
         kind: HelmRepository
         name: rook-ceph


### PR DESCRIPTION
## Summary
- Bump `rook-ceph` and `rook-ceph-cluster` Helm charts from `v1.19.2` → `v1.19.7`.
- Required intermediate hop before Rook 1.20: Helm upgrades need ≥ `v1.19.5` for CSI helm-ownership annotations that make the later `ceph-csi-drivers` adoption safe.

## Why
Rook's [1.20 upgrade guide](https://rook.io/docs/rook/latest/Upgrade/rook-upgrade/) says: *Before upgrading to v1.20, ensure the cluster is already on at least v1.19.5.*

Merging Renovate [#1240](https://github.com/zebernst/homelab/pull/1240) / [#1241](https://github.com/zebernst/homelab/pull/1241) (`1.19.2` → `1.20.2`) without this hop skips that fix.

## Test plan
- [ ] Merge and wait for Flux to reconcile both HelmReleases to `v1.19.7`
- [ ] Confirm `CephCluster` health is `HEALTH_OK` or `HEALTH_WARN` (not `HEALTH_ERR`)
- [ ] Confirm CSI provisioner/plugin pods are Ready
- [ ] Spot-check an existing RBD and CephFS mount still work
- [ ] Then proceed to the follow-up PR: `feat/rook-ceph-1.20-csi-drivers`


Made with [Cursor](https://cursor.com)