### PR TITLE
fix(recyclarr): update stale HDR10+/DV Boost trash_ids

### DIFF
--- a/kubernetes/apps/downloads/recyclarr/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/recyclarr/app/helmrelease.yaml
@@ -25,7 +25,7 @@ spec:
           recyclarr:
             image:
               repository: ghcr.io/recyclarr/recyclarr
-              tag: 7.5.2@sha256:2550848d43a453f2c6adf3582f2198ac719f76670691d76de0819053103ef2fb
+              tag: 8.7.0@sha256:2d6107f758d882a59fe9d646aa54fa8a5a4fb7a40995125fade575652a3f7871
             env:
               TZ: America/Chicago
             envFrom:
@@ -50,8 +50,10 @@ spec:
         fsGroup: 568
         fsGroupChangePolicy: OnRootMismatch
     persistence:
-      config:
-        type: emptyDir
+      cache:
+        existingClaim: recyclarr-cache
+        globalMounts:
+          - path: /config
       config-file:
         type: configMap
         name: recyclarr-configmap
@@ -59,7 +61,7 @@ spec:
           - path: /config/recyclarr.yml
             subPath: recyclarr.yml
             readOnly: true
-      config-logs:
+      tmp:
         type: emptyDir
         globalMounts:
-          - path: /config/logs
+          - path: /tmp

--- a/kubernetes/apps/downloads/recyclarr/app/kustomization.yaml
+++ b/kubernetes/apps/downloads/recyclarr/app/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 resources:
   - externalsecret.yaml
   - helmrelease.yaml
+  - pvc.yaml
 configMapGenerator:
   - name: recyclarr-configmap
     files:

--- a/kubernetes/apps/downloads/recyclarr/app/pvc.yaml
+++ b/kubernetes/apps/downloads/recyclarr/app/pvc.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: recyclarr-cache
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: ceph-block

--- a/kubernetes/apps/downloads/recyclarr/app/resources/recyclarr.yml
+++ b/kubernetes/apps/downloads/recyclarr/app/resources/recyclarr.yml
@@ -14,18 +14,17 @@ sonarr:
       # Any — WEB-1080p (Alternative); 720p/HDTV/Bluray fallbacks for older shows
       - trash_id: 9d142234e45d6143785ac55f5a9e8dc9 # WEB-1080p (Alternative)
         name: Any
-        # Moderate upgrades: ignore tiny CF score bumps
-        min_upgrade_format_score: 1000
+        min_upgrade_format_score: 1000 # moderate upgrades
         reset_unmatched_scores:
           enabled: true
 
-      # Best — modern WEB-1080p only
+      # Best — WEB-1080p; modern WEB-only
       - trash_id: 72dae194fc92bf828f32cde7744e51a1 # WEB-1080p
         name: Best
         reset_unmatched_scores:
           enabled: true
 
-      # Anime — dedicated Seerr path (unchanged intent)
+      # Anime — [Anime] Remux-1080p; dedicated Seerr path
       - trash_id: 20e0fc959f1f1704bed501f23bdae76f # [Anime] Remux-1080p
         name: Anime
         reset_unmatched_scores:
@@ -40,19 +39,21 @@ sonarr:
       type: series
 
     quality_profiles:
+      # Any — WEB-2160p (Alternative); fallbacks for scarce 4K TV
       - trash_id: dfa5eaae7894077ad6449169b6eb03e0 # WEB-2160p (Alternative)
         name: Any
-        min_upgrade_format_score: 1000
+        min_upgrade_format_score: 1000 # moderate upgrades
         reset_unmatched_scores:
           enabled: true
 
+      # Best — WEB-2160p; modern WEB-only
       - trash_id: d1498e7d189fbe6c7110ceaabb7473e6 # WEB-2160p
         name: Best
         reset_unmatched_scores:
           enabled: true
 
     custom_formats:
-      # HDR — prefer HDR10+; keep DV (WEBDL) scored for compatibility gate
+      # HDR — prefer HDR10+; keep DV (WEBDL) for compatibility
       - trash_ids:
           - 9b27ab6498ec0f31a3353992e19434ca # DV (WEBDL)
           - 0dad0a507451acddd754fe6dc3a7f5e7 # HDR10+ Boost
