### PR TITLE
fix(esphome): raise VolSync capacity to 10Gi

### DIFF
--- a/kubernetes/apps/self-hosted/esphome/ks.yaml
+++ b/kubernetes/apps/self-hosted/esphome/ks.yaml
@@ -6,6 +6,7 @@ metadata:
   name: &app esphome
   namespace: &ns self-hosted
 spec:
+  suspend: false
   targetNamespace: *ns
   commonMetadata:
     labels:
@@ -31,3 +32,11 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 10Gi
+  patches:
+    - target:
+        kind: ReplicationDestination
+        name: esphome
+      patch: |-
+        - op: replace
+          path: /spec/trigger/manual
+          value: restore-10gi

--- a/kubernetes/apps/self-hosted/esphome/ks.yaml
+++ b/kubernetes/apps/self-hosted/esphome/ks.yaml
@@ -30,4 +30,4 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      VOLSYNC_CAPACITY: 1Gi
+      VOLSYNC_CAPACITY: 10Gi

--- a/kubernetes/apps/self-hosted/esphome/ks.yaml
+++ b/kubernetes/apps/self-hosted/esphome/ks.yaml
@@ -6,7 +6,6 @@ metadata:
   name: &app esphome
   namespace: &ns self-hosted
 spec:
-  suspend: false
   targetNamespace: *ns
   commonMetadata:
     labels:
@@ -32,11 +31,3 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 10Gi
-  patches:
-    - target:
-        kind: ReplicationDestination
-        name: esphome
-      patch: |-
-        - op: replace
-          path: /spec/trigger/manual
-          value: restore-10gi


### PR DESCRIPTION
## Summary
- Bump `VOLSYNC_CAPACITY` `1Gi → 10Gi` so ReplicationDestination restore can fit the ~5Gi restic snapshot.

Resume / re-trigger restore stay imperative after merge.

## Test plan
- [ ] Merge and wait for Flux to apply capacity
- [ ] `flux resume kustomization esphome -n self-hosted`
- [ ] Re-trigger RD manual restore; confirm success
- [ ] Confirm PVC `esphome` recreates and deploy is healthy