### PR TITLE
refactor(talos): 1.14 multi-doc machineconfig (hold for GA)

### DIFF
--- a/.taskfiles/talos/Taskfile.yaml
+++ b/.taskfiles/talos/Taskfile.yaml
@@ -40,8 +40,12 @@ tasks:
         sh: talosctl --nodes {{.NODE}} get machinetypes --output=jsonpath='{.spec}'
       TALOS_IMAGE:
         sh: |-
+          # Prefer UnattendedInstallConfig when present; fall back to legacy .machine.install.image
           talosctl --nodes {{.NODE}} get machineconfig --output=jsonpath='{.spec}' \
-            | yq '.machine.install.image'
+            | yq -r '
+                ([select(.kind == "UnattendedInstallConfig") | .installer.image] | first)
+                // .machine.install.image
+              '
     requires:
       vars: [NODE]
     preconditions:

--- a/docs/runbooks/2026-07-29-talos-1.14-multidoc.md
+++ b/docs/runbooks/2026-07-29-talos-1.14-multidoc.md
@@ -1,0 +1,57 @@
+# Talos 1.14 multi-document machineconfig
+
+Hold this change until **Talos v1.14.0 GA** is available and you are ready to upgrade the cluster.
+
+## Why
+
+Talos 1.14 continues decomposing the monolithic `version: v1alpha1` document into typed multi-doc kinds ([what's new](https://docs.siderolabs.com/talos/v1.14/getting-started/what's-new-in-talos), epic [siderolabs/talos#13135](https://github.com/siderolabs/talos/issues/13135)). New features land only on the new documents; legacy fields remain supported but are deprecated.
+
+## What this PR migrates
+
+| From (legacy) | To (multi-doc) |
+|---|---|
+| `.machine.files` (nfsmount) | `EtcFileConfig` |
+| `.machine.files` (CRI TOML) | `CRICustomizationConfig` |
+| `.machine.sysctls` / node sysctls | `SysctlConfig` |
+| `.machine.sysfs` | `SysfsConfig` |
+| `.machine.kernel.modules` | `KernelModuleConfig` (named) |
+| `.machine.udev.rules` | `UdevRulesConfig` |
+| `.machine.time` | `TimeSyncConfig` |
+| `.machine.network.nameservers` / `disableSearchDomain` / `features.hostDNS` | `ResolverConfig` |
+| `.machine.network.hostname` / `features.stableHostname` | `HostnameConfig` |
+| `.machine.kubelet` | `KubeletConfig` |
+| `.machine.nodeLabels` / kubelet nodeIP / CP scheduling | `KubeNodeConfig` |
+| `.machine.features.kubePrism` | `KubePrismConfig` |
+| `.cluster.name` / `.cluster.controlPlane.endpoint` | `KubeClusterConfig` |
+| `.cluster.network` (incl. `cni: none`) | `KubeNetworkConfig` (**no** `KubeFlannelCNIConfig` → Cilium) |
+| `.cluster.coreDNS` / `.cluster.proxy` | `KubeCoreDNSConfig` / `KubeProxyConfig` |
+| `.cluster.apiServer` / CM / scheduler | `KubeAPIServerConfig` / `KubeControllerManagerConfig` / `KubeSchedulerConfig` |
+| `.cluster.extraManifests` | `KubeExternalManifestConfig` (named) |
+| `.cluster.id` / `.cluster.secret` / `.cluster.discovery` | `DiscoveryIdentityConfig` / `DiscoveryServiceConfig` |
+| `.cluster.secretboxEncryptionSecret` | `KubeEtcdEncryptionConfig` |
+| europa `ExistingVolumeConfig` | unchanged (already multi-doc) |
+
+## Intentionally deferred
+
+- **`UnattendedInstallConfig`** — mutually exclusive with *any* `.machine.install`, including `extraKernelArgs`. Keep install + kernel args in legacy until schematics absorb node IOMMU args (pairs well with `homelab-3ro` BOOT reinstall).
+- **Bond/VLAN/Link multi-doc** — host networking stays under `.machine.network.interfaces` for now.
+- **Kube* CA / service-account PEM docs** — `KubeAPIServerCAConfig` wants PEM; 1Password refs today are classic base64. Leave `cluster.ca`, `aggregatorCA`, `etcd.ca`, `serviceAccount` in legacy.
+- **New 1.14 defaults** — do **not** enable `SecurityProfileConfig.workloadIsolation`, EPHEMERAL `mount.secure`, or `FilesystemTrimConfig` on upgrade (opt-in later).
+
+## Merge / apply order
+
+1. Wait for **v1.14.0** GA (not beta).
+2. Merge this PR (bumps tuppr + installer tags to `v1.14.0` and rewrites machineconfig).
+3. Let tuppr roll Talos **or** upgrade manually, then `task talos:apply-node` per node so live MC matches git.
+4. Validate: `talosctl get mc -o yaml` shows multi-doc kinds; CRI nvidia on europa; Ceph/`e-extra` healthy.
+
+Do **not** apply this config on 1.13 — unknown document kinds / conflict validators will reject it.
+
+## Validate offline (optional)
+
+```bash
+# After 1.14 talosctl is installed:
+MACHINE_TYPE=controlplane minijinja-cli talos/machineconfig.yaml.j2 \
+  | op inject \
+  | talosctl validate --config /dev/stdin --mode metal
+```

--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/talos.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/talos.yaml
@@ -6,7 +6,8 @@ metadata:
 spec:
   talos:
     # renovate: datasource=custom.talos-factory depName=siderolabs/talos
-    version: v1.13.7
+    # Hold merge until Talos 1.14.0 GA — multi-doc machineconfig requires >= 1.14
+    version: v1.14.0
   policy:
     rebootMode: powercycle
   healthChecks:

--- a/talos/controlplane/callisto.yaml
+++ b/talos/controlplane/callisto.yaml
@@ -6,7 +6,6 @@ machine:
     extraKernelArgs:
       - intel_iommu=on          # PCI Passthrough
   network:
-    hostname: callisto.k8s.internal
     interfaces:
       - interface: bond0
         bond:
@@ -32,7 +31,18 @@ machine:
         mtu: 65520
         addresses: [169.254.255.12/32]
         routes: [{ network: 169.254.255.11/32, metric: 2048 }]
-  nodeLabels:
-    topology.kubernetes.io/zone: m
-  sysfs:
-    devices.system.cpu.intel_pstate.hwp_dynamic_boost: 1
+---
+apiVersion: v1alpha1
+kind: HostnameConfig
+hostname: callisto.k8s.internal
+---
+apiVersion: v1alpha1
+kind: KubeNodeConfig
+labels:
+  topology.kubernetes.io/region: jupiter
+  topology.kubernetes.io/zone: m
+---
+apiVersion: v1alpha1
+kind: SysfsConfig
+params:
+  devices.system.cpu.intel_pstate.hwp_dynamic_boost: "1"

--- a/talos/controlplane/ganymede.yaml
+++ b/talos/controlplane/ganymede.yaml
@@ -6,7 +6,6 @@ machine:
     extraKernelArgs:
       - intel_iommu=on          # PCI Passthrough
   network:
-    hostname: ganymede.k8s.internal
     interfaces:
       - interface: bond0
         bond:
@@ -32,7 +31,18 @@ machine:
         mtu: 65520
         addresses: [169.254.255.11/32]
         routes: [{ network: 169.254.255.12/32, metric: 2048 }]
-  nodeLabels:
-    topology.kubernetes.io/zone: m
-  sysfs:
-    devices.system.cpu.intel_pstate.hwp_dynamic_boost: 1
+---
+apiVersion: v1alpha1
+kind: HostnameConfig
+hostname: ganymede.k8s.internal
+---
+apiVersion: v1alpha1
+kind: KubeNodeConfig
+labels:
+  topology.kubernetes.io/region: jupiter
+  topology.kubernetes.io/zone: m
+---
+apiVersion: v1alpha1
+kind: SysfsConfig
+params:
+  devices.system.cpu.intel_pstate.hwp_dynamic_boost: "1"

--- a/talos/controlplane/io.yaml
+++ b/talos/controlplane/io.yaml
@@ -1,4 +1,5 @@
 ---
+# Legacy install disk + IOMMU + host networking (Bond/VLAN multi-doc later).
 machine:
   install:
     diskSelector:
@@ -6,7 +7,6 @@ machine:
     extraKernelArgs:
       - intel_iommu=on          # PCI Passthrough
   network:
-    hostname: io.k8s.internal
     interfaces:
       - interface: bond0
         bond:
@@ -32,7 +32,18 @@ machine:
         mtu: 65520
         addresses: [169.254.255.10/32]
         routes: [{ network: 169.254.255.12/32, metric: 2048 }]
-  nodeLabels:
-    topology.kubernetes.io/zone: m
-  sysfs:
-    devices.system.cpu.intel_pstate.hwp_dynamic_boost: 1
+---
+apiVersion: v1alpha1
+kind: HostnameConfig
+hostname: io.k8s.internal
+---
+apiVersion: v1alpha1
+kind: KubeNodeConfig
+labels:
+  topology.kubernetes.io/region: jupiter
+  topology.kubernetes.io/zone: m
+---
+apiVersion: v1alpha1
+kind: SysfsConfig
+params:
+  devices.system.cpu.intel_pstate.hwp_dynamic_boost: "1"

--- a/talos/machineconfig.yaml.j2
+++ b/talos/machineconfig.yaml.j2
@@ -1,4 +1,7 @@
 ---
+# Legacy v1alpha1 shell — secrets, install (extraKernelArgs), etcd, and leftover
+# machine/network bits that are not yet multi-doc (interfaces stay here).
+# DO NOT MERGE / APPLY until cluster is on Talos >= 1.14.0.
 version: v1alpha1
 debug: false
 persist: true
@@ -12,7 +15,6 @@ machine:
     {% endif %}
   features:
     rbac: true
-    stableHostname: true
     {% if ENV.MACHINE_TYPE == 'controlplane' %}
     kubernetesTalosAPIAccess:
       enabled: true
@@ -21,28 +23,8 @@ machine:
     {% endif %}
     apidCheckExtKeyUsage: true
     diskQuotaSupport: true
-    kubePrism:
-      enabled: true
-      port: 7445
-    hostDNS:
-      enabled: true
-      forwardKubeDNSToHost: false
-      resolveMemberNames: true
-  files:
-    - op: overwrite
-      path: /etc/nfsmount.conf
-      permissions: 0o644
-      content: |
-        [ NFSMount_Global_Options ]
-        nfsvers=4.1
-        hard=True
-        nconnect=16
-        noatime=True
-    - op: create
-      path: /etc/cri/conf.d/20-customization.part
-      content: |
-        [plugins."io.containerd.cri.v1.images"]
-          discard_unpacked_layers = false
+  # install retained (mutually exclusive with UnattendedInstallConfig).
+  # extraKernelArgs still live here; Image Factory schematics also carry shared args.
   install:
     extraKernelArgs:
       - apparmor=0              # Less security, faster puter
@@ -52,102 +34,24 @@ machine:
       - mitigations=off         # Less security, faster puter
       - security=none           # Less security, faster puter
       - talos.auditd.disabled=1 # Less security, faster puter
-    image: factory.talos.dev/installer/5c030c38dbb790ca3298ec86a336ea4e6d287256dd5c5bbc7c56c347b0df5f3f:v1.13.7
+    # renovate: datasource=custom.talos-factory depName=siderolabs/talos
+    image: factory.talos.dev/installer/5c030c38dbb790ca3298ec86a336ea4e6d287256dd5c5bbc7c56c347b0df5f3f:v1.14.0
     wipe: false
-  kernel:
-    modules:
-      - name: nbd
-      - name: thunderbolt
-      - name: thunderbolt_net
-  kubelet:
-    image: ghcr.io/siderolabs/kubelet:v1.35.2
-    extraConfig:
-      featureGates:
-        UserNamespacesSupport: true
-      maxPods: 150
-      serializeImagePulls: false
-    defaultRuntimeSeccompProfileEnabled: true
-    nodeIP:
-      validSubnets: ["192.168.10.0/24"]
-    disableManifestsDirectory: true
-  network:
-    nameservers: ["192.168.10.1"]
-    disableSearchDomain: true
-  nodeLabels:
-    topology.kubernetes.io/region: jupiter
-  sysctls:
-    fs.inotify.max_user_watches: 1048576   # Watchdog
-    fs.inotify.max_user_instances: 8192    # Watchdog
-    net.core.default_qdisc: fq             # 10Gb/s
-    net.core.rmem_max: 67108864            # 10Gb/s | Cloudflared / QUIC
-    net.core.wmem_max: 67108864            # 10Gb/s | Cloudflared / QUIC
-    net.ipv4.tcp_congestion_control: bbr   # 10Gb/s
-    net.ipv4.tcp_fastopen: 3               # Send and accept data in the opening SYN packet
-    net.ipv4.tcp_mtu_probing: 1            # 10Gb/s | Jumbo frames
-    net.ipv4.tcp_rmem: 4096 87380 33554432 # 10Gb/s
-    net.ipv4.tcp_wmem: 4096 65536 33554432 # 10Gb/s
-    net.ipv4.tcp_window_scaling: 1         # 10Gb/s
-    vm.nr_hugepages: 1024                  # PostgreSQL
-    user.max_user_namespaces: "11255"      # Steam/Flatpak support
-  time:
-    servers:
-      - nas.internal
-      - time.cloudflare.com
-      - time.nist.gov
-  udev:
-    rules:
-      - # Thunderbolt
-        ACTION=="add", SUBSYSTEM=="thunderbolt", ATTR{authorized}=="0", ATTR{authorized}="1"
-      - # Intel GPU
-        SUBSYSTEM=="drm", KERNEL=="renderD*", GROUP="44", MODE="0660"
+  # Host networking (bonds/VLANs/links) — migrate to BondConfig/VLANConfig/LinkConfig later.
+  network: {}
 cluster:
+  # Cluster PKI / join material — PEM multi-doc CA migration is a follow-up
+  # (KubeAPIServerCAConfig wants PEM; our 1Password refs are classic base64).
   ca:
     crt: op://Secrets/talos/CLUSTER_CA_CRT
     {% if ENV.MACHINE_TYPE == 'controlplane' %}
     key: op://Secrets/talos/CLUSTER_CA_KEY
     {% endif %}
-  clusterName: jupiter
-  controlPlane:
-    endpoint: https://k8s.internal:6443
-  discovery:
-    enabled: true
-    registries:
-      kubernetes:
-        disabled: true
-      service:
-        disabled: false
-  extraManifests:
-    - # renovate: datasource=github-releases depName=kubernetes-sigs/gateway-api
-      https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.6.1/experimental-install.yaml
-    - # renovate: datasource=github-releases depName=prometheus-operator/prometheus-operator
-      https://github.com/prometheus-operator/prometheus-operator/releases/download/v0.92.1/stripped-down-crds.yaml
-  id: op://Secrets/talos/CLUSTER_ID
-  network:
-    cni:
-      name: none
-    dnsDomain: cluster.local
-    podSubnets: ["10.244.0.0/16"]
-    serviceSubnets: ["10.245.0.0/16"]
-  secret: op://Secrets/talos/CLUSTER_SECRET
   token: op://Secrets/talos/CLUSTER_TOKEN
   {% if ENV.MACHINE_TYPE == 'controlplane' %}
   aggregatorCA:
     crt: op://Secrets/talos/CLUSTER_AGGREGATOR_CA_CRT
     key: op://Secrets/talos/CLUSTER_AGGREGATOR_CA_KEY
-  allowSchedulingOnControlPlanes: true
-  apiServer:
-    image: registry.k8s.io/kube-apiserver:v1.35.2
-    extraArgs:
-      enable-aggregator-routing: true
-      feature-gates: UserNamespacesSupport=true
-    certSANs: ["k8s.internal"]
-    disablePodSecurityPolicy: true
-  controllerManager:
-    image: registry.k8s.io/kube-controller-manager:v1.35.2
-    extraArgs:
-      bind-address: 0.0.0.0
-  coreDNS:
-    disabled: true
   etcd:
     advertisedSubnets: ["192.168.10.0/24"]
     ca:
@@ -155,31 +59,225 @@ cluster:
       key: op://Secrets/talos/CLUSTER_ETCD_CA_KEY
     extraArgs:
       listen-metrics-urls: http://0.0.0.0:2381
-  proxy:
-    disabled: true
-    image: registry.k8s.io/kube-proxy:v1.35.2
-  secretboxEncryptionSecret: op://Secrets/talos/CLUSTER_SECRETBOX_ENCRYPTION_SECRET
-  scheduler:
-    image: registry.k8s.io/kube-scheduler:v1.35.2
-    extraArgs:
-      bind-address: 0.0.0.0
-    config:
-      apiVersion: kubescheduler.config.k8s.io/v1
-      kind: KubeSchedulerConfiguration
-      profiles:
-        - schedulerName: default-scheduler
-          plugins:
-            score:
-              disabled:
-                - name: ImageLocality
-          pluginConfig:
-            - name: PodTopologySpread
-              args:
-                defaultingType: List
-                defaultConstraints:
-                  - maxSkew: 1
-                    topologyKey: kubernetes.io/hostname
-                    whenUnsatisfiable: ScheduleAnyway
   serviceAccount:
     key: op://Secrets/talos/CLUSTER_SERVICE_ACCOUNT_KEY
   {% endif %}
+
+---
+apiVersion: v1alpha1
+kind: DiscoveryServiceConfig
+name: default
+endpoint: https://discovery.talos.dev/
+
+---
+apiVersion: v1alpha1
+kind: DiscoveryIdentityConfig
+clusterID: op://Secrets/talos/CLUSTER_ID
+clusterSecret: op://Secrets/talos/CLUSTER_SECRET
+
+---
+apiVersion: v1alpha1
+kind: ResolverConfig
+nameservers:
+  - address: 192.168.10.1
+searchDomains:
+  disableDefault: true
+hostDNS:
+  enabled: true
+  forwardKubeDNSToHost: false
+  resolveMemberNames: true
+
+---
+apiVersion: v1alpha1
+kind: TimeSyncConfig
+ntp:
+  servers:
+    - nas.internal
+    - time.cloudflare.com
+    - time.nist.gov
+  # Mixed local + public NTP; NTS not available on nas.internal.
+  useNTS: false
+
+---
+apiVersion: v1alpha1
+kind: SysctlConfig
+params:
+  fs.inotify.max_user_watches: "1048576"   # Watchdog
+  fs.inotify.max_user_instances: "8192"    # Watchdog
+  net.core.default_qdisc: fq             # 10Gb/s
+  net.core.rmem_max: "67108864"            # 10Gb/s | Cloudflared / QUIC
+  net.core.wmem_max: "67108864"            # 10Gb/s | Cloudflared / QUIC
+  net.ipv4.tcp_congestion_control: bbr   # 10Gb/s
+  net.ipv4.tcp_fastopen: "3"               # Send and accept data in the opening SYN packet
+  net.ipv4.tcp_mtu_probing: "1"            # 10Gb/s | Jumbo frames
+  net.ipv4.tcp_rmem: 4096 87380 33554432 # 10Gb/s
+  net.ipv4.tcp_wmem: 4096 65536 33554432 # 10Gb/s
+  net.ipv4.tcp_window_scaling: "1"         # 10Gb/s
+  vm.nr_hugepages: "1024"                  # PostgreSQL
+  user.max_user_namespaces: "11255"      # Steam/Flatpak support
+
+---
+apiVersion: v1alpha1
+kind: KernelModuleConfig
+name: nbd
+
+---
+apiVersion: v1alpha1
+kind: KernelModuleConfig
+name: thunderbolt
+
+---
+apiVersion: v1alpha1
+kind: KernelModuleConfig
+name: thunderbolt_net
+
+---
+apiVersion: v1alpha1
+kind: UdevRulesConfig
+rules:
+  - ACTION=="add", SUBSYSTEM=="thunderbolt", ATTR{authorized}=="0", ATTR{authorized}="1"
+  - SUBSYSTEM=="drm", KERNEL=="renderD*", GROUP="44", MODE="0660"
+
+---
+apiVersion: v1alpha1
+kind: EtcFileConfig
+name: nfsmount.conf
+mode: 0o644
+contents: |
+  [ NFSMount_Global_Options ]
+  nfsvers=4.1
+  hard=True
+  nconnect=16
+  noatime=True
+
+---
+apiVersion: v1alpha1
+kind: CRICustomizationConfig
+name: 00-images
+content: |
+  [plugins."io.containerd.cri.v1.images"]
+    discard_unpacked_layers = false
+
+---
+apiVersion: v1alpha1
+kind: KubePrismConfig
+port: 7445
+
+---
+apiVersion: v1alpha1
+kind: KubeClusterConfig
+clusterName: jupiter
+endpoint: https://k8s.internal:6443
+
+---
+apiVersion: v1alpha1
+kind: KubeNetworkConfig
+dnsDomain: cluster.local
+podSubnets:
+  - 10.244.0.0/16
+serviceSubnets:
+  - 10.245.0.0/16
+# No KubeFlannelCNIConfig — Cilium is the CNI (equivalent to former cni.name: none).
+
+---
+apiVersion: v1alpha1
+kind: KubeletConfig
+image: ghcr.io/siderolabs/kubelet:v1.35.2
+defaultRuntimeSeccompProfileEnabled: true
+config:
+  featureGates:
+    UserNamespacesSupport: true
+  maxPods: 150
+  serializeImagePulls: false
+
+---
+apiVersion: v1alpha1
+kind: KubeNodeConfig
+nodeIP:
+  validSubnets:
+    - 192.168.10.0/24
+labels:
+  topology.kubernetes.io/region: jupiter
+# CP: omit control-plane NoSchedule taint (was allowSchedulingOnControlPlanes: true).
+# Worker zone / GPU taints come from node patches.
+
+{% if ENV.MACHINE_TYPE == 'controlplane' %}
+---
+apiVersion: v1alpha1
+kind: KubeCoreDNSConfig
+enabled: false
+
+---
+apiVersion: v1alpha1
+kind: KubeProxyConfig
+enabled: false
+image: registry.k8s.io/kube-proxy:v1.35.2
+
+---
+apiVersion: v1alpha1
+kind: KubeExternalManifestConfig
+name: gateway-api
+# renovate: datasource=github-releases depName=kubernetes-sigs/gateway-api
+url: https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.6.1/experimental-install.yaml
+
+---
+apiVersion: v1alpha1
+kind: KubeExternalManifestConfig
+name: prometheus-operator-crds
+# renovate: datasource=github-releases depName=prometheus-operator/prometheus-operator
+url: https://github.com/prometheus-operator/prometheus-operator/releases/download/v0.92.1/stripped-down-crds.yaml
+
+---
+apiVersion: v1alpha1
+kind: KubeAPIServerConfig
+image: registry.k8s.io/kube-apiserver:v1.35.2
+certExtraSANs:
+  - k8s.internal
+extraArgs:
+  enable-aggregator-routing: "true"
+  feature-gates: UserNamespacesSupport=true
+
+---
+apiVersion: v1alpha1
+kind: KubeControllerManagerConfig
+image: registry.k8s.io/kube-controller-manager:v1.35.2
+extraArgs:
+  bind-address: 0.0.0.0
+
+---
+apiVersion: v1alpha1
+kind: KubeSchedulerConfig
+image: registry.k8s.io/kube-scheduler:v1.35.2
+extraArgs:
+  bind-address: 0.0.0.0
+config:
+  apiVersion: kubescheduler.config.k8s.io/v1
+  kind: KubeSchedulerConfiguration
+  profiles:
+    - schedulerName: default-scheduler
+      plugins:
+        score:
+          disabled:
+            - name: ImageLocality
+      pluginConfig:
+        - name: PodTopologySpread
+          args:
+            defaultingType: List
+            defaultConstraints:
+              - maxSkew: 1
+                topologyKey: kubernetes.io/hostname
+                whenUnsatisfiable: ScheduleAnyway
+
+---
+apiVersion: v1alpha1
+kind: KubeEtcdEncryptionConfig
+config:
+  resources:
+    - providers:
+        - secretbox:
+            keys:
+              - name: key1
+                secret: op://Secrets/talos/CLUSTER_SECRETBOX_ENCRYPTION_SECRET
+      resources:
+        - secrets
+{% endif %}

--- a/talos/worker/europa.yaml
+++ b/talos/worker/europa.yaml
@@ -1,37 +1,13 @@
 ---
 machine:
-  files:
-    - path: /etc/cri/conf.d/20-customization.part
-      $patch: delete
-    - op: create
-      path: /etc/cri/conf.d/20-customization.part
-      content: |
-        [plugins."io.containerd.cri.v1.images"]
-          discard_unpacked_layers = false
-        [plugins."io.containerd.cri.v1.runtime"]
-          [plugins."io.containerd.cri.v1.runtime".containerd]
-            default_runtime_name = "nvidia"
   install:
     diskSelector:
       serial: S5H9NS0N517111K
     extraKernelArgs:
       - amd_iommu=on            # PCI Passthrough
-    image: factory.talos.dev/installer/0b97c67c1c2feb9a5ae7c196445e624332c6e381c45ef4c84f9c48debd4fa70c:v1.13.7
-  kernel:
-    modules:
-      - name: nvidia
-      - name: nvidia_uvm
-      - name: nvidia_drm
-      - name: nvidia_modeset
-      - name: uinput
-  kubelet:
-    extraConfig:
-      registerWithTaints:
-        - key: "nvidia.com/gpu"
-          value: "true"
-          effect: PreferNoSchedule
+    # renovate: datasource=custom.talos-factory depName=siderolabs/talos
+    image: factory.talos.dev/installer/0b97c67c1c2feb9a5ae7c196445e624332c6e381c45ef4c84f9c48debd4fa70c:v1.14.0
   network:
-    hostname: europa.k8s.internal
     interfaces:
       - interface: enp12s0
         dhcp: true
@@ -39,10 +15,51 @@ machine:
         vlans:
           - { vlanId: 20, dhcp: false, mtu: 1500 }
           - { vlanId: 30, dhcp: false, mtu: 1500 }
-  nodeLabels:
-    topology.kubernetes.io/zone: w
-  sysctls:
-    net.core.bpf_jit_harden: 1    # required for NVIDIA kernel modules
+---
+apiVersion: v1alpha1
+kind: HostnameConfig
+hostname: europa.k8s.internal
+---
+apiVersion: v1alpha1
+kind: KubeNodeConfig
+labels:
+  topology.kubernetes.io/region: jupiter
+  topology.kubernetes.io/zone: w
+taints:
+  nvidia.com/gpu: "true:PreferNoSchedule"
+---
+apiVersion: v1alpha1
+kind: SysctlConfig
+params:
+  net.core.bpf_jit_harden: "1"    # required for NVIDIA kernel modules
+---
+apiVersion: v1alpha1
+kind: KernelModuleConfig
+name: nvidia
+---
+apiVersion: v1alpha1
+kind: KernelModuleConfig
+name: nvidia_uvm
+---
+apiVersion: v1alpha1
+kind: KernelModuleConfig
+name: nvidia_drm
+---
+apiVersion: v1alpha1
+kind: KernelModuleConfig
+name: nvidia_modeset
+---
+apiVersion: v1alpha1
+kind: KernelModuleConfig
+name: uinput
+---
+apiVersion: v1alpha1
+kind: CRICustomizationConfig
+name: 10-nvidia-runtime
+content: |
+  [plugins."io.containerd.cri.v1.runtime"]
+    [plugins."io.containerd.cri.v1.runtime".containerd]
+      default_runtime_name = "nvidia"
 ---
 apiVersion: v1alpha1
 kind: ExistingVolumeConfig


### PR DESCRIPTION
## Summary

- Migrates Talos machineconfig from monolithic `v1alpha1` into **1.14 multi-document kinds** (Kube*, CRI, Sysctl/Sysfs, Hostname, Resolver, TimeSync, Discovery, external manifests, etc.).
- Pins tuppr + factory installer tags to **`v1.14.0`** (GA tag; do not merge until it exists).
- Adds runbook: `docs/runbooks/2026-07-29-talos-1.14-multidoc.md`.
- Validated offline with `talosctl v1.14.0-beta.0 machineconfig patch` + `validate --mode metal` for io (CP) and europa (worker).

**Hold:** draft until Talos **1.14.0 GA**. Applying on 1.13 will fail.

## Migrated vs deferred

**Migrated:** files→`EtcFileConfig`/`CRICustomizationConfig`, sysctl/sysfs/kernel/udev/time/DNS/hostname, kubelet/node labels/taints, KubePrism, cluster name/endpoint/network (Cilium = no Flannel doc), CoreDNS/proxy disabled, APIserver/CM/scheduler, discovery, secretbox encryption, europa GPU CRI + modules + `ExistingVolumeConfig`.

**Deferred (documented in runbook):**
- `UnattendedInstallConfig` (conflicts with `.machine.install.extraKernelArgs`)
- Bond/VLAN → network multi-doc
- PEM `Kube*CAConfig` / service-account docs (1Password still base64)
- Opt-in 1.14 defaults (`workloadIsolation`, EPHEMERAL `noexec`, filesystem trim)

## Test plan

- [ ] Wait for `v1.14.0` GA on GitHub releases / factory tags
- [ ] Merge this PR
- [ ] Tuppr (or manual) upgrade all nodes to 1.14.0
- [ ] `task talos:apply-node NODE=<n>` per node; confirm multi-doc in `talosctl get mc`
- [ ] europa: NVIDIA CRI + `nvidia.com/gpu` capacity; `e-extra` ready
- [ ] Ceph `HEALTH_OK`; steam/ollama healthy


Made with [Cursor](https://cursor.com)