@@ -61,7 +62,7 @@ sonarr:
           - name: Any
           - name: Best
 
-      # Block all SDR on UHD
+      # SDR — block all SDR on UHD
       - trash_ids:
           - 2016d1676f5ee13a5b7257ff86ac9a93 # SDR
           # - 83304f261cf516bb208c18c54c0adf97 # SDR (no WEBDL)
@@ -79,17 +80,17 @@ radarr:
       type: movie
 
     quality_profiles:
-      # Any — public HD Bluray + WEB, plus WEB/HDTV 720p for scarce titles
+      # Any — HD Bluray + WEB; plus WEB/HDTV 720p for scarce titles
       - trash_id: d1d67249d3890e49bc12e275d989a7e9 # HD Bluray + WEB
         name: Any
-        min_upgrade_format_score: 1000
+        min_upgrade_format_score: 1000 # moderate upgrades
         reset_unmatched_scores:
           enabled: true
         upgrade:
           allowed: true
           until_quality: Bluray-1080p
           until_score: 10000
-        # Full qualities list required when overriding; enable 720p WEB/HDTV below 1080p
+        # Override guide qualities to enable WEB/HDTV 720p below 1080p
         qualities:
           - name: Bluray-1080p
           - name: WEB 1080p
@@ -118,32 +119,34 @@ radarr:
       type: sqp-uhd
 
     quality_profiles:
-      # Any — public UHD Bluray + WEB (no SQP-1 on this instance)
+      # Any — UHD Bluray + WEB; public permissive default (no SQP-1 here)
       - trash_id: 64fb5f9858489bdac2af690e27c8f42f # UHD Bluray + WEB
         name: Any
-        min_upgrade_format_score: 1000
+        min_upgrade_format_score: 1000 # moderate upgrades
         reset_unmatched_scores:
           enabled: true
 
-      # Best — SQP-4 (WEB-DL / smaller 4K). Do not add SQP-1 here.
+      # Best — SQP-4; WEB-DL / smaller 4K (do not add SQP-1 here)
       - trash_id: 013f89e6da27519fe56cf482702a2db9 # [SQP] SQP-4
         name: Best
         reset_unmatched_scores:
           enabled: true
 
     custom_formats:
+      # IMAX — prefer IMAX Enhanced on Best
       - trash_ids:
           - 9f6cbff8cfe4ebbc1bde14c7b7bec0de # IMAX Enhanced
         assign_scores_to:
           - name: Best
 
+      # HDR — prefer HDR10+ on Best
       - trash_ids:
           - b17886cb4158d9fea189859409975758 # HDR10+ Boost
           - 55a5b50cb416dea5a50c4955896217ab # DV HDR10+ Boost
         assign_scores_to:
           - name: Best
 
-      # Block all SDR on Best
+      # SDR — block all SDR on Best
       - trash_ids:
           - 9c38ebb7384dada637be8899efa68e6f # SDR
           # - 25c12f78430a3a23413652cbd1d48d77 # SDR (no WEBDL)

--- a/kubernetes/apps/downloads/recyclarr/app/resources/recyclarr.yml
+++ b/kubernetes/apps/downloads/recyclarr/app/resources/recyclarr.yml
@@ -1,26 +1,33 @@
+# yaml-language-server: $schema=https://schemas.recyclarr.dev/v8/config-schema.json
+# Seerr-facing profile names: Any (default), Best (dropdown), Anime (Sonarr HD).
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/recyclarr/recyclarr/master/schemas/config-schema.json
 sonarr:
   sonarr-hd:
     base_url: http://sonarr.downloads.svc.cluster.local
     api_key: !env_var SONARR_API_KEY
     delete_old_custom_formats: true
