### PR TITLE
feat(database): add Barman plugin backups for dawarich-db

### DIFF
--- a/kubernetes/apps/self-hosted/dawarich/app/cluster.yaml
+++ b/kubernetes/apps/self-hosted/dawarich/app/cluster.yaml
@@ -24,5 +24,11 @@ spec:
       memory: 256Mi
     limits:
       memory: 1Gi
+  plugins:
+    - name: barman-cloud.cloudnative-pg.io
+      isWALArchiver: true
+      parameters:
+        barmanObjectName: dawarich-db-backup
+        serverName: dawarich-db-v1
   monitoring:
     enablePodMonitor: true

--- a/kubernetes/apps/self-hosted/dawarich/app/externalsecret.yaml
+++ b/kubernetes/apps/self-hosted/dawarich/app/externalsecret.yaml
@@ -26,6 +26,27 @@ spec:
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
+  name: dawarich-db-backup
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: dawarich-db-backup-secret
+  data:
+    - secretKey: aws-access-key-id
+      remoteRef:
+        key: barman-b2-credentials
+        property: AWS_ACCESS_KEY_ID
+    - secretKey: aws-secret-access-key
+      remoteRef:
+        key: barman-b2-credentials
+        property: AWS_SECRET_ACCESS_KEY
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
   name: dawarich
 spec:
   secretStoreRef:

--- a/kubernetes/apps/self-hosted/dawarich/app/kustomization.yaml
+++ b/kubernetes/apps/self-hosted/dawarich/app/kustomization.yaml
@@ -5,8 +5,10 @@ kind: Kustomization
 components:
   - ../../../../components/vmrule
 resources:
-  - cluster.yaml
   - externalsecret.yaml
+  - objectstore.yaml
+  - cluster.yaml
+  - scheduledbackup.yaml
   - helmrelease.yaml
   - vmservicescrape.yaml
   - vmrule.yaml

--- a/kubernetes/apps/self-hosted/dawarich/app/objectstore.yaml
+++ b/kubernetes/apps/self-hosted/dawarich/app/objectstore.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/barmancloud.cnpg.io/objectstore_v1.json
+---
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: dawarich-db-backup
+spec:
+  retentionPolicy: 30d
+  configuration:
+    destinationPath: s3://cluster-db-backup/dawarich-db/
+    endpointURL: https://s3.us-west-001.backblazeb2.com
+    s3Credentials:
+      accessKeyId:
+        name: dawarich-db-backup-secret
+        key: aws-access-key-id
+      secretAccessKey:
+        name: dawarich-db-backup-secret
+        key: aws-secret-access-key
+    wal:
+      compression: bzip2
+      maxParallel: 8
+    data:
+      compression: bzip2

--- a/kubernetes/apps/self-hosted/dawarich/app/scheduledbackup.yaml
+++ b/kubernetes/apps/self-hosted/dawarich/app/scheduledbackup.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/postgresql.cnpg.io/scheduledbackup_v1.json
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: dawarich-db
+spec:
+  schedule: "@daily"
+  immediate: true
+  backupOwnerReference: self
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io
+  cluster:
+    name: dawarich-db

--- a/kubernetes/apps/self-hosted/dawarich/ks.yaml
+++ b/kubernetes/apps/self-hosted/dawarich/ks.yaml
@@ -15,6 +15,8 @@ spec:
   dependsOn:
     - name: cloudnative-pg
       namespace: database
+    - name: cloudnative-pg-barman-plugin
+      namespace: database
     - name: nominatim
       namespace: self-hosted
     - name: onepassword


### PR DESCRIPTION
## Summary
- Enable CNPG plugin-barman-cloud backups for `dawarich-db` (ObjectStore → B2, WAL archiver, `@daily` ScheduledBackup with `immediate: true`)
- Wire ExternalSecret from `barman-b2-credentials` and Flux `dependsOn` on `cloudnative-pg-barman-plugin`
- Closes DR gap tracked in beads `homelab-54w.10` (in-place Talos/K8s upgrade epic)

## Test plan
- [ ] Flux reconciles `dawarich` Kustomization after merge
- [ ] `ExternalSecret/dawarich-db-backup` syncs; `ObjectStore/dawarich-db-backup` Ready
- [ ] Cluster shows plugin WAL archiver with `serverName: dawarich-db-v1`
- [ ] Immediate/plugin Backup completes successfully
- [ ] `kubectl -n self-hosted get objectstore dawarich-db-backup -o jsonpath='{.status.serverRecoveryWindow}'` shows recoverability window


Made with [Cursor](https://cursor.com)