### PR TITLE
feat(minecraft): pin Java VIP and replace Tailscale RCON with web UIs

### DIFF
--- a/kubernetes/apps/auth/tinyauth/app/helmrelease.yaml
+++ b/kubernetes/apps/auth/tinyauth/app/helmrelease.yaml
@@ -25,6 +25,7 @@ spec:
             env:
               TINYAUTH_APPS_ID_IP_BYPASS: "0.0.0.0/0"
               TINYAUTH_APPS_AUTH_PATH_ALLOW: "^/api/auth"
+              TINYAUTH_AUTH_TRUSTEDPROXIES: "10.244.0.0/16"
             envFrom:
               - secretRef:
                   name: tinyauth-secret

--- a/kubernetes/apps/auth/tinyauth/app/kustomization.yaml
+++ b/kubernetes/apps/auth/tinyauth/app/kustomization.yaml
@@ -6,4 +6,5 @@ resources:
   - ciliumenvoyconfig.yaml
   - externalsecret.yaml
   - helmrelease.yaml
+  - referencegrant.yaml
   - vmprobe.yaml

--- a/kubernetes/apps/auth/tinyauth/app/referencegrant.yaml
+++ b/kubernetes/apps/auth/tinyauth/app/referencegrant.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/referencegrant_v1beta1.json
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: httproute-tinyauth
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      namespace: games
+  to:
+    - group: ""
+      kind: Service
+      name: tinyauth

--- a/kubernetes/apps/games/minecraft/atm10/app/externalsecret.yaml
+++ b/kubernetes/apps/games/minecraft/atm10/app/externalsecret.yaml
@@ -11,6 +11,8 @@ spec:
     template:
       data:
         RCON_PASSWORD: "{{ .RCON_PASSWORD }}"
+        RWA_PASSWORD: "{{ .RCON_PASSWORD }}"
+        RWA_RCON_PASSWORD: "{{ .RCON_PASSWORD }}"
         CF_API_KEY: "{{ .CF_API_KEY }}"
   dataFrom:
     - extract:

--- a/kubernetes/apps/games/minecraft/atm10/app/helmrelease.yaml
+++ b/kubernetes/apps/games/minecraft/atm10/app/helmrelease.yaml
@@ -151,7 +151,7 @@ spec:
               RWA_ADMIN: "TRUE"
               RWA_GAME: minecraft
               RWA_SERVER_NAME: *app
-              RWA_RCON_HOST: "{{ .Release.Name }}-rcon"
+              RWA_RCON_HOST: "{{ .Release.Name }}"
               RWA_RCON_PORT: "25578"
               RWA_WEBSOCKET_URL_SSL: "wss://{{ .Release.Name }}.jptr.zebernst.dev/ws"
               RWA_WEBSOCKET_URL: "wss://{{ .Release.Name }}.jptr.zebernst.dev/ws"
@@ -201,9 +201,6 @@ spec:
             port: 25565
           metrics:
             port: 8080
-      rcon:
-        controller: *app
-        ports:
           rcon:
             port: 25578
       rcon-web:

--- a/kubernetes/apps/games/minecraft/atm10/app/helmrelease.yaml
+++ b/kubernetes/apps/games/minecraft/atm10/app/helmrelease.yaml
@@ -202,7 +202,9 @@ spec:
           metrics:
             port: 8080
           rcon:
+            name: rcon
             port: 25578
+            protocol: TCP
       rcon-web:
         controller: rcon-web
         ports:

--- a/kubernetes/apps/games/minecraft/atm10/app/helmrelease.yaml
+++ b/kubernetes/apps/games/minecraft/atm10/app/helmrelease.yaml
@@ -67,6 +67,7 @@ spec:
               INIT_MEMORY: 2G
               MAX_MEMORY: &max-memory 14G
               MAX_TICK_TIME: "-1"
+              RCON_PORT: "25578"
             envFrom:
               - secretRef:
                   name: atm10-secret
@@ -129,6 +130,54 @@ spec:
               limits:
                 memory: 4Gi
 
