### PR TITLE
chore(database): disable immediate redspot ScheduledBackup

### DIFF
--- a/kubernetes/apps/database/cloudnative-pg/cluster/scheduledbackup.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/scheduledbackup.yaml
@@ -6,7 +6,7 @@ metadata:
   name: redspot
 spec:
   schedule: "@daily"
-  immediate: true
+  immediate: false
   backupOwnerReference: self
   method: plugin
   pluginConfiguration:


### PR DESCRIPTION
## Summary
- Sets `ScheduledBackup/redspot` `immediate: false` after Phase 0 plugin gate backup `redspot-plugin-gate` completed successfully (`method: plugin`, `serverName: redspot-v17`).
- Cluster remains Ready with ContinuousArchiving healthy.

## Test plan
- [ ] Flux reconciles ScheduledBackup; `immediate: false` observed
- [ ] No unexpected immediate Backup CR created on reconcile
- [ ] Close beads `homelab-63y.1.3` / `homelab-63y.1` after merge


Made with [Cursor](https://cursor.com)