### PR TITLE
fix(talos): drop removed feature gate and rshared /var/mnt extraMount

### DIFF
--- a/talos/machineconfig.yaml.j2
+++ b/talos/machineconfig.yaml.j2
@@ -64,14 +64,10 @@ machine:
     extraConfig:
       featureGates:
         UserNamespacesSupport: true
-        UserNamespacesPodSecurityStandards: true
       maxPods: 150
       serializeImagePulls: false
-    extraMounts:
-      - destination: /var/mnt/extra
-        type: bind
-        source: /var/mnt/extra
-        options: ["bind", "rshared", "rw"]
+    # No kubelet.extraMounts for /var/mnt/* — Talos exposes user volumes to kubelet;
+    # rshared bind mounts leak CSI mounts across kubelet restarts (siderolabs/talos#13053).
     defaultRuntimeSeccompProfileEnabled: true
     nodeIP:
       validSubnets: ["192.168.10.0/24"]
@@ -145,7 +141,7 @@ cluster:
     image: registry.k8s.io/kube-apiserver:v1.35.2
     extraArgs:
       enable-aggregator-routing: true
-      feature-gates: UserNamespacesSupport=true,UserNamespacesPodSecurityStandards=true
+      feature-gates: UserNamespacesSupport=true
     certSANs: ["k8s.internal"]
     disablePodSecurityPolicy: true
   controllerManager:

--- a/talos/machineconfig.yaml.j2
+++ b/talos/machineconfig.yaml.j2
@@ -66,8 +66,6 @@ machine:
         UserNamespacesSupport: true
       maxPods: 150
       serializeImagePulls: false
-    # No kubelet.extraMounts for /var/mnt/* — Talos exposes user volumes to kubelet;
-    # rshared bind mounts leak CSI mounts across kubelet restarts (siderolabs/talos#13053).
     defaultRuntimeSeccompProfileEnabled: true
     nodeIP:
       validSubnets: ["192.168.10.0/24"]


### PR DESCRIPTION
## Summary
Two related machineconfig cleanups from the 1.35.2 upgrade incident:

1. Drop `UserNamespacesPodSecurityStandards` (removed in Kubernetes 1.35 — this is what crashlooped `kube-apiserver` on io).
2. Remove `kubelet.extraMounts` for `/var/mnt/extra` (`bind` + `rshared`).

No `kubelet.extraMounts` for `/var/mnt/*`: Talos exposes user volumes to kubelet already; `rshared` bind mounts leak CSI mounts across kubelet restarts (`ENOSPC` / tens of thousands of mounts on callisto). See [siderolabs/talos#13053](https://github.com/siderolabs/talos/issues/13053). OpenEBS hostpath at `/var/mnt/extra/openebs/local` does not need this bind.

Follow-up (after apply): migrate europa’s legacy `machine.disks` mount of `/var/mnt/extra` to `UserVolumeConfig` / `ExistingVolumeConfig` (`homelab-54w.12`).

## Post-merge
Apply machineconfig on all nodes (kubelet will restart). Prefer reboot on callisto if it has accumulated mounts again:

```bash
task talos:apply-node NODE=callisto
task talos:apply-node NODE=ganymede
task talos:apply-node NODE=io
task talos:apply-node NODE=europa
```

## Test plan
- [ ] PR merged
- [ ] Machineconfig applied; kubelets healthy on all nodes
- [ ] OpenEBS hostpath volumes still provision/mount
- [ ] `talosctl -n callisto read /proc/1/mounts | wc -l` stays modest after a kubelet restart (no climb toward tens of thousands)