+      rcon-web:
+        type: deployment
+        annotations:
+          reloader.stakater.com/auto: "true"
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+            fsGroupChangePolicy: OnRootMismatch
+        containers:
+          rcon-web:
+            image:
+              repository: docker.io/itzg/rcon
+              tag: latest@sha256:66cc978f196e2fb4c0afccc7bf7102773445cff85ea41eefe58dca19ea78413c
+            env:
+              RWA_USERNAME: admin
+              RWA_ADMIN: "TRUE"
+              RWA_GAME: minecraft
+              RWA_SERVER_NAME: *app
+              RWA_RCON_HOST: "{{ .Release.Name }}-rcon"
+              RWA_RCON_PORT: "25578"
+              RWA_WEBSOCKET_URL_SSL: "wss://{{ .Release.Name }}.jptr.zebernst.dev/ws"
+              RWA_WEBSOCKET_URL: "wss://{{ .Release.Name }}.jptr.zebernst.dev/ws"
+            envFrom:
+              - secretRef:
+                  name: atm10-secret
+            probes:
+              liveness: &rconProbe
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: 4326
+              readiness: *rconProbe
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: false
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                memory: 256Mi
+
     defaultPodOptions:
       securityContext:
         runAsNonRoot: true
@@ -154,13 +203,16 @@ spec:
             port: 8080
       rcon:
         controller: *app
-        type: LoadBalancer
-        loadBalancerClass: tailscale
-        annotations:
-          tailscale.com/hostname: atm10-rcon
         ports:
           rcon:
             port: 25578
+      rcon-web:
+        controller: rcon-web
+        ports:
+          http:
+            port: 4326
+          websocket:
+            port: 4327
 
     serviceMonitor:
       atm10:
@@ -171,6 +223,51 @@ spec:
             path: /metrics
             interval: 1m
             scrapeTimeout: 30s
+    route:
+      rcon-web:
+        annotations:
+          gatus.home-operations.com/enabled: "false"
+        hostnames:
+          - "{{ .Release.Name }}.jptr.zebernst.dev"
+        parentRefs:
+          - name: tailscale
+            namespace: kube-system
+            sectionName: https-canon
+        rules:
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /ws
+            filters: &rconAuth
+              - type: ExternalAuth
+                externalAuth:
+                  protocol: HTTP
+                  backendRef:
+                    name: tinyauth
+                    namespace: auth
+                    port: 3000
+                  http:
+                    path: "/api/auth/envoy?path="
+                    allowedHeaders:
+                      - cookie
+                      - accept
+                      - authorization
+                      - x-forwarded-proto
+                      - x-forwarded-host
+                    allowedResponseHeaders:
+                      - set-cookie
+                      - content-type
+            timeouts:
+              request: 0s
+            backendRefs:
+              - identifier: rcon-web
+                port: 4327
+          - filters: *rconAuth
+            timeouts:
+              request: 0s
+            backendRefs:
+              - identifier: rcon-web
+                port: 4326
     persistence:
       tmp:
         type: emptyDir
@@ -227,3 +324,9 @@ spec:
               - path: /app/config
             bluemap:
               - path: /app/config
+      rcon-web-db:
+        type: emptyDir
+        advancedMounts:
+          rcon-web:
+            rcon-web:
+              - path: /opt/rcon-web-admin/db

--- a/kubernetes/apps/games/minecraft/atm10/app/helmrelease.yaml
+++ b/kubernetes/apps/games/minecraft/atm10/app/helmrelease.yaml
@@ -189,7 +189,7 @@ spec:
     service:
       atm10:
         annotations:
-          mc-router.itzg.me/externalServerName: "atm10.zebernst.dev"
+          mc-router.itzg.me/externalServerName: "atm10.zebernst.dev,atm10.jptr.zebernst.dev"
           mc-router.itzg.me/autoScaleUp: "true"
           mc-router.itzg.me/autoScaleDown: "true"
           mc-router.itzg.me/autoScaleAsleepMOTD: "§eATM10 is sleeping.§r Join once to wake it, then reconnect in a few minutes."

--- a/kubernetes/apps/games/minecraft/atm10/ks.yaml
+++ b/kubernetes/apps/games/minecraft/atm10/ks.yaml
@@ -13,6 +13,8 @@ spec:
   components:
     - ../../../../../components/volsync
   dependsOn:
