### PR TITLE
fix(talos): bump to v1.13.7 (Phase 3)

### DIFF
--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/talos.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/talos.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   talos:
     # renovate: datasource=custom.talos-factory depName=siderolabs/talos
-    version: v1.12.10
+    version: v1.13.7
   policy:
     rebootMode: powercycle
   healthChecks:

--- a/talos/machineconfig.yaml.j2
+++ b/talos/machineconfig.yaml.j2
@@ -52,7 +52,7 @@ machine:
       - mitigations=off         # Less security, faster puter
       - security=none           # Less security, faster puter
       - talos.auditd.disabled=1 # Less security, faster puter
-    image: factory.talos.dev/installer/5c030c38dbb790ca3298ec86a336ea4e6d287256dd5c5bbc7c56c347b0df5f3f:v1.12.10
+    image: factory.talos.dev/installer/5c030c38dbb790ca3298ec86a336ea4e6d287256dd5c5bbc7c56c347b0df5f3f:v1.13.7
     wipe: false
   kernel:
     modules:

--- a/talos/worker/europa.yaml
+++ b/talos/worker/europa.yaml
@@ -16,7 +16,7 @@ machine:
       serial: S5H9NS0N517111K
     extraKernelArgs:
       - amd_iommu=on            # PCI Passthrough
-    image: factory.talos.dev/installer/0b97c67c1c2feb9a5ae7c196445e624332c6e381c45ef4c84f9c48debd4fa70c:v1.12.10
+    image: factory.talos.dev/installer/0b97c67c1c2feb9a5ae7c196445e624332c6e381c45ef4c84f9c48debd4fa70c:v1.13.7
   kernel:
     modules:
       - name: nvidia


### PR DESCRIPTION
## Summary
- Bump `TalosUpgrade` + CP/europa installer tags to **v1.13.7**
- Keep schematic IDs (`5c030c38…` / `0b97c67c…`); factory resolves nvidia production → **595.71.05**
- Supersedes Renovate [#1279](https://github.com/zebernst/homelab/pull/1279) (stale/conflicting)

Bead: `homelab-54w.4`  
Gates: etcd + redspot-v18 pre-phase3 backups completed.

## Test plan
- [ ] Tuppr rolls all nodes to Talos v1.13.7 (powercycle)
- [ ] K8s remains v1.35.2
- [ ] europa GPU extensions 595.x; steam/ollama healthy
- [ ] Close #1279


Made with [Cursor](https://cursor.com)