### PR TITLE
fix(talos): bump to v1.12.10 (Phase 2)

### DIFF
--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/talos.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/talos.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   talos:
     # renovate: datasource=custom.talos-factory depName=siderolabs/talos
-    version: v1.12.4
+    version: v1.12.10
   policy:
     rebootMode: powercycle
   healthChecks:

--- a/talos/machineconfig.yaml.j2
+++ b/talos/machineconfig.yaml.j2
@@ -52,7 +52,7 @@ machine:
       - mitigations=off         # Less security, faster puter
       - security=none           # Less security, faster puter
       - talos.auditd.disabled=1 # Less security, faster puter
-    image: factory.talos.dev/installer/5c030c38dbb790ca3298ec86a336ea4e6d287256dd5c5bbc7c56c347b0df5f3f:v1.12.4
+    image: factory.talos.dev/installer/5c030c38dbb790ca3298ec86a336ea4e6d287256dd5c5bbc7c56c347b0df5f3f:v1.12.10
     wipe: false
   kernel:
     modules:

--- a/talos/worker/europa.yaml
+++ b/talos/worker/europa.yaml
@@ -16,7 +16,7 @@ machine:
       serial: S5H9NS0N517111K
     extraKernelArgs:
       - amd_iommu=on            # PCI Passthrough
-    image: factory.talos.dev/installer/0b97c67c1c2feb9a5ae7c196445e624332c6e381c45ef4c84f9c48debd4fa70c:v1.12.4
+    image: factory.talos.dev/installer/0b97c67c1c2feb9a5ae7c196445e624332c6e381c45ef4c84f9c48debd4fa70c:v1.12.10
   kernel:
     modules:
       - name: nvidia


### PR DESCRIPTION
## Summary
- Bump `TalosUpgrade` to **v1.12.10**
- Retag CP + europa installer images on existing schematic IDs (patch-level; no schematic regen)
- Supersedes Renovate [#1272](https://github.com/zebernst/homelab/pull/1272) (rebased onto post-europa `main`)

Bead: `homelab-54w.3`

## Preflight
- [x] Ceph crash archived (`RECENT_MGR_MODULE_CRASH`) → aiming `HEALTH_OK` for tuppr gate
- [x] K8s v1.35.2 / prior `TalosUpgrade` Completed
- [x] Redspot Ready

## Test plan
- [ ] Merge; Flux updates `TalosUpgrade`
- [ ] Watch tuppr roll nodes (powercycle) to v1.12.10
- [ ] All nodes Talos v1.12.10; K8s still v1.35.2
- [ ] `TalosUpgrade` Completed
- [ ] Close #1272


Made with [Cursor](https://cursor.com)