+    - name: tinyauth
+      namespace: auth
     - name: bluemap
       namespace: games
     - name: onepassword

--- a/kubernetes/apps/games/minecraft/atmons/app/externalsecret.yaml
+++ b/kubernetes/apps/games/minecraft/atmons/app/externalsecret.yaml
@@ -11,6 +11,8 @@ spec:
     template:
       data:
         RCON_PASSWORD: "{{ .RCON_PASSWORD }}"
+        RWA_PASSWORD: "{{ .RCON_PASSWORD }}"
+        RWA_RCON_PASSWORD: "{{ .RCON_PASSWORD }}"
         CF_API_KEY: "{{ .CF_API_KEY }}"
   dataFrom:
     - extract:

--- a/kubernetes/apps/games/minecraft/atmons/app/helmrelease.yaml
+++ b/kubernetes/apps/games/minecraft/atmons/app/helmrelease.yaml
@@ -153,7 +153,7 @@ spec:
               RWA_ADMIN: "TRUE"
               RWA_GAME: minecraft
               RWA_SERVER_NAME: *app
-              RWA_RCON_HOST: "{{ .Release.Name }}-rcon"
+              RWA_RCON_HOST: "{{ .Release.Name }}"
               RWA_RCON_PORT: "25578"
               RWA_WEBSOCKET_URL_SSL: "wss://{{ .Release.Name }}.jptr.zebernst.dev/ws"
               RWA_WEBSOCKET_URL: "wss://{{ .Release.Name }}.jptr.zebernst.dev/ws"
@@ -203,9 +203,6 @@ spec:
             port: 25565
           metrics:
             port: 8080
-      rcon:
-        controller: *app
-        ports:
           rcon:
             port: 25578
       rcon-web:

--- a/kubernetes/apps/games/minecraft/atmons/app/helmrelease.yaml
+++ b/kubernetes/apps/games/minecraft/atmons/app/helmrelease.yaml
@@ -191,7 +191,7 @@ spec:
     service:
       atmons:
         annotations:
-          mc-router.itzg.me/externalServerName: "atmons.zebernst.dev"
+          mc-router.itzg.me/externalServerName: "atmons.zebernst.dev,atmons.jptr.zebernst.dev"
           mc-router.itzg.me/autoScaleUp: "true"
           mc-router.itzg.me/autoScaleDown: "true"
           mc-router.itzg.me/autoScaleAsleepMOTD: "§eAll the Mons is sleeping.§r Join once to wake it, then reconnect in a few minutes."

--- a/kubernetes/apps/games/minecraft/atmons/app/helmrelease.yaml
+++ b/kubernetes/apps/games/minecraft/atmons/app/helmrelease.yaml
@@ -69,6 +69,7 @@ spec:
               INIT_MEMORY: 2G
               MAX_MEMORY: &max-memory 14G
               MAX_TICK_TIME: "-1"
+              RCON_PORT: "25578"
             envFrom:
               - secretRef:
                   name: atmons-secret
@@ -131,6 +132,54 @@ spec:
               limits:
                 memory: 4Gi
 
+      rcon-web:
+        type: deployment
+        annotations:
+          reloader.stakater.com/auto: "true"
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+            fsGroupChangePolicy: OnRootMismatch
+        containers:
+          rcon-web:
+            image:
+              repository: docker.io/itzg/rcon
+              tag: latest@sha256:66cc978f196e2fb4c0afccc7bf7102773445cff85ea41eefe58dca19ea78413c
+            env:
+              RWA_USERNAME: admin
+              RWA_ADMIN: "TRUE"
+              RWA_GAME: minecraft
+              RWA_SERVER_NAME: *app
+              RWA_RCON_HOST: "{{ .Release.Name }}-rcon"
+              RWA_RCON_PORT: "25578"
+              RWA_WEBSOCKET_URL_SSL: "wss://{{ .Release.Name }}.jptr.zebernst.dev/ws"
+              RWA_WEBSOCKET_URL: "wss://{{ .Release.Name }}.jptr.zebernst.dev/ws"
+            envFrom:
+              - secretRef:
+                  name: atmons-secret
+            probes:
+              liveness: &rconProbe
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: 4326
+              readiness: *rconProbe
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: false
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                memory: 256Mi
+
     defaultPodOptions:
       securityContext:
         runAsNonRoot: true
