### PR TITLE
feat(database): roll redspot to 17.10-standard-trixie (Phase 1)

### DIFF
--- a/kubernetes/apps/database/cloudnative-pg/ks.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/ks.yaml
@@ -76,7 +76,7 @@ spec:
   postBuild:
     substitute:
       # renovate: datasource=docker depName=ghcr.io/cloudnative-pg/postgresql
-      POSTGRESQL_VERSION: 17.2-27
+      POSTGRESQL_VERSION: 17.10-standard-trixie
   prune: true
   retryInterval: 1m
   sourceRef:


### PR DESCRIPTION
## Summary
- Bumps `POSTGRESQL_VERSION` from `17.2-27` (bullseye) to `17.10-standard-trixie` (latest 17.x standard/trixie per CNPG catalog dated 2026-07-27).
- Phase 1 of redspot PG18 upgrade (`homelab-63y.2`): rolling image/OS align before major `pg_upgrade`.
- `serverName` stays `redspot-v17`; Barman plugin path unchanged.

## Preconditions
- [x] Phase 0 plugin gate backup completed (`redspot-plugin-gate`)
- [ ] [#1356](https://github.com/zebernst/homelab/pull/1356) merged (ScheduledBackup `immediate: false`) — preferred before/alongside

## Test plan
- [ ] Flux reconciles; CNPG rolling update completes (switchover primary updates)
- [ ] All redspot pods on `ghcr.io/cloudnative-pg/postgresql:17.10-standard-trixie`
- [ ] `/etc/os-release` shows Debian 13 (trixie)
- [ ] Cluster Ready; ContinuousArchiving True; replication healthy
- [ ] Plugin Backup succeeds; `serverName` still `redspot-v17`


Made with [Cursor](https://cursor.com)