### PR TITLE
fix(observability): clear Alertmanager firings for VM disk and ESPHome

### DIFF
--- a/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
@@ -66,8 +66,6 @@ spec:
             # vmalert/VMRule webhook only allows $labels/$value/$expr — not Helm's `default`
             job: '{{ if $labels.namespace }}{{ $labels.namespace }}{{ else }}cluster{{ end }}'
       groups:
-        # count:up0 is empty whenever every target is up, which permanently trips
-        # RecordingRulesNoData. Nothing in-tree depends on count:up{0,1}.
         kube-prometheus-general.rules:
           enabled: false
 
@@ -363,8 +361,6 @@ spec:
           storageClassName: ceph-block
           resources:
             requests:
-              # Was 50Gi and 100% full (~52Gi data, 90d retention); expand so
-              # DiskRunsOutOfSpace / KubePersistentVolumeFillingUp clear.
               storage: 100Gi
       ingress:
         enabled: false

--- a/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
@@ -65,6 +65,11 @@ spec:
           labels:
             # vmalert/VMRule webhook only allows $labels/$value/$expr — not Helm's `default`
             job: '{{ if $labels.namespace }}{{ $labels.namespace }}{{ else }}cluster{{ end }}'
+      groups:
+        # count:up0 is empty whenever every target is up, which permanently trips
+        # RecordingRulesNoData. Nothing in-tree depends on count:up{0,1}.
+        kube-prometheus-general.rules:
+          enabled: false
 
     extraRules:
       dockerhub-rules:
@@ -358,7 +363,9 @@ spec:
           storageClassName: ceph-block
           resources:
             requests:
-              storage: 50Gi
+              # Was 50Gi and 100% full (~52Gi data, 90d retention); expand so
+              # DiskRunsOutOfSpace / KubePersistentVolumeFillingUp clear.
+              storage: 100Gi
       ingress:
         enabled: false
 

--- a/kubernetes/apps/self-hosted/esphome/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/esphome/app/helmrelease.yaml
@@ -105,8 +105,6 @@ spec:
         existingClaim: *app
         globalMounts:
           - path: /config
-      # Share the VolSync-managed claim (runtime already mounted both paths on it).
-      # A second Helm PVC named `esphome` fought Flux's VolSync PVC and broke reconcile.
       cache:
         existingClaim: *app
         globalMounts:

--- a/kubernetes/apps/self-hosted/esphome/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/esphome/app/helmrelease.yaml
@@ -105,11 +105,10 @@ spec:
         existingClaim: *app
         globalMounts:
           - path: /config
+      # Share the VolSync-managed claim (runtime already mounted both paths on it).
+      # A second Helm PVC named `esphome` fought Flux's VolSync PVC and broke reconcile.
       cache:
-        type: persistentVolumeClaim
-        size: 20Gi
-        accessMode: ReadWriteOnce
-        storageClass: ceph-block
+        existingClaim: *app
         globalMounts:
           - path: /cache
       tmp:

--- a/kubernetes/apps/self-hosted/esphome/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/esphome/app/helmrelease.yaml
@@ -106,7 +106,11 @@ spec:
         globalMounts:
           - path: /config
       cache:
-        existingClaim: *app
+        type: persistentVolumeClaim
+        forceRename: esphome-cache
+        size: 20Gi
+        accessMode: ReadWriteOnce
+        storageClass: ceph-block
         globalMounts:
           - path: /cache
       tmp:

--- a/kubernetes/apps/self-hosted/esphome/ks.yaml
+++ b/kubernetes/apps/self-hosted/esphome/ks.yaml
@@ -30,4 +30,26 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      VOLSYNC_CAPACITY: 1Gi
+      # Must match the already-bound claim (Helm previously provisioned 20Gi);
+      # PVC size cannot shrink, and 1Gi was failing Flux dry-run.
+      VOLSYNC_CAPACITY: 20Gi
+  patches:
+    # Claim was created by Helm without dataSourceRef. Leaving dataSourceRef in
+    # the desired VolSync PVC makes every reconcile fail (immutable field).
+    - target:
+        kind: PersistentVolumeClaim
+        name: esphome
+      patch: |-
+        - op: remove
+          path: /spec/dataSourceRef
+    # Keep annotation so Helm can drop ownership when cache stops creating the PVC.
+    - target:
+        kind: PersistentVolumeClaim
+        name: esphome
+      patch: |-
+        apiVersion: v1
+        kind: PersistentVolumeClaim
+        metadata:
+          name: esphome
+          annotations:
+            helm.sh/resource-policy: keep

--- a/kubernetes/apps/self-hosted/esphome/ks.yaml
+++ b/kubernetes/apps/self-hosted/esphome/ks.yaml
@@ -30,19 +30,14 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      # Must match the already-bound claim (Helm previously provisioned 20Gi);
-      # PVC size cannot shrink, and 1Gi was failing Flux dry-run.
       VOLSYNC_CAPACITY: 20Gi
   patches:
-    # Claim was created by Helm without dataSourceRef. Leaving dataSourceRef in
-    # the desired VolSync PVC makes every reconcile fail (immutable field).
     - target:
         kind: PersistentVolumeClaim
         name: esphome
       patch: |-
         - op: remove
           path: /spec/dataSourceRef
-    # Keep annotation so Helm can drop ownership when cache stops creating the PVC.
     - target:
         kind: PersistentVolumeClaim
         name: esphome

--- a/kubernetes/apps/self-hosted/esphome/ks.yaml
+++ b/kubernetes/apps/self-hosted/esphome/ks.yaml
@@ -30,21 +30,4 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      VOLSYNC_CAPACITY: 20Gi
-  patches:
-    - target:
-        kind: PersistentVolumeClaim
-        name: esphome
-      patch: |-
-        - op: remove
-          path: /spec/dataSourceRef
-    - target:
-        kind: PersistentVolumeClaim
-        name: esphome
-      patch: |-
-        apiVersion: v1
-        kind: PersistentVolumeClaim
-        metadata:
-          name: esphome
-          annotations:
-            helm.sh/resource-policy: keep
+      VOLSYNC_CAPACITY: 1Gi


### PR DESCRIPTION
## Summary
- Expand `vmsingle` PVC `50Gi → 100Gi` — disk was 100% full (~52Gi data, 90d retention), firing `DiskRunsOutOfSpace`, `DiskRunsOutOfSpaceIn3Days`, `KubePersistentVolumeFillingUp`, and `NodeBecomesReadonlyIn3Days`.
- ESPHome: `forceRename: esphome-cache` so the Helm cache claim no longer collides with the VolSync `esphome` claim (app-template drops the `-<key>` suffix when only one Helm PVC exists). After merge, delete the faulty `esphome` PVC and let VolSync recreate it.
- Disable `kube-prometheus-general.rules` — `count:up0` is empty when every target is up, which permanently trips `RecordingRulesNoData`.

## Test plan
- [ ] After merge, confirm `vmsingle-vmks` PVC expands to 100Gi and disk alerts clear once free space recovers
- [ ] Delete the bad `esphome` PVC; confirm VolSync recreates `esphome` and Helm creates `esphome-cache`
- [ ] Confirm `kustomization/esphome` becomes Ready and the Flux alert clears
- [ ] Confirm `RecordingRulesNoData` for `count:up0` clears / rule group is gone
- [ ] Confirm ESPHome mounts `/config` → `esphome` and `/cache` → `esphome-cache`