@@ -156,13 +205,16 @@ spec:
             port: 8080
       rcon:
         controller: *app
-        type: LoadBalancer
-        loadBalancerClass: tailscale
-        annotations:
-          tailscale.com/hostname: atmons-rcon
         ports:
           rcon:
             port: 25578
+      rcon-web:
+        controller: rcon-web
+        ports:
+          http:
+            port: 4326
+          websocket:
+            port: 4327
 
     serviceMonitor:
       atmons:
@@ -173,6 +225,51 @@ spec:
             path: /metrics
             interval: 1m
             scrapeTimeout: 30s
+    route:
+      rcon-web:
+        annotations:
+          gatus.home-operations.com/enabled: "false"
+        hostnames:
+          - "{{ .Release.Name }}.jptr.zebernst.dev"
+        parentRefs:
+          - name: tailscale
+            namespace: kube-system
+            sectionName: https-canon
+        rules:
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /ws
+            filters: &rconAuth
+              - type: ExternalAuth
+                externalAuth:
+                  protocol: HTTP
+                  backendRef:
+                    name: tinyauth
+                    namespace: auth
+                    port: 3000
+                  http:
+                    path: "/api/auth/envoy?path="
+                    allowedHeaders:
+                      - cookie
+                      - accept
+                      - authorization
+                      - x-forwarded-proto
+                      - x-forwarded-host
+                    allowedResponseHeaders:
+                      - set-cookie
+                      - content-type
+            timeouts:
+              request: 0s
+            backendRefs:
+              - identifier: rcon-web
+                port: 4327
+          - filters: *rconAuth
+            timeouts:
+              request: 0s
+            backendRefs:
+              - identifier: rcon-web
+                port: 4326
     persistence:
       tmp:
         type: emptyDir
@@ -229,3 +326,9 @@ spec:
               - path: /app/config
             bluemap:
               - path: /app/config
+      rcon-web-db:
+        type: emptyDir
+        advancedMounts:
+          rcon-web:
+            rcon-web:
+              - path: /opt/rcon-web-admin/db

--- a/kubernetes/apps/games/minecraft/atmons/app/helmrelease.yaml
+++ b/kubernetes/apps/games/minecraft/atmons/app/helmrelease.yaml
@@ -204,7 +204,9 @@ spec:
           metrics:
             port: 8080
           rcon:
+            name: rcon
             port: 25578
+            protocol: TCP
       rcon-web:
         controller: rcon-web
         ports:

--- a/kubernetes/apps/games/minecraft/atmons/ks.yaml
+++ b/kubernetes/apps/games/minecraft/atmons/ks.yaml
@@ -13,6 +13,8 @@ spec:
   components:
     - ../../../../../components/volsync
   dependsOn:
+    - name: tinyauth
+      namespace: auth
     - name: bluemap
       namespace: games
     - name: onepassword

--- a/kubernetes/apps/games/minecraft/router/app/gateway.yaml
+++ b/kubernetes/apps/games/minecraft/router/app/gateway.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/gateway_v1.json
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: minecraft
+  annotations:
+    gatus.home-operations.com/enabled: "false"
+spec:
+  gatewayClassName: cilium
+  addresses:
+    - type: IPAddress
+      value: 192.168.20.65
+    - type: IPAddress
+      value: ::ffff:192.168.20.65
+  listeners:
+    - name: java
+      protocol: TCP
+      port: 25565
+      allowedRoutes:
+        namespaces:
+          from: Same
+        kinds:
+          - kind: TCPRoute

--- a/kubernetes/apps/games/minecraft/router/app/helmrelease.yaml
+++ b/kubernetes/apps/games/minecraft/router/app/helmrelease.yaml
@@ -84,9 +84,7 @@ spec:
     service:
       mc-router:
         controller: *app
