### PR TITLE
fix(talos): align machineconfig kube images with Kubernetes 1.35.2

### DIFF
--- a/talos/machineconfig.yaml.j2
+++ b/talos/machineconfig.yaml.j2
@@ -60,7 +60,7 @@ machine:
       - name: thunderbolt
       - name: thunderbolt_net
   kubelet:
-    image: ghcr.io/siderolabs/kubelet:v1.34.5
+    image: ghcr.io/siderolabs/kubelet:v1.35.2
     extraConfig:
       featureGates:
         UserNamespacesSupport: true
@@ -142,14 +142,14 @@ cluster:
     key: op://Secrets/talos/CLUSTER_AGGREGATOR_CA_KEY
   allowSchedulingOnControlPlanes: true
   apiServer:
-    image: registry.k8s.io/kube-apiserver:v1.34.5
+    image: registry.k8s.io/kube-apiserver:v1.35.2
     extraArgs:
       enable-aggregator-routing: true
       feature-gates: UserNamespacesSupport=true,UserNamespacesPodSecurityStandards=true
     certSANs: ["k8s.internal"]
     disablePodSecurityPolicy: true
   controllerManager:
-    image: registry.k8s.io/kube-controller-manager:v1.34.5
+    image: registry.k8s.io/kube-controller-manager:v1.35.2
     extraArgs:
       bind-address: 0.0.0.0
   coreDNS:
@@ -163,10 +163,10 @@ cluster:
       listen-metrics-urls: http://0.0.0.0:2381
   proxy:
     disabled: true
-    image: registry.k8s.io/kube-proxy:v1.34.5
+    image: registry.k8s.io/kube-proxy:v1.35.2
   secretboxEncryptionSecret: op://Secrets/talos/CLUSTER_SECRETBOX_ENCRYPTION_SECRET
   scheduler:
-    image: registry.k8s.io/kube-scheduler:v1.34.5
+    image: registry.k8s.io/kube-scheduler:v1.35.2
     extraArgs:
       bind-address: 0.0.0.0
     config:


### PR DESCRIPTION
## Summary
Align `machineconfig.yaml.j2` kubelet + control-plane images with the existing tuppr target (`v1.35.2`) so Phase 1 can safely recreate the Failed `KubernetesUpgrade` without Git/live skew.

Part of `homelab-54w.2`. Ceph is `HEALTH_OK` again (telemetry cleared), which was the likely tuppr health-check blocker from March.

## Post-merge
1. Confirm Flux has the change on `main`
2. Delete Failed CR: `kubectl delete kubernetesupgrade kubernetes`
3. Watch Flux recreate it and the upgrade Job → `Completed`
4. Verify all nodes report `v1.35.2` (Talos stays `v1.12.4`)

## Test plan
- [ ] PR merged; machineconfig images at v1.35.2 on main
- [ ] `KubernetesUpgrade` recreated and Completes at v1.35.2
- [ ] `kubectl get nodes` shows v1.35.2 on all four nodes
- [ ] Talos still v1.12.4

