### PR TITLE
fix(rook-ceph): disable leaky rook mgr module to stop mgr OOMKills

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -27,6 +27,13 @@ spec:
         mgr:
           mgr/dashboard/ALERTMANAGER_API_HOST: http://vmalertmanager-vmks.observability.svc.cluster.local:9093
           mgr/dashboard/GRAFANA_API_URL: http://grafana.observability.svc.cluster.local
+          # https://github.com/rook/rook/issues/17786: on ceph v20.2.2 the rook mgr
+          # module's orchestrator availability check logs full pod-list responses
+          # (multi-MB JSON) roughly every 15s, filling the log_max_recent ring buffer
+          # (daemon default 10000, not the documented client default of 500) and
+          # OOMing mgr within hours regardless of the memory limit. Bound the buffer
+          # as defense-in-depth on top of disabling the rook module below.
+          log_max_recent: "100"
       crashCollector:
         disable: false
       csi:
@@ -43,8 +50,9 @@ spec:
             enabled: true
           - name: pg_autoscaler
             enabled: true
+          # Disabled: leaks memory and OOMs mgr, see log_max_recent comment above.
           - name: rook
-            enabled: true
+            enabled: false
       resources:
         mgr:
           requests:

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -27,12 +27,8 @@ spec:
         mgr:
           mgr/dashboard/ALERTMANAGER_API_HOST: http://vmalertmanager-vmks.observability.svc.cluster.local:9093
           mgr/dashboard/GRAFANA_API_URL: http://grafana.observability.svc.cluster.local
-          # https://github.com/rook/rook/issues/17786: on ceph v20.2.2 the rook mgr
-          # module's orchestrator availability check logs full pod-list responses
-          # (multi-MB JSON) roughly every 15s, filling the log_max_recent ring buffer
-          # (daemon default 10000, not the documented client default of 500) and
-          # OOMing mgr within hours regardless of the memory limit. Bound the buffer
-          # as defense-in-depth on top of disabling the rook module below.
+          # Bound the log ring buffer (daemon default 10000) as defense-in-depth
+          # against the mgr OOM leak: https://github.com/rook/rook/issues/17786
           log_max_recent: "100"
       crashCollector:
         disable: false
@@ -50,7 +46,7 @@ spec:
             enabled: true
           - name: pg_autoscaler
             enabled: true
-          # Disabled: leaks memory and OOMs mgr, see log_max_recent comment above.
+          # Disabled: leaks memory and OOMs mgr (rook/rook#17786)
           - name: rook
             enabled: false
       resources:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`rook-ceph-mgr` pods are getting repeatedly OOMKilled (per the Alertmanager `OOMKilled` alerts). We already bumped the mgr memory limit twice ([512Mi→2Gi](https://github.com/zebernst/homelab/commit/b3871c39), then [→3Gi](https://github.com/zebernst/homelab/commit/0d50dbea)) without actually fixing the underlying cause — mgr keeps growing until it hits whatever limit is set.

## Root cause

We recently cut over to the `rook-ceph-cluster` chart `v1.20.2` (no `cephVersion` override, so it pulls the current default Ceph image, `v20.2.2`). That version combo has a known, currently-open, unfixed upstream leak: [rook/rook#17786](https://github.com/rook/rook/issues/17786).

- Our `cephClusterSpec.mgr.modules` explicitly enables the `rook` orchestrator module.
- With the `prometheus` module also enabled (`monitoring.enabled: true`), `orch_is_available()` polls the `rook` module's `available()` check roughly every 15s.
- That check lists every pod in the `rook-ceph` namespace and logs the full JSON response body (multi-MB).
- Those log entries pile up in mgr's `log_max_recent` ring buffer, whose *daemon* default is `10000` (not the documented *client* default of `500`, per [ceph/ceph#67515](https://github.com/ceph/ceph/pull/67515)), so the buffer alone can balloon to multiple GB within hours.
- The fix in [ceph/ceph#69609](https://github.com/ceph/ceph/pull/69609) has not been backported to the v20.2.x branch we're on.

Multiple users in the linked issue confirmed disabling the `rook` mgr module resolves the leak. We don't rely on the in-cluster `ceph orch` CLI (Rook reconciles the cluster declaratively via its operator/CRDs, not through this module), so disabling it has no functional impact for us.

## Fix

- Disable the `rook` mgr module (`cephClusterSpec.mgr.modules`).
- Set `log_max_recent: "100"` on the `mgr` Ceph config as defense-in-depth, in case some other path re-triggers large log entries in the future.

## Testing

No cluster access from this environment, so I validated the YAML syntax locally and cross-referenced the exact failure signature (rook v1.20.x mgr OOMKills, module-list config, chart version, missing `cephVersion` override) against the upstream issue thread. Please monitor mgr memory/OOM alerts after this rolls out via Flux to confirm it resolves.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fd0be-e260-7502-ba44-95f9d1ff63db?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fd0be-e260-7502-ba44-95f9d1ff63db&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

