### PR TITLE
feat(downloads): deploy Whisparr v3 (eros) alongside v2

### DIFF
--- a/kubernetes/apps/downloads/kustomization.yaml
+++ b/kubernetes/apps/downloads/kustomization.yaml
@@ -22,3 +22,4 @@ resources:
   - sonarr/ks.yaml
   - unpackerr/ks.yaml
   - whisparr/ks.yaml
+  - whisparr-eros/ks.yaml

--- a/kubernetes/apps/downloads/whisparr-eros/app/externalsecret.yaml
+++ b/kubernetes/apps/downloads/whisparr-eros/app/externalsecret.yaml
@@ -1,0 +1,35 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: whisparr-eros
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: whisparr-eros-secret
+    template:
+      engineVersion: v2
+      data:
+        WHISPARR__AUTH__APIKEY: "{{ .WHISPARR_API_KEY }}"
+        WHISPARR__POSTGRES__HOST: &dbHost redspot-rw.database.svc.cluster.local
+        WHISPARR__POSTGRES__PORT: "5432"
+        WHISPARR__POSTGRES__USER: &dbUser "{{ .WHISPARR_POSTGRES_USER }}"
+        WHISPARR__POSTGRES__PASSWORD: &dbPass "{{ .WHISPARR_POSTGRES_PASSWORD }}"
+        WHISPARR__POSTGRES__MAINDB: &dbName whisparr-eros
+        PUSHOVER_TOKEN: "{{ .WHISPARR_PUSHOVER_TOKEN }}"
+        PUSHOVER_USER_KEY: "{{ .PUSHOVER_USER_KEY }}"
+        INIT_POSTGRES_DBNAME: *dbName
+        INIT_POSTGRES_HOST: *dbHost
+        INIT_POSTGRES_USER: *dbUser
+        INIT_POSTGRES_PASS: *dbPass
+        INIT_POSTGRES_SUPER_PASS: "{{ .POSTGRES_SUPER_PASS }}"
+  dataFrom:
+    - extract:
+        key: cloudnative-pg
+    - extract:
+        key: pushover
+    - extract:
+        key: whisparr

--- a/kubernetes/apps/downloads/whisparr-eros/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/whisparr-eros/app/helmrelease.yaml
@@ -1,0 +1,101 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app whisparr-eros
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+    namespace: flux-system
+
+  values:
+    controllers:
+      whisparr-eros:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        initContainers:
+          init-db:
+            image:
+              repository: ghcr.io/home-operations/postgres-init
+              tag: 17
+            envFrom: &envFrom
+              - secretRef:
+                  name: whisparr-eros-secret
+        containers:
+          whisparr-eros:
+            image:
+              # Whisparr v3 (eros) — parallel to v2 whisparr until parity is verified
+              repository: ghcr.io/hotio/whisparr
+              tag: v3-3.3.8-release.1097@sha256:11fefc888d1483a7ce0e36e839d5e89fb78f28aeb784468131b4b3b4d509017a
+            env:
+              PUID: 568
+              PGID: 568
+              UMASK: "002"
+              # hotio defaults to 6969; keep cluster Service/probes on 80
+              WEBUI_PORTS: "80/tcp"
+              WHISPARR__APP__INSTANCENAME: Whisparr Eros
+              WHISPARR__APP__THEME: dark
+              WHISPARR__AUTH__METHOD: External
+              WHISPARR__AUTH__REQUIRED: DisabledForLocalAddresses
+              WHISPARR__LOG__DBENABLED: "False"
+              WHISPARR__LOG__LEVEL: info
+              WHISPARR__SERVER__PORT: &port 80
+              WHISPARR__UPDATE__BRANCH: eros
+              TZ: America/Chicago
+            envFrom: *envFrom
+            probes:
+              liveness: &probe
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /ping
+                    port: *port
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
+              readiness: *probe
+            resources:
+              requests:
+                cpu: 10m
+              limits:
+                memory: 1Gi
+    defaultPodOptions:
+      # hotio s6 /init must start as root, then drops to PUID/PGID
+      securityContext:
+        fsGroup: 568
+        fsGroupChangePolicy: OnRootMismatch
+        supplementalGroups: [65568]
+    service:
+      whisparr-eros:
+        controller: *app
+        ports:
+          http:
+            port: *port
+    route:
+      canonical:
+        annotations:
+          gatus.home-operations.com/endpoint: |
+            name: "{{ .Release.Name }}"
+            group: "{{ .Release.Namespace }}"
+        hostnames:
+          - "{{ .Release.Name }}.jptr.zebernst.dev"
+        parentRefs:
+          - name: tailscale
+            namespace: kube-system
+            sectionName: https-canon
+    persistence:
+      config:
+        existingClaim: whisparr-eros
+      media:
+        type: nfs
+        server: nas.internal
+        path: /volume1/media
+        globalMounts:
+          - path: /media
+      tmp:
+        type: emptyDir

--- a/kubernetes/apps/downloads/whisparr-eros/app/kustomization.yaml
+++ b/kubernetes/apps/downloads/whisparr-eros/app/kustomization.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - externalsecret.yaml
+  - helmrelease.yaml
+  - vmprobe.yaml

--- a/kubernetes/apps/downloads/whisparr-eros/app/vmprobe.yaml
+++ b/kubernetes/apps/downloads/whisparr-eros/app/vmprobe.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/operator.victoriametrics.com/vmprobe_v1beta1.json
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMProbe
+metadata:
+  name: whisparr-eros
+spec:
+  interval: 1m
+  module: http_2xx
+  vmProberSpec:
+    url: blackbox-exporter.observability.svc.cluster.local:9115
+  targets:
+    static:
+      labels:
+        namespace: downloads
+        app: whisparr-eros
+      targets:
+        - http://whisparr-eros.downloads.svc.cluster.local/ping

--- a/kubernetes/apps/downloads/whisparr-eros/ks.yaml
+++ b/kubernetes/apps/downloads/whisparr-eros/ks.yaml
@@ -1,0 +1,39 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app whisparr-eros
+  namespace: &ns downloads
+spec:
+  targetNamespace: *ns
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/keda/nfs-scaler
+    - ../../../../components/volsync
+    - ../../../../components/vmalert-rules
+  dependsOn:
+    - name: cloudnative-pg-cluster
+      namespace: database
+    - name: onepassword
+      namespace: external-secrets
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+    - name: volsync
+      namespace: volsync-system
+  path: kubernetes/apps/downloads/whisparr-eros/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 10Gi


### PR DESCRIPTION
## Summary
- Add parallel `whisparr-eros` app on Whisparr v3 (`ghcr.io/hotio/whisparr:v3-3.3.8-release.1097`) so we can validate setup parity before retiring v2
- Keep existing `whisparr` (v2 / jfroy nightly) unchanged; unpackerr still targets v2 only
- Isolate eros with its own PVC (`whisparr-eros`), Postgres DB (`whisparr-eros`), secret, Tailscale route (`whisparr-eros.jptr.zebernst.dev`), and VMProbe

## Test plan
- [ ] Flux reconciles `whisparr-eros` Kustomization in `downloads`
- [ ] Postgres init creates `whisparr-eros` DB; pod reaches Ready
- [ ] UI reachable at `https://whisparr-eros.jptr.zebernst.dev`
- [ ] Confirm v2 `whisparr` still healthy and unpackerr still works against it
- [ ] Configure indexers / download clients on eros and spot-check search/grab parity
- [ ] After parity: remove v2 and rename eros → `whisparr` in a follow-up PR


Made with [Cursor](https://cursor.com)