### PR TITLE
fix(database): switchover on redspot primary updates

### DIFF
--- a/kubernetes/apps/database/cloudnative-pg/cluster/cluster.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/cluster.yaml
@@ -8,6 +8,7 @@ spec:
   instances: 3
   imageName: ghcr.io/cloudnative-pg/postgresql:${POSTGRESQL_VERSION}
   primaryUpdateStrategy: unsupervised
+  primaryUpdateMethod: switchover
   failoverDelay: 2
   storage:
     size: 20Gi


### PR DESCRIPTION
## Summary
- Set `spec.primaryUpdateMethod: switchover` on Cluster `redspot` so rolling updates promote a replica before recycling the old primary
- Avoids in-place primary restarts (`primaryUpdateMethod: restart` default) that leave the write leader stuck `Terminating` mid-roll

Follow-up to #1354 / beads `homelab-63y`.

## Test plan
- [ ] Flux reconciles `cloudnative-pg-cluster`; Cluster shows `primaryUpdateMethod: switchover`
- [ ] Next rolling change (or deliberate pod recycle) switchovers primary instead of restarting in place
- [ ] `-rw` fails over; old primary recycles as replica without prolonged Terminating-as-primary


Made with [Cursor](https://cursor.com)