### PR TITLE
feat(helm): update chart cilium (1.19.6 ➔ 1.20.1)

### DIFF
--- a/kubernetes/apps/kube-system/cilium/app/helm-values.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/helm-values.yaml
@@ -51,7 +51,8 @@ loadBalancer:
   mode: dsr
   l7:
     backend: envoy
-localRedirectPolicy: true
+localRedirectPolicies:
+  enabled: true
 operator:
   replicas: 2
   rollOutPods: true

--- a/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cilium
-      version: 1.19.6
+      version: 1.20.1
       sourceRef:
         kind: HelmRepository
         name: cilium

--- a/kubernetes/apps/network/external-dns/cloudflare/helmrelease.yaml
+++ b/kubernetes/apps/network/external-dns/cloudflare/helmrelease.yaml
@@ -41,7 +41,7 @@ spec:
       - --exclude-domains=jptr.zebernst.dev
     triggerLoopOnEvent: true
     policy: sync
-    sources: ["crd", "ingress", "gateway-httproute", "gateway-tlsroute"]
+    sources: ["crd", "ingress", "gateway-httproute", "gateway-tlsroute", "gateway-tcproute", "gateway-udproute"]
     domainFilters: ["zebernst.dev"]
     podAnnotations:
       secret.reloader.stakater.com/reload: *secret

--- a/kubernetes/apps/network/external-dns/unifi/helmrelease.yaml
+++ b/kubernetes/apps/network/external-dns/unifi/helmrelease.yaml
@@ -63,7 +63,7 @@ spec:
       - --exclude-domains=jptr.zebernst.dev
     triggerLoopOnEvent: true
     policy: sync
-    sources: ["ingress", "service", "gateway-httproute", "gateway-tlsroute"]
+    sources: ["ingress", "service", "gateway-httproute", "gateway-tlsroute", "gateway-tcproute", "gateway-udproute"]
     domainFilters: ["zebernst.dev", "internal"]
     podAnnotations:
       secret.reloader.stakater.com/reload: *secret

--- a/kubernetes/bootstrap/helmfile.yaml
+++ b/kubernetes/bootstrap/helmfile.yaml
@@ -16,7 +16,7 @@ releases:
   - name: cilium
     namespace: kube-system
     chart: cilium/cilium
-    version: 1.19.6
+    version: 1.20.1
     values: ["../apps/kube-system/cilium/app/helm-values.yaml"]
     hooks:
       - events: ["postsync"]


### PR DESCRIPTION
## Summary
- Bump the Cilium Helm chart from 1.19.6 to 1.20.1 in both the Flux HelmRelease and bootstrap helmfile.
- Replace the deprecated `localRedirectPolicy` Helm value with `localRedirectPolicies.enabled`.
- Add `gateway-tcproute` and `gateway-udproute` sources to UniFi and Cloudflare ExternalDNS so Cilium 1.20 L4 routes get DNS records. The Helm chart grants matching RBAC from those sources.
- Cluster prerequisites already match 1.20: Gateway API v1.6.1 experimental (`TLSRoute`/`TCPRoute`/`UDPRoute` still have `v1alpha2`) and `CiliumNodeConfig` is already `cilium.io/v2`.

Cilium 1.20 also defaults Envoy to ADS xDS for new 1.20 installs when `upgradeCompatibility` is unset. Gateway / L7 connections will reset during the Envoy restart.

TCPRoute/UDPRoute have no `hostnames` field; ExternalDNS expects `external-dns.alpha.kubernetes.io/hostname` on the Route. Records are only created when the parent Gateway has a matching TCP/UDP listener.

## Test plan
- [ ] Flux reconciles `kube-system/cilium` HelmRelease to 1.20.1 without remaining in failed
- [ ] `cilium` DaemonSet, `cilium-envoy`, and `cilium-operator` roll to `v1.20.1` and go Ready
- [ ] LAN / tailscale / external Gateways stay Accepted and HTTPRoutes keep serving
- [ ] Hubble UI / relay come back after the Hubble cert CronJob path is unchanged
- [ ] Spot-check L2 VIP services (Plex, qBittorrent, cluster VIP) still get LB IPs
- [ ] `external-dns-unifi` and `external-dns-cloudflare` roll with `--source=gateway-tcproute` and `--source=gateway-udproute`
- [ ] ClusterRoles for both ExternalDNS instances include `tcproutes` and `udproutes`