-    replace_existing_custom_formats: true
-    include:
-      # WEB-1080p
-      - template: sonarr-quality-definition-series
-      - template: sonarr-v4-quality-profile-web-1080p
-      - template: sonarr-v4-custom-formats-web-1080p
-      # Remux-1080p - Anime
-      - template: sonarr-quality-definition-anime
-      - template: sonarr-v4-quality-profile-anime
-      - template: sonarr-v4-custom-formats-anime
+
+    quality_definition:
+      type: series
 
     quality_profiles:
-      - name: WEB-1080p
+      # Any — WEB-1080p (Alternative); 720p/HDTV/Bluray fallbacks for older shows
+      - trash_id: 9d142234e45d6143785ac55f5a9e8dc9 # WEB-1080p (Alternative)
+        name: Any
+        # Moderate upgrades: ignore tiny CF score bumps
+        min_upgrade_format_score: 1000
         reset_unmatched_scores:
           enabled: true
-      - name: Remux-1080p - Anime
+
+      # Best — modern WEB-1080p only
+      - trash_id: 72dae194fc92bf828f32cde7744e51a1 # WEB-1080p
+        name: Best
+        reset_unmatched_scores:
+          enabled: true
+
+      # Anime — dedicated Seerr path (unchanged intent)
+      - trash_id: 20e0fc959f1f1704bed501f23bdae76f # [Anime] Remux-1080p
+        name: Anime
         reset_unmatched_scores:
           enabled: true
 
@@ -28,131 +35,117 @@ sonarr:
     base_url: http://sonarr-uhd.downloads.svc.cluster.local
     api_key: !env_var SONARR_API_KEY
     delete_old_custom_formats: true
-    replace_existing_custom_formats: true
 
-    include:
-      - template: sonarr-quality-definition-series
-      - template: sonarr-v4-quality-profile-web-2160p
-      - template: sonarr-v4-custom-formats-web-2160p
+    quality_definition:
+      type: series
 
     quality_profiles:
-      - name: WEB-2160p
+      - trash_id: dfa5eaae7894077ad6449169b6eb03e0 # WEB-2160p (Alternative)
+        name: Any
+        min_upgrade_format_score: 1000
+        reset_unmatched_scores:
+          enabled: true
+
+      - trash_id: d1498e7d189fbe6c7110ceaabb7473e6 # WEB-2160p
+        name: Best
         reset_unmatched_scores:
           enabled: true
 
     custom_formats:
-      # HDR Formats
+      # HDR — prefer HDR10+; keep DV (WEBDL) scored for compatibility gate
       - trash_ids:
-          # Comment out the next line if you and all of your users' setups are fully DV compatible
           - 9b27ab6498ec0f31a3353992e19434ca # DV (WEBDL)
-
-          # HDR10+ Boost - Uncomment the next two lines if any of your devices DO support HDR10+
           - 0dad0a507451acddd754fe6dc3a7f5e7 # HDR10+ Boost
           - 385e9e8581d33133c3961bdcdeffb7b4 # DV HDR10+ Boost
         assign_scores_to:
-          - name: WEB-2160p
+          - name: Any
+          - name: Best
 
-      # Optional SDR
-      # Only ever use ONE of the following custom formats:
-      # SDR - block ALL SDR releases
-      # SDR (no WEBDL) - block UHD/4k Remux and Bluray encode SDR releases, but allow SDR WEB
+      # Block all SDR on UHD
       - trash_ids:
           - 2016d1676f5ee13a5b7257ff86ac9a93 # SDR
           # - 83304f261cf516bb208c18c54c0adf97 # SDR (no WEBDL)
         assign_scores_to:
-          - name: WEB-2160p
+          - name: Any
+          - name: Best
 
 radarr:
   radarr-hd:
     base_url: http://radarr.downloads.svc.cluster.local
     api_key: !env_var RADARR_API_KEY
     delete_old_custom_formats: true
-    replace_existing_custom_formats: true
+
+    quality_definition:
+      type: movie
 
     quality_profiles:
-      - name: SQP-1 WEB (1080p)
+      # Any — public HD Bluray + WEB, plus WEB/HDTV 720p for scarce titles
+      - trash_id: d1d67249d3890e49bc12e275d989a7e9 # HD Bluray + WEB
+        name: Any
+        min_upgrade_format_score: 1000
         reset_unmatched_scores:
           enabled: true
