### PR TITLE
fix(flux): escape Grafana template vars for postBuild envsubst

### DIFF
--- a/kubernetes/apps/downloads/autobrr/app/resources/grafana-dashboard.json
+++ b/kubernetes/apps/downloads/autobrr/app/resources/grafana-dashboard.json
@@ -61,7 +61,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${prometheus}"
+        "uid": "$${prometheus}"
       },
       "fieldConfig": {
         "defaults": {
@@ -126,7 +126,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -143,7 +143,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${prometheus}"
+        "uid": "$${prometheus}"
       },
       "fieldConfig": {
         "defaults": {
@@ -192,7 +192,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "max(autobrr_release_total)",
@@ -209,7 +209,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${prometheus}"
+        "uid": "$${prometheus}"
       },
       "fieldConfig": {
         "defaults": {
@@ -262,7 +262,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -279,7 +279,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${prometheus}"
+        "uid": "$${prometheus}"
       },
       "fieldConfig": {
         "defaults": {
@@ -332,7 +332,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -349,7 +349,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${prometheus}"
+        "uid": "$${prometheus}"
       },
       "fieldConfig": {
         "defaults": {
@@ -402,7 +402,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -419,7 +419,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${prometheus}"
+        "uid": "$${prometheus}"
       },
       "fieldConfig": {
         "defaults": {
@@ -472,7 +472,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -485,7 +485,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${prometheus}"
+            "uid": "$${prometheus}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -499,7 +499,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -517,7 +517,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${prometheus}"
+        "uid": "$${prometheus}"
       },
       "fieldConfig": {
         "defaults": {
@@ -598,7 +598,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "max(autobrr_release_filter_rejected_total)",
@@ -609,7 +609,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${prometheus}"
+            "uid": "$${prometheus}"
           },
           "editorMode": "code",
           "expr": "max(autobrr_release_total)",
@@ -622,7 +622,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "max(autobrr_release_filtered_total)",
@@ -635,7 +635,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${prometheus}"
+            "uid": "$${prometheus}"
           },
           "editorMode": "code",
           "expr": "max(autobrr_release_push_rejected_total)",
@@ -648,7 +648,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "max(autobrr_release_push_approved_total)",
@@ -661,7 +661,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${prometheus}"
+            "uid": "$${prometheus}"
           },
           "editorMode": "code",
           "expr": "max(autobrr_release_push_error_total)",
@@ -678,7 +678,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "$${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -760,7 +760,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${prometheus}"
+            "uid": "$${prometheus}"
           },
           "editorMode": "code",
           "expr": "max(time() - autobrr_feed_last_run_timestamp_seconds) by (feed)",
@@ -771,7 +771,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "max(autobrr_feed_next_run_timestamp_seconds - time()) by (feed)",
@@ -788,7 +788,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${prometheus}"
+        "uid": "$${prometheus}"
       },
       "fieldConfig": {
         "defaults": {
@@ -870,7 +870,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "max(time() - autobrr_irc_channel_last_announced_timestamp_seconds) by (network, channel)",
@@ -885,7 +885,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${prometheus}"
+        "uid": "$${prometheus}"
       },
       "fieldConfig": {
         "defaults": {
@@ -967,7 +967,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "max(time() - autobrr_list_last_refresh_timestamp_seconds) by (list)",

--- a/kubernetes/apps/observability/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/grafana/app/helmrelease.yaml
@@ -110,7 +110,7 @@ spec:
             url: http://vmsingle-vmks.observability.svc.cluster.local:8428
             isDefault: true
             # Explore Correlations: metrics → logs on taxonomy labels.
-            # Links only render when every ${var} is present on the clicked row.
+            # Links only render when every $${var} is present on the clicked row.
             correlations:
               - targetUID: victorialogs
                 label: Logs for pod
@@ -122,7 +122,7 @@ spec:
                     refId: A
                     editorMode: code
                     queryType: instant
-                    expr: '{namespace="${namespace}", pod="${pod}"}'
+                    expr: '{namespace="$${namespace}", pod="$${pod}"}'
               - targetUID: victorialogs
                 label: Logs for app
                 description: Open VictoriaLogs filtered by namespace and app
@@ -133,7 +133,7 @@ spec:
                     refId: A
                     editorMode: code
                     queryType: instant
-                    expr: '{namespace="${namespace}", app="${app}"}'
+                    expr: '{namespace="$${namespace}", app="$${app}"}'
               - targetUID: victorialogs
                 label: Logs for namespace
                 description: Open VictoriaLogs filtered by namespace
@@ -144,7 +144,7 @@ spec:
                     refId: A
                     editorMode: code
                     queryType: instant
-                    expr: '{namespace="${namespace}"}'
+                    expr: '{namespace="$${namespace}"}'
           - name: VictoriaLogs
             type: victoriametrics-logs-datasource
             uid: victorialogs
@@ -166,8 +166,8 @@ spec:
                       sum by (pod, container) (
                         rate(container_cpu_usage_seconds_total{
                           cluster="jupiter",
-                          namespace="${namespace}",
-                          pod="${pod}",
+                          namespace="$${namespace}",
+                          pod="$${pod}",
                           container!="",
                           container!="POD"
                         }[5m])
@@ -180,7 +180,7 @@ spec:
                   field: app
                   target:
                     refId: A
-                    expr: 'up{cluster="jupiter", namespace="${namespace}", app="${app}"}'
+                    expr: 'up{cluster="jupiter", namespace="$${namespace}", app="$${app}"}'
               - targetUID: prometheus
                 label: Metrics for namespace
                 description: Application up{} series for the log row's namespace
@@ -189,7 +189,7 @@ spec:
                   field: namespace
                   target:
                     refId: A
-                    expr: 'up{cluster="jupiter", namespace="${namespace}", app!=""}'
+                    expr: 'up{cluster="jupiter", namespace="$${namespace}", app!=""}'
           - name: Alertmanager
             type: alertmanager
             uid: alertmanager


### PR DESCRIPTION
## Summary
- Escape Grafana `${...}` placeholders as `$${...}` so Flux `postBuild` envsubst leaves them intact for Grafana
- Fixes `FluxKustomizationBuildfailed` for `observability/grafana` (`namespace`/`pod`/`app` correlations) and `downloads/autobrr` (dashboard datasource UIDs)

## Test plan
- [ ] CI / yaml checks pass
- [ ] After merge, `flux get ks grafana -n observability` and `flux get ks autobrr -n downloads` become Ready
- [ ] Grafana Explore correlations still expand `${namespace}` / `${pod}` / `${app}` correctly
- [ ] Autobrr dashboard still resolves Prometheus datasource


Made with [Cursor](https://cursor.com)