### PR TITLE
feat(database)!: upgrade Bitnami MariaDB chart to 26.2.1

### DIFF
--- a/kubernetes/apps/database/mariadb/app/helmrelease.yaml
+++ b/kubernetes/apps/database/mariadb/app/helmrelease.yaml
@@ -17,6 +17,8 @@ spec:
       existingSecret: mariadb-secret
     metrics:
       enabled: true
+      auth:
+        existingSecret: mariadb-metrics
       resourcesPreset: small
       serviceMonitor:
         enabled: true

--- a/kubernetes/apps/database/mariadb/app/kustomization.yaml
+++ b/kubernetes/apps/database/mariadb/app/kustomization.yaml
@@ -4,4 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - externalsecret.yaml
+  - metrics-password.yaml
   - helmrelease.yaml

--- a/kubernetes/apps/database/mariadb/app/metrics-password.yaml
+++ b/kubernetes/apps/database/mariadb/app/metrics-password.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/generators.external-secrets.io/password_v1alpha1.json
+---
+apiVersion: generators.external-secrets.io/v1alpha1
+kind: Password
+metadata:
+  name: mariadb-metrics
+spec:
+  length: 32
+  symbols: 0
+  allowRepeat: true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: mariadb-metrics
+spec:
+  refreshPolicy: CreatedOnce
+  target:
+    name: mariadb-metrics
+    immutable: true
+    template:
+      engineVersion: v2
+      data:
+        mariadb-metrics-password: "{{ .password }}"
+  dataFrom:
+    - sourceRef:
+        generatorRef:
+          apiVersion: generators.external-secrets.io/v1alpha1
+          kind: Password
+          name: mariadb-metrics

--- a/kubernetes/flux/meta/repositories/oci/mariadb.yaml
+++ b/kubernetes/flux/meta/repositories/oci/mariadb.yaml
@@ -11,5 +11,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 25.0.1
+    tag: 26.2.1
   url: oci://registry-1.docker.io/bitnamicharts/mariadb


### PR DESCRIPTION
## Summary
- Bump Bitnami MariaDB OCI chart `25.0.1` → `26.2.1` (MariaDB `12.2.2` → `12.3.2`)
- Generate durable `mariadb-metrics` password via ESO Password generator (`CreatedOnce` + immutable) so chart 26.x metrics auth works with `existingSecret`
- Point HelmRelease `metrics.auth.existingSecret` at that secret

## Pre-merge ops
- VolSync manual snapshot of `database/mariadb` completed (`job/volsync-src-mariadb`)
- `mariadb-metrics` ExternalSecret already applied and synced on-cluster

## Test plan
- [x] VolSync snapshot completed
- [ ] Flux reconciles OCIRepository + HelmRelease to 26.2.1
- [ ] `mariadb-0` Ready (2/2)
- [ ] Create `exporter` user if metrics init skipped on existing datadir
- [ ] Booklore still connects
- [ ] Close/supersede renovate #1264


Made with [Cursor](https://cursor.com)