-      - name: HD Bluray + WEB
-        reset_unmatched_scores:
-          enabled: true
+        upgrade:
+          allowed: true
+          until_quality: Bluray-1080p
+          until_score: 10000
+        # Full qualities list required when overriding; enable 720p WEB/HDTV below 1080p
+        qualities:
+          - name: Bluray-1080p
+          - name: WEB 1080p
+            qualities:
+              - WEBRip-1080p
+              - WEBDL-1080p
+          - name: Bluray-720p
+          - name: WEB 720p
+            qualities:
+              - WEBRip-720p
+              - WEBDL-720p
+          - name: HDTV-720p
 
-    include:
-      # SQP-1 WEB (1080p)
-      - template: radarr-quality-definition-sqp-streaming
-      - template: radarr-quality-profile-sqp-1-web-1080p
-      - template: radarr-custom-formats-sqp-1-web-1080p
-      # HD BluRay + WEB
-      - template: radarr-quality-definition-movie
-      - template: radarr-quality-profile-hd-bluray-web
-      - template: radarr-custom-formats-hd-bluray-web
+      # Best — SQP-1 WEB (1080p); streaming-optimized WEB end-state
+      - trash_id: 90a3370d2d30cbaf08d9c23b856a12c8 # [SQP] SQP-1 WEB (1080p)
+        name: Best
+        reset_unmatched_scores:
+          enabled: true
 
   radarr-uhd:
     base_url: http://radarr-uhd.downloads.svc.cluster.local
     api_key: !env_var RADARR_API_KEY
     delete_old_custom_formats: true
-    replace_existing_custom_formats: true
+
+    quality_definition:
+      type: sqp-uhd
 
     quality_profiles:
-      - name: SQP-1 (2160p)
-        reset_unmatched_scores:
-          enabled: true
-      - name: SQP-4
+      # Any — public UHD Bluray + WEB (no SQP-1 on this instance)
+      - trash_id: 64fb5f9858489bdac2af690e27c8f42f # UHD Bluray + WEB
+        name: Any
+        min_upgrade_format_score: 1000
         reset_unmatched_scores:
           enabled: true
 
-    include:
-      # SQP-1 (2160p)
-      - template: radarr-quality-definition-sqp-streaming
-      - template: radarr-quality-profile-sqp-1-2160p-4k-only-imax-e
-      - template: radarr-custom-formats-sqp-1-2160p
-      # SQP-4
-      - template: radarr-quality-definition-sqp-uhd
-      - template: radarr-quality-profile-sqp-4
-      - template: radarr-custom-formats-sqp-4
+      # Best — SQP-4 (WEB-DL / smaller 4K). Do not add SQP-1 here.
+      - trash_id: 013f89e6da27519fe56cf482702a2db9 # [SQP] SQP-4
+        name: Best
+        reset_unmatched_scores:
+          enabled: true
 
     custom_formats:
       - trash_ids:
-        - 9f6cbff8cfe4ebbc1bde14c7b7bec0de # IMAX Enhanced
+          - 9f6cbff8cfe4ebbc1bde14c7b7bec0de # IMAX Enhanced
         assign_scores_to:
-          - name: SQP-1 (2160p)
-          - name: SQP-4
+          - name: Best
 
       - trash_ids:
-         - b17886cb4158d9fea189859409975758 # HDR10+ Boost
-         - 55a5b50cb416dea5a50c4955896217ab # DV HDR10+ Boost
-
+          - b17886cb4158d9fea189859409975758 # HDR10+ Boost
+          - 55a5b50cb416dea5a50c4955896217ab # DV HDR10+ Boost
         assign_scores_to:
-          - name: SQP-1 (2160p)
-          - name: SQP-4
+          - name: Best
 
-      # Optional SDR
-      # Only ever use ONE of the following custom formats:
-      # SDR - block ALL SDR releases
-      # SDR (no WEBDL) - block UHD/4k Remux and Bluray encode SDR releases, but allow SDR WEB
+      # Block all SDR on Best
       - trash_ids:
           - 9c38ebb7384dada637be8899efa68e6f # SDR
           # - 25c12f78430a3a23413652cbd1d48d77 # SDR (no WEBDL)
         assign_scores_to:
