### PR TITLE
feat(database): redspot Barman plugin cutover (Phase 0)

### DIFF
--- a/kubernetes/apps/database/cloudnative-pg/cluster/cluster.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/cluster.yaml
@@ -1,5 +1,5 @@
----
 # yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/postgresql.cnpg.io/cluster_v1.json
+---
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
@@ -35,33 +35,9 @@ spec:
           cnpg.io/cluster: *cluster
   monitoring:
     enablePodMonitor: true
-  backup:
-    retentionPolicy: 30d
-    barmanObjectStore: &barmanObjectStore
-      data:
-        compression: bzip2
-      wal:
-        compression: bzip2
-        maxParallel: 8
-      destinationPath: s3://cluster-db-backup/
-      endpointURL: https://s3.us-west-001.backblazeb2.com
-      # Note: serverName version needs to be incremented when recovering from an existing cnpg cluster
-      serverName: postgres-v16-5
-      s3Credentials:
-        accessKeyId:
-          name: cloudnative-pg-secret
-          key: aws-access-key-id
-        secretAccessKey:
-          name: cloudnative-pg-secret
-          key: aws-secret-access-key
-  # Note: previousCluster needs to be set to the name of the previous
-  # cluster when recovering from an existing cnpg cluster
-  bootstrap:
-    recovery:
-      source: &previousCluster postgres-v16-4
-  # Note: externalClusters is needed when recovering from an existing cnpg cluster
-  externalClusters:
-    - name: *previousCluster
-      barmanObjectStore:
-        <<: *barmanObjectStore
-        serverName: *previousCluster
+  plugins:
+    - name: barman-cloud.cloudnative-pg.io
+      isWALArchiver: true
+      parameters:
+        barmanObjectName: redspot-backup
+        serverName: redspot-v17

--- a/kubernetes/apps/database/cloudnative-pg/cluster/kustomization.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 components:
   - ../../../../components/vmrule
 resources:
+  - objectstore.yaml
   - cluster.yaml
   - scheduledbackup.yaml
   - vmrule.yaml

--- a/kubernetes/apps/database/cloudnative-pg/cluster/objectstore.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/objectstore.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/barmancloud.cnpg.io/objectstore_v1.json
+---
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: redspot-backup
+spec:
+  retentionPolicy: 30d
+  configuration:
+    destinationPath: s3://cluster-db-backup/redspot/
+    endpointURL: https://s3.us-west-001.backblazeb2.com
+    s3Credentials:
+      accessKeyId:
+        name: cloudnative-pg-secret
+        key: aws-access-key-id
+      secretAccessKey:
+        name: cloudnative-pg-secret
+        key: aws-secret-access-key
+    wal:
+      compression: bzip2
+      maxParallel: 8
+    data:
+      compression: bzip2

--- a/kubernetes/apps/database/cloudnative-pg/cluster/scheduledbackup.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/scheduledbackup.yaml
@@ -1,5 +1,5 @@
----
 # yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/postgresql.cnpg.io/scheduledbackup_v1.json
+---
 apiVersion: postgresql.cnpg.io/v1
 kind: ScheduledBackup
 metadata:
@@ -8,5 +8,8 @@ spec:
   schedule: "@daily"
   immediate: true
   backupOwnerReference: self
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io
   cluster:
     name: redspot

--- a/kubernetes/apps/database/cloudnative-pg/ks.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/ks.yaml
@@ -62,6 +62,8 @@ spec:
   dependsOn:
     - name: cloudnative-pg
       namespace: *ns
+    - name: cloudnative-pg-barman-plugin
+      namespace: *ns
     - name: openebs
       namespace: openebs-system
   healthCheckExprs:


### PR DESCRIPTION
## Summary
- Add `ObjectStore/redspot-backup` and Flux `dependsOn` on `cloudnative-pg-barman-plugin`
- Wire Cluster `redspot` to barman-cloud plugin (`serverName: redspot-v17`); drop in-tree backup + stale recovery bootstrap
- Point `ScheduledBackup` at `method: plugin` (`immediate: true` for first backup)

Phase 0 of beads epic `homelab-63y` (PG17→18 in-place). Phases 1–2 (trixie roll, major upgrade) follow after live gate.

## Test plan
- [ ] Flux `cloudnative-pg-cluster` reconciles; ObjectStore present
- [ ] Cluster Ready after rolling restart; plugins set; no `spec.backup`
- [ ] WAL archive healthy (`pg_switch_wal` / ContinuousArchiving)
- [ ] Plugin base backup completes on `redspot-v17`
- [ ] Follow-up: set `immediate: false` after first success


Made with [Cursor](https://cursor.com)