-        type: LoadBalancer
         annotations:
-          lbipam.cilium.io/ips: 192.168.20.65
           # Single Minecraft health signal — backends scale to zero and shouldn't be probed
           gatus.home-operations.com/enabled: "true"
           gatus.home-operations.com/endpoint: |
@@ -115,6 +113,16 @@ spec:
             interval: 1m
             scrapeTimeout: 30s
     route:
+      java:
+        kind: TCPRoute
+        parentRefs:
+          - name: minecraft
+            namespace: "{{ .Release.Namespace }}"
+            sectionName: java
+        rules:
+          - backendRefs:
+              - name: *app
+                port: *port
       api:
         kind: HTTPRoute
         annotations:

--- a/kubernetes/apps/games/minecraft/router/app/helmrelease.yaml
+++ b/kubernetes/apps/games/minecraft/router/app/helmrelease.yaml
@@ -115,9 +115,14 @@ spec:
     route:
       java:
         kind: TCPRoute
+        annotations:
+          gatus.home-operations.com/enabled: "false"
         parentRefs:
           - name: minecraft
             namespace: "{{ .Release.Namespace }}"
+            sectionName: java
+          - name: tailscale
+            namespace: kube-system
             sectionName: java
         rules:
           - backendRefs:

--- a/kubernetes/apps/games/minecraft/router/app/kustomization.yaml
+++ b/kubernetes/apps/games/minecraft/router/app/kustomization.yaml
@@ -4,4 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - dnsendpoint.yaml
+  - gateway.yaml
   - helmrelease.yaml

--- a/kubernetes/apps/games/minecraft/vanilla/app/externalsecret.yaml
+++ b/kubernetes/apps/games/minecraft/vanilla/app/externalsecret.yaml
@@ -11,6 +11,8 @@ spec:
     template:
       data:
         RCON_PASSWORD: "{{ .RCON_PASSWORD }}"
+        RWA_PASSWORD: "{{ .RCON_PASSWORD }}"
+        RWA_RCON_PASSWORD: "{{ .RCON_PASSWORD }}"
   dataFrom:
     - extract:
         key: minecraft

--- a/kubernetes/apps/games/minecraft/vanilla/app/helmrelease.yaml
+++ b/kubernetes/apps/games/minecraft/vanilla/app/helmrelease.yaml
@@ -56,6 +56,7 @@ spec:
               PAUSE_WHEN_EMPTY_SECONDS: "60"
               INIT_MEMORY: 1G
               MAX_MEMORY: &max-memory 4G
+              RCON_PORT: "25578"
             envFrom:
               - secretRef:
                   name: vanilla-secret
@@ -118,6 +119,54 @@ spec:
               limits:
                 memory: 1536Mi
 
+      rcon-web:
+        type: deployment
+        annotations:
+          reloader.stakater.com/auto: "true"
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+            fsGroupChangePolicy: OnRootMismatch
+        containers:
+          rcon-web:
+            image:
+              repository: docker.io/itzg/rcon
+              tag: latest@sha256:66cc978f196e2fb4c0afccc7bf7102773445cff85ea41eefe58dca19ea78413c
+            env:
+              RWA_USERNAME: admin
+              RWA_ADMIN: "TRUE"
+              RWA_GAME: minecraft
+              RWA_SERVER_NAME: *app
+              RWA_RCON_HOST: "{{ .Release.Name }}-rcon"
+              RWA_RCON_PORT: "25578"
+              RWA_WEBSOCKET_URL_SSL: "wss://{{ .Release.Name }}.jptr.zebernst.dev/ws"
+              RWA_WEBSOCKET_URL: "wss://{{ .Release.Name }}.jptr.zebernst.dev/ws"
+            envFrom:
+              - secretRef:
+                  name: vanilla-secret
+            probes:
+              liveness: &rconProbe
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: 4326
+              readiness: *rconProbe
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: false
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                memory: 256Mi
+
     defaultPodOptions:
       priorityClassName: best-effort
       securityContext:
@@ -140,13 +189,16 @@ spec:
             port: 8080
       rcon:
         controller: *app
