### PR TITLE
fix(whisparr-eros): use PGID 65568 for Synology NFS access

### DIFF
--- a/kubernetes/apps/downloads/whisparr-eros/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/whisparr-eros/app/helmrelease.yaml
@@ -32,8 +32,6 @@ spec:
               tag: v3-3.3.8-release.1097@sha256:11fefc888d1483a7ce0e36e839d5e89fb78f28aeb784468131b4b3b4d509017a
             env:
               PUID: 568
-              # Synology NFS ACLs require group 65568; hotio's setuid drop
-              # does not keep pod supplementalGroups, so make it primary GID
               PGID: 65568
               UMASK: "002"
               # hotio defaults to 6969; keep cluster Service/probes on 80

--- a/kubernetes/apps/downloads/whisparr-eros/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/whisparr-eros/app/helmrelease.yaml
@@ -32,7 +32,9 @@ spec:
               tag: v3-3.3.8-release.1097@sha256:11fefc888d1483a7ce0e36e839d5e89fb78f28aeb784468131b4b3b4d509017a
             env:
               PUID: 568
-              PGID: 568
+              # Synology NFS ACLs require group 65568; hotio's setuid drop
+              # does not keep pod supplementalGroups, so make it primary GID
+              PGID: 65568
               UMASK: "002"
               # hotio defaults to 6969; keep cluster Service/probes on 80
               WEBUI_PORTS: "80/tcp"


### PR DESCRIPTION
## Summary
- hotio drops privileges after s6 init and loses pod `supplementalGroups`, so Whisparr v3 could not read `/media` on Synology NFS
- Set `PGID: 65568` so the app primary group matches the NAS share group (same group v2 gets via `supplementalGroups`)

Follow-up to #1445 (merged without this fix).

## Test plan
- [ ] Flux rolls `whisparr-eros`
- [ ] In-pod: Whisparr process groups include `65568` and can `ls /media`
- [ ] UI can browse `/media/xxx` (or configured root folder path)


Made with [Cursor](https://cursor.com)