### PR TITLE
fix(talos-backup): bump image for age env compatibility

### DIFF
--- a/kubernetes/apps/kube-system/talos-backup/app/cronjob.yaml
+++ b/kubernetes/apps/kube-system/talos-backup/app/cronjob.yaml
@@ -23,7 +23,7 @@ spec:
           containers:
             - name: talos-backup
               # renovate: datasource=docker depName=ghcr.io/siderolabs/talos-backup
-              image: ghcr.io/siderolabs/talos-backup:v0.1.0-beta.2
+              image: ghcr.io/siderolabs/talos-backup:v0.1.0-beta.3-10-gb9fd478
               imagePullPolicy: IfNotPresent
               workingDir: /tmp
               command: ["/talos-backup"]


### PR DESCRIPTION
## Summary
Smoke Jobs were failing after etcd snapshot because `v0.1.0-beta.2` ignores `AGE_RECIPIENT_PUBLIC_KEY` (empty recipient → encrypt error). Bump to `v0.1.0-beta.3-10-gb9fd478`, which honors that env and fixes `USE_PATH_STYLE`.

Follow-up to #1365.

## Test plan
- [x] Manual Job with new image: snapshot → zstd → age → B2 `etcd/jupiter/*.snap.zst.age` succeeded
- [ ] Flux reconciles CronJob after merge

