### PR TITLE
fix(cilium): give CNI upgrades a 15m wait and roll one node at a time

### DIFF
--- a/kubernetes/apps/kube-system/cilium/app/helm-values.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/helm-values.yaml
@@ -75,6 +75,9 @@ prometheus:
     trustCRDsExist: true
 rollOutCiliumPods: true
 routingMode: native
+updateStrategy:
+  rollingUpdate:
+    maxUnavailable: 1
 securityContext:
   capabilities:
     ciliumAgent:

--- a/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
@@ -6,6 +6,7 @@ metadata:
   name: cilium
 spec:
   interval: 30m
+  timeout: 15m
   chart:
     spec:
       chart: cilium

--- a/kubernetes/apps/kube-system/cilium/ks.yaml
+++ b/kubernetes/apps/kube-system/cilium/ks.yaml
@@ -19,7 +19,7 @@ spec:
   wait: true
   interval: 30m
   retryInterval: 1m
-  timeout: 5m
+  timeout: 15m
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization


### PR DESCRIPTION
## Summary
- The 1.20.1 Helm upgrade was applied, then Flux marked it failed with `context canceled` when Cilium restarted on helm-controller's node (~37s into the wait).
- Retry already succeeded: Helm revision 39 is `cilium@1.20.1` and the DaemonSet is Ready 4/4. This change only hardens the next CNI roll.
- Raise the Cilium HelmRelease and Kustomization timeout from 5m to 15m, and set `updateStrategy.rollingUpdate.maxUnavailable: 1` so one agent restarts at a time.

## Test plan
- [ ] Flux reconciles `kube-system/cilium` HelmRelease Ready with the new 15m timeout
- [ ] Cilium DaemonSet `updateStrategy.rollingUpdate.maxUnavailable` is `1`
- [ ] Agents stay Ready 4/4 on `v1.20.1`


Made with [Cursor](https://cursor.com)