### PR TITLE
feat(database): in-place redspot upgrade to PostgreSQL 18 (Phase 2)

### DIFF
--- a/kubernetes/apps/database/cloudnative-pg/cluster/cluster.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/cluster.yaml
@@ -41,4 +41,4 @@ spec:
       isWALArchiver: true
       parameters:
         barmanObjectName: redspot-backup
-        serverName: redspot-v17
+        serverName: redspot-v18

--- a/kubernetes/apps/database/cloudnative-pg/ks.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/ks.yaml
@@ -76,7 +76,7 @@ spec:
   postBuild:
     substitute:
       # renovate: datasource=docker depName=ghcr.io/cloudnative-pg/postgresql
-      POSTGRESQL_VERSION: 17.10-standard-trixie
+      POSTGRESQL_VERSION: 18.4-standard-trixie
   prune: true
   retryInterval: 1m
   sourceRef:


### PR DESCRIPTION
## Summary
- Atomic Phase 2 change for epic `homelab-63y`: `POSTGRESQL_VERSION` → `18.4-standard-trixie` and plugin `serverName` → `redspot-v18`.
- Triggers CNPG offline in-place `pg_upgrade` (full outage accepted; no app drain).
- Rollback **only if major-upgrade Job fails before success**: revert both image and `serverName` to Phase 1 values; do not delete PVCs.

## Preconditions (verified)
- [x] Cluster Ready on `17.10-standard-trixie` / Debian 13
- [x] Fresh plugin backup `redspot-phase1-gate` completed on `redspot-v17`
- [x] `max_slot_wal_keep_size = -1`

## Test plan
- [ ] Major-upgrade Job succeeds; primary on PG 18
- [ ] `SELECT version()` shows 18.x; all 3 pods Ready on `18.4-standard-trixie`
- [ ] `serverName` is `redspot-v18`
- [ ] ANALYZE all connectable DBs
- [ ] Plugin Backup completes on `redspot-v18`
- [ ] Spot-check tenants (pocket-id / grafana / one *arr)


Made with [Cursor](https://cursor.com)