### PR TITLE
fix(talos): migrate europa /var/mnt/extra to ExistingVolumeConfig

### DIFF
--- a/talos/worker/europa.yaml
+++ b/talos/worker/europa.yaml
@@ -1,8 +1,5 @@
 ---
 machine:
-  disks:
-    - device: /dev/disk/by-id/nvme-Samsung_SSD_990_PRO_4TB_S7KGNU0XC10841D
-      partitions: [{ mountpoint: /var/mnt/extra }]
   files:
     - path: /etc/cri/conf.d/20-customization.part
       $patch: delete
@@ -46,3 +43,10 @@ machine:
     topology.kubernetes.io/zone: w
   sysctls:
     net.core.bpf_jit_harden: 1    # required for NVIDIA kernel modules
+---
+apiVersion: v1alpha1
+kind: ExistingVolumeConfig
+name: extra
+discovery:
+  volumeSelector:
+    match: disk.serial == "S7KGNU0XC10841D" && volume.partition_index == 1u

--- a/talos/worker/europa.yaml
+++ b/talos/worker/europa.yaml
@@ -1,5 +1,7 @@
 ---
 machine:
+  disks:
+    $patch: delete
   files:
     - path: /etc/cri/conf.d/20-customization.part
       $patch: delete

--- a/talos/worker/europa.yaml
+++ b/talos/worker/europa.yaml
@@ -1,7 +1,5 @@
 ---
 machine:
-  disks:
-    $patch: delete
   files:
     - path: /etc/cri/conf.d/20-customization.part
       $patch: delete


### PR DESCRIPTION
## Summary
- Remove europa legacy `machine.disks` mount for the 4TB Samsung at `/var/mnt/extra` (`$patch: delete` — omit is not enough)
- Add `ExistingVolumeConfig` `name: extra` selecting `disk.serial == S7KGNU0XC10841D` + partition index 1
- Preserves OpenEBS `basePath` (`/var/mnt/extra/openebs/local`) and steam-library data

Bead: `homelab-54w.12`

## Applied live
- Required reboot when deleting `machine.disks`
- `e-extra` ready on `/dev/nvme0n1p1` → `/var/mnt/extra`
- steam `/mnt/games/SteamLibrary` readable (~1.6T)

## Test plan
- [x] Apply europa (`MODE=auto`; reboot expected for disks delete)
- [x] `talosctl -n europa get volumestatus e-extra` → ready, `/dev/nvme0n1p1`
- [x] Mount `/var/mnt/extra`; OpenEBS PVC dir present
- [x] steam library readable
- [ ] Merge PR so Git matches live