### PR TITLE
feat(rook-ceph): cut over to 1.20 with ceph-csi-drivers chart

### DIFF
--- a/kubernetes/apps/rook-ceph/ceph-csi-drivers/app/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/ceph-csi-drivers/app/helmrelease.yaml
@@ -1,0 +1,49 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: ceph-csi-drivers
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: ceph-csi-drivers
+      version: 1.0.4
+      sourceRef:
+        kind: HelmRepository
+        name: ceph-csi-operator
+        namespace: flux-system
+
+  values:
+    # Rook-compatible defaults — driver names must match existing StorageClasses.
+    # See https://rook.io/docs/rook/v1.20/Helm-Charts/csi-drivers-chart/
+    operatorConfig:
+      namespace: rook-ceph
+      driverSpecDefaults:
+        imageSet:
+          name: rook-csi-operator-image-set-configmap
+        nodePlugin:
+          priorityClassName: system-node-critical
+        controllerPlugin:
+          priorityClassName: system-cluster-critical
+        # Migrated from rook-ceph chart: csi.cephFSKernelMountOptions
+        kernelMountOptions:
+          ms_mode: prefer-crc
+    drivers:
+      rbd:
+        enabled: true
+        name: rook-ceph.rbd.csi.ceph.com
+        snapshotPolicy: volumeSnapshot
+      cephfs:
+        enabled: true
+        name: rook-ceph.cephfs.csi.ceph.com
+        snapshotPolicy: volumeSnapshot
+        kernelMountOptions:
+          ms_mode: prefer-crc
+      nfs:
+        enabled: false
+        name: rook-ceph.nfs.csi.ceph.com
+      nvmeof:
+        enabled: false
+        name: rook-ceph.nvmeof.csi.ceph.com

--- a/kubernetes/apps/rook-ceph/ceph-csi-drivers/app/kustomization.yaml
+++ b/kubernetes/apps/rook-ceph/ceph-csi-drivers/app/kustomization.yaml
@@ -2,9 +2,5 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: rook-ceph
-components:
-  - ../../components/common
 resources:
-  - ceph-csi-drivers/ks.yaml
-  - rook-ceph/ks.yaml
+  - helmrelease.yaml

--- a/kubernetes/apps/rook-ceph/ceph-csi-drivers/ks.yaml
+++ b/kubernetes/apps/rook-ceph/ceph-csi-drivers/ks.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app ceph-csi-drivers
+  namespace: &ns rook-ceph
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: rook-ceph
+      namespace: *ns
+  interval: 30m
+  retryInterval: 1m
+  path: kubernetes/apps/rook-ceph/ceph-csi-drivers/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *ns
+  timeout: 5m
+  wait: true

--- a/kubernetes/apps/rook-ceph/rook-ceph/app/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/app/helmrelease.yaml
@@ -9,18 +9,15 @@ spec:
   chart:
     spec:
       chart: rook-ceph
-      version: v1.19.7
+      version: v1.20.2
       sourceRef:
         kind: HelmRepository
         name: rook-ceph
         namespace: flux-system
 
   values:
-    csi:
-      cephFSKernelMountOptions: ms_mode=prefer-crc
-      enableLiveness: true
-      serviceMonitor:
-        enabled: false
+    # CSI driver settings moved to the ceph-csi-drivers chart in Rook 1.20.
+    # See kubernetes/apps/rook-ceph/ceph-csi-drivers/
     enableDiscoveryDaemon: true
     monitoring:
       enabled: true

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -10,7 +10,7 @@ spec:
   chart:
     spec:
       chart: rook-ceph-cluster
-      version: v1.19.7
+      version: v1.20.2
       sourceRef:
         kind: HelmRepository
         name: rook-ceph

--- a/kubernetes/apps/rook-ceph/rook-ceph/ks.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/ks.yaml
@@ -34,6 +34,8 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   dependsOn:
+    - name: ceph-csi-drivers
+      namespace: *ns
     - name: rook-ceph
       namespace: *ns
   healthCheckExprs:

--- a/kubernetes/flux/meta/repositories/helm/ceph-csi-operator.yaml
+++ b/kubernetes/flux/meta/repositories/helm/ceph-csi-operator.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: ceph-csi-operator
+  namespace: flux-system
+spec:
+  interval: 2h
+  url: https://ceph.github.io/ceph-csi-operator

--- a/kubernetes/flux/meta/repositories/helm/kustomization.yaml
+++ b/kubernetes/flux/meta/repositories/helm/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 resources:
   - backube.yaml
   - bjw-s.yaml
+  - ceph-csi-operator.yaml
   - cilium.yaml
   - cloudnative-pg.yaml
   - controlplaneio.yaml


### PR DESCRIPTION
## Summary
Safe replacement for Renovate [#1240](https://github.com/zebernst/homelab/pull/1240) / [#1241](https://github.com/zebernst/homelab/pull/1241). Those PRs only bump chart versions and would break CSI attach/detach after Rook 1.20.

- Bump `rook-ceph` + `rook-ceph-cluster` `v1.19.7` → `v1.20.2` (Ceph image will move `v19.2.3` → `v20.2.2` via the cluster chart)
- Add `HelmRepository` `ceph-csi-operator` + new `ceph-csi-drivers` app (chart `1.0.4`)
- Flux order: `rook-ceph` → `ceph-csi-drivers` → `rook-ceph-cluster`
- Rook-compatible driver names (`rook-ceph.rbd.csi.ceph.com` / `rook-ceph.cephfs.csi.ceph.com`) so existing StorageClasses keep working
- Migrate `csi.cephFSKernelMountOptions: ms_mode=prefer-crc` → `kernelMountOptions.ms_mode`
- Drop obsolete operator-chart CSI keys (`enableLiveness`, `serviceMonitor`, kernel mount string)

**Stacked on:** [#1352](https://github.com/zebernst/homelab/pull/1352) (`v1.19.2` → `v1.19.7`). Merge and reconcile that first, then retarget/merge this.

## Why this is required
Rook 1.20 moves CSI management to `ceph-csi-operator`. Helm users **must** install the [`ceph-csi-drivers`](https://rook.io/docs/rook/v1.20/Helm-Charts/csi-drivers-chart/) chart or CSI controller pods lose ServiceAccounts ([rook#17644](https://github.com/rook/rook/issues/17644)). Chart defaults use unprefixed driver names and will break mounts unless Rook-compatible values are set.

## Notes / known gaps
- Previous `csi.enableLiveness: true` is not exposed by the drivers chart templates (`LivenessSpec` exists on the CRD but is not wired in values). Liveness sidecars may drop unless we add a post-renderer later.
- `cephClusterSpec.csi.readAffinity.enabled: true` stays on the cluster chart (unchanged).

## Test plan
- [ ] [#1352](https://github.com/zebernst/homelab/pull/1352) merged and reconciled on `v1.19.7`
- [ ] Merge this PR; confirm Flux applies operator, then drivers, then cluster
- [ ] `kubectl -n rook-ceph get operatorconfig,driver` shows rook-prefixed Drivers Ready
- [ ] CSI ctrlplugin/nodeplugin pods Ready (no missing ServiceAccount errors)
- [ ] Create/delete a throwaway PVC on `ceph-block` and `ceph-filesystem`
- [ ] Existing workloads with mounted PVCs survive (no attach storms)
- [ ] Ceph health returns to OK/WARN after Ceph 19→20 upgrade
- [ ] Close Renovate [#1240](https://github.com/zebernst/homelab/pull/1240) and [#1241](https://github.com/zebernst/homelab/pull/1241) as superseded


Made with [Cursor](https://cursor.com)