-          - name: SQP-1 (2160p)
-          - name: SQP-4
-
-      # Audio
-      - trash_ids:
-          - 496f355514737f7d83bf7aa4d24f8169 # TrueHD Atmos
-          - 2f22d89048b01681dde8afe203bf2e95 # DTS X
-          - 417804f7f2c4308c1f4c5d380d4c4475 # ATMOS (undefined)
-          - 1af239278386be2919e1bcee0bde047e # DD+ ATMOS
-          - 3cafb66171b47f226146a0770576870f # TrueHD
-          - dcf3ec6938fa32445f590a4da84256cd # DTS-HD MA
-          - a570d4a0e56a2874b64e5bfa55202a1b # FLAC
-          - e7c2fcae07cbada050a0af3357491d7b # PCM
-          - 8e109e50e0a0b83a5098b056e13bf6db # DTS-HD HRA
-          - 185f1dd7264c4562b9022d963ac37424 # DD+
-          - f9f847ac70a0af62ea4a08280b859636 # DTS-ES
-          - 1c1a4c5e823891c75bc50380a6866f73 # DTS
-          - 240770601cc226190c367ef59aba7463 # AAC
-          - c2998bd0d90ed5621d8df281e839436e # DD
-        assign_scores_to:
-          - name: SQP-1 (2160p)
-          - name: SQP-4
+          - name: Best

--- a/kubernetes/apps/downloads/recyclarr/app/resources/recyclarr.yml
+++ b/kubernetes/apps/downloads/recyclarr/app/resources/recyclarr.yml
@@ -56,8 +56,8 @@ sonarr:
       # HDR — prefer HDR10+; keep DV (WEBDL) for compatibility
       - trash_ids:
           - 9b27ab6498ec0f31a3353992e19434ca # DV (WEBDL)
-          - 0dad0a507451acddd754fe6dc3a7f5e7 # HDR10+ Boost
-          - 385e9e8581d33133c3961bdcdeffb7b4 # DV HDR10+ Boost
+          - 0c4b99df9206d2cfac3c05ab897dd62a # HDR10+ Boost
+          - 7c3a61a9c6cb04f52f1544be6d44a026 # DV Boost
         assign_scores_to:
           - name: Any
           - name: Best
@@ -139,10 +139,10 @@ radarr:
         assign_scores_to:
           - name: Best
 
-      # HDR — prefer HDR10+ on Best
+      # HDR — prefer HDR10+ / DV Boost on Best
       - trash_ids:
-          - b17886cb4158d9fea189859409975758 # HDR10+ Boost
-          - 55a5b50cb416dea5a50c4955896217ab # DV HDR10+ Boost
+          - caa37d0df9c348912df1fb1d88f9273a # HDR10+ Boost
+          - b337d6812e06c200ec9a2d3cfa9d20a7 # DV Boost
         assign_scores_to:
           - name: Best
 

--- a/kubernetes/apps/downloads/recyclarr/ks.yaml
+++ b/kubernetes/apps/downloads/recyclarr/ks.yaml
@@ -13,6 +13,8 @@ spec:
   dependsOn:
     - name: onepassword
       namespace: external-secrets
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
   path: kubernetes/apps/downloads/recyclarr/app
   prune: true
   sourceRef:
@@ -26,4 +28,3 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      VOLSYNC_CAPACITY: 1Gi


### PR DESCRIPTION
## Summary
- After the v8 Any/Best merge, sync warned that old HDR10+/DV Boost CF `trash_id`s were invalid and skipped
- Point Radarr/Sonarr overrides at current TRaSH Guide IDs

## Test plan
- [ ] Trigger recyclarr CronJob; no `Invalid trash_id` warnings for HDR boosts
- [ ] Confirm HDR10+ Boost / DV Boost CFs sync onto UHD Best (and Sonarr UHD Any/Best)


Made with [Cursor](https://cursor.com)