-        type: LoadBalancer
-        loadBalancerClass: tailscale
-        annotations:
-          tailscale.com/hostname: vanilla-rcon
         ports:
           rcon:
             port: 25578
+      rcon-web:
+        controller: rcon-web
+        ports:
+          http:
+            port: 4326
+          websocket:
+            port: 4327
 
     serviceMonitor:
       vanilla:
@@ -157,6 +209,51 @@ spec:
             path: /metrics
             interval: 1m
             scrapeTimeout: 30s
+    route:
+      rcon-web:
+        annotations:
+          gatus.home-operations.com/enabled: "false"
+        hostnames:
+          - "{{ .Release.Name }}.jptr.zebernst.dev"
+        parentRefs:
+          - name: tailscale
+            namespace: kube-system
+            sectionName: https-canon
+        rules:
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /ws
+            filters: &rconAuth
+              - type: ExternalAuth
+                externalAuth:
+                  protocol: HTTP
+                  backendRef:
+                    name: tinyauth
+                    namespace: auth
+                    port: 3000
+                  http:
+                    path: "/api/auth/envoy?path="
+                    allowedHeaders:
+                      - cookie
+                      - accept
+                      - authorization
+                      - x-forwarded-proto
+                      - x-forwarded-host
+                    allowedResponseHeaders:
+                      - set-cookie
+                      - content-type
+            timeouts:
+              request: 0s
+            backendRefs:
+              - identifier: rcon-web
+                port: 4327
+          - filters: *rconAuth
+            timeouts:
+              request: 0s
+            backendRefs:
+              - identifier: rcon-web
+                port: 4326
     persistence:
       tmp:
         type: emptyDir
@@ -213,3 +310,9 @@ spec:
               - path: /app/config
             bluemap:
               - path: /app/config
+      rcon-web-db:
+        type: emptyDir
+        advancedMounts:
+          rcon-web:
+            rcon-web:
+              - path: /opt/rcon-web-admin/db

--- a/kubernetes/apps/games/minecraft/vanilla/app/helmrelease.yaml
+++ b/kubernetes/apps/games/minecraft/vanilla/app/helmrelease.yaml
@@ -188,7 +188,9 @@ spec:
           metrics:
             port: 8080
           rcon:
+            name: rcon
             port: 25578
+            protocol: TCP
       rcon-web:
         controller: rcon-web
         ports:

--- a/kubernetes/apps/games/minecraft/vanilla/app/helmrelease.yaml
+++ b/kubernetes/apps/games/minecraft/vanilla/app/helmrelease.yaml
@@ -140,7 +140,7 @@ spec:
               RWA_ADMIN: "TRUE"
               RWA_GAME: minecraft
               RWA_SERVER_NAME: *app
-              RWA_RCON_HOST: "{{ .Release.Name }}-rcon"
+              RWA_RCON_HOST: "{{ .Release.Name }}"
               RWA_RCON_PORT: "25578"
               RWA_WEBSOCKET_URL_SSL: "wss://{{ .Release.Name }}.jptr.zebernst.dev/ws"
               RWA_WEBSOCKET_URL: "wss://{{ .Release.Name }}.jptr.zebernst.dev/ws"
@@ -187,9 +187,6 @@ spec:
             port: 25565
           metrics:
             port: 8080
-      rcon:
-        controller: *app
-        ports:
           rcon:
             port: 25578
       rcon-web:

--- a/kubernetes/apps/games/minecraft/vanilla/app/helmrelease.yaml
+++ b/kubernetes/apps/games/minecraft/vanilla/app/helmrelease.yaml
@@ -179,7 +179,7 @@ spec:
     service:
       vanilla:
         annotations:
-          mc-router.itzg.me/externalServerName: "minecraft.zebernst.dev,vanilla.zebernst.dev"
+          mc-router.itzg.me/externalServerName: "minecraft.zebernst.dev,vanilla.zebernst.dev,vanilla.jptr.zebernst.dev"
           mc-router.itzg.me/autoScaleUp: "true"
           mc-router.itzg.me/autoScaleDown: "false"
         ports:

--- a/kubernetes/apps/games/minecraft/vanilla/ks.yaml
+++ b/kubernetes/apps/games/minecraft/vanilla/ks.yaml
@@ -13,6 +13,8 @@ spec:
   components:
     - ../../../../../components/volsync
   dependsOn:
+    - name: tinyauth
+      namespace: auth
     - name: bluemap
       namespace: games
     - name: onepassword

--- a/kubernetes/apps/kube-system/cilium/gateway/tailscale.yaml
+++ b/kubernetes/apps/kube-system/cilium/gateway/tailscale.yaml
@@ -57,3 +57,13 @@ spec:
           - kind: Secret
             name: jptr-zebernst-dev-tls
             namespace: cert-manager
+    # No hostname: Minecraft has no TLS SNI. All jptr names share this
+    # Tailscale IP; mc-router muxes on the handshake server address.
+    - name: java
+      protocol: TCP
+      port: 25565
+      allowedRoutes:
+        namespaces:
+          from: All
+        kinds:
+          - kind: TCPRoute


### PR DESCRIPTION
## Summary

Minecraft Java stays on `192.168.20.65:25565`, so UDM DNAT and the existing Cloudflare CNAMEs do not need to change. mc-router is no longer a Cilium LoadBalancer Service; a Gateway + TCPRoute owns that VIP instead.

On the tailnet, the same worlds are reachable as `vanilla.jptr.zebernst.dev` / `atm10.jptr.zebernst.dev` / `atmons.jptr.zebernst.dev` on port 25565 (Java default). Those names already share the Tailscale Gateway IP; TCP cannot hostname-mux there, so mc-router continues to pick the world from the handshake server address.

RCON leaves the three Tailscale MagicDNS LoadBalancers (`vanilla-rcon` / `atm10-rcon` / `atmons-rcon`). Binary RCON cannot share the Tailscale HTTPS Gateway, and `itzg/rcon`'s websocket is a second port, so a `/rcon` path is a trap. Each world now has a Tinyauth-gated console at hostname root on 443:

- https://vanilla.jptr.zebernst.dev
- https://atm10.jptr.zebernst.dev
- https://atmons.jptr.zebernst.dev

Auth is Cilium HTTPRoute `ExternalAuth` to Tinyauth only on these routes (Pocket ID). After that, rcon-web-admin still asks for `admin` / the Minecraft `RCON_PASSWORD`. ATM10 and ATMONS consoles stay up when those worlds scale to zero; RCON itself only works while the server is running.

## Cutover

- Brief Java drop while `cilium-gateway-minecraft` replaces the old LB (same IP).
- MagicDNS `*-rcon` names go away. CLI `mcrcon` should use in-cluster `<world>.games.svc:25578` or the web UI.
- Tailscale Java needs no UDM change. Confirm the Tailscale operator publishes `:25565` on `cilium-gateway` after apply.

## Test plan

- [ ] Java join still works at `minecraft.zebernst.dev` / per-world names after Flux apply
- [ ] `cilium-gateway-minecraft` holds `192.168.20.65`
- [ ] From a tailnet client, join `vanilla.jptr.zebernst.dev`, `atm10.jptr.zebernst.dev`, and `atmons.jptr.zebernst.dev` (port 25565)
- [ ] Tailscale `*-rcon` hostnames disappear
- [ ] Unauthenticated GET to `vanilla.jptr.zebernst.dev` redirects to Tinyauth
- [ ] After Pocket ID, the console and websocket work
- [ ] ATM10 scaled to zero: UI up, RCON disconnected until wake

## New concepts

**Gateway API ExternalAuth (GEP-1494).** An HTTPRoute filter that asks an external service whether a request may proceed, mapped by Cilium onto Envoy `ext_authz`. It is used here instead of attaching a CiliumEnvoyConfig to the whole Tailscale Gateway, so only the RCON routes require Tinyauth.

Do not use it for TCP/UDP routes, or for auth that must inspect a request body unless `forwardBody` is set. Tinyauth's Envoy endpoint needs `http.path: /api/auth/envoy?path=` so the original path is passed as a query string rather than concatenated onto `/api/auth/envoy`.

Made with [Cursor](https://cursor.com)

