### PR TITLE
feat(tofu): import Cloudflare into OpenTofu

### DIFF
--- a/tofu/cloudflare/.fnox.toml
+++ b/tofu/cloudflare/.fnox.toml
@@ -1,0 +1,3 @@
+[secrets]
+CLOUDFLARE_API_TOKEN = { provider = "op", value = "cloudflare-token-opentofu/token" }
+TF_VAR_account_id    = { provider = "op", value = "cloudflare-token-opentofu/account-id" }

--- a/tofu/cloudflare/.terraform.lock.hcl
+++ b/tofu/cloudflare/.terraform.lock.hcl
@@ -1,0 +1,26 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/cloudflare/cloudflare" {
+  version     = "5.24.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:EdatAvZg845pGYfEdzYNkxmQfV8or5y6HDbh6CIJfI8=",
+    "h1:F3V4hF42Y/Usl9OhzNFQHwUL8oNXTzbY5x6dQaDaASc=",
+    "h1:HR6WGGeB70a/yygHbNFsg+3Ko7s9AgtlkFf8PdbZfT8=",
+    "h1:NxZYEFjCgaI7lGi3L8mn0KZcWPfbqUdmt5Bo4yqWMFE=",
+    "h1:PIAng5QYiHeydJm1S6sG6d1YYIjaFuIwnifvq/qEV1Q=",
+    "h1:R1Pt6vcenzSH8FDbxW1MQ3tk+/nXAfvscASTFaOmERM=",
+    "h1:ZGuBr8oAhWpWIni1jaNofXcsNUoaHuejjHcbcH72z1Q=",
+    "h1:yM0PvkOY7H66+yk+vlDJOnhDQXOFT6cHlmZ/C6UjT/c=",
+    "zh:2390fc5df95addfd47d3f638964a1f9f6192a8c84ad3b1eab554ef88e0ac4091",
+    "zh:2b09c0afbebeb3139a3094e3debda1ba5ff3d73b6eca536549bdc903284b6798",
+    "zh:3241ce471f20745b1dc93baea73a716e1db4637ff41acc134114b7a8c9684714",
+    "zh:3513243e5582836054076a21abeadd8142a8421df6ec1ead53d96dc37a9e6326",
+    "zh:99b33ccb8a1c10a08e8903a2848eb2664c889dc79801a1e61e0373dd41c6c0f9",
+    "zh:99c7b510b100a605b0c80e0c3665d99c2381b0834f52ad6ca767e161c2ffa416",
+    "zh:c523d747a2d8457bc2d2cc00967c419ef38a5ebebd12d5091cf18322b7201f04",
+    "zh:f520e37f4d875b6fee95cffb74cf5fe9efc3cd54fe6bb4b815da5cee87e517e8",
+    "zh:f809ab383cca0a5f83072981c64208cbd7fa67e986a86ee02dd2c82333221e32",
+  ]
+}

--- a/tofu/cloudflare/account.tf
+++ b/tofu/cloudflare/account.tf
@@ -1,0 +1,4 @@
+data "cloudflare_account" "account" {
+  account_id = var.account_id
+}
+

--- a/tofu/cloudflare/cloudflared_tunnels.tf
+++ b/tofu/cloudflare/cloudflared_tunnels.tf
@@ -1,0 +1,12 @@
+resource "cloudflare_zero_trust_tunnel_cloudflared" "cloudflared_noauth" {
+  account_id = data.cloudflare_account.account.id
+  config_src = "local"
+  name       = "k8s"
+}
+
+resource "cloudflare_zero_trust_tunnel_cloudflared" "cloudflared_auth" {
+  account_id = data.cloudflare_account.account.id
+  config_src = "local"
+  name       = "k8s-auth"
+}
+

--- a/tofu/cloudflare/dns.tf
+++ b/tofu/cloudflare/dns.tf
@@ -53,7 +53,7 @@ resource "cloudflare_dns_record" "google_domainconnect" {
   }
 }
 
-resource "cloudflare_dns_record" "dkim_fastmail" {
+resource "cloudflare_dns_record" "fastmail_dkim" {
   for_each = local.fastmail_dkim
 
   comment = "Fastmail"

--- a/tofu/cloudflare/dns.tf
+++ b/tofu/cloudflare/dns.tf
@@ -1,0 +1,122 @@
+locals {
+  domain = cloudflare_zone.zebernst_dev.name
+  zone   = cloudflare_zone.zebernst_dev.id
+
+  # Fastmail DKIM selector CNAMEs (fm1/fm2/fm3).
+  fastmail_dkim = {
+    for i in range(1, 4) : "fm${i}" => {
+      name    = "fm${i}._domainkey.${local.domain}"
+      content = "fm${i}.${local.domain}.dkim.fmhosted.com"
+    }
+  }
+
+  # Fastmail MX (apex + wildcard).
+  mx = {
+    apex_primary = {
+      name     = local.domain
+      content  = "in1-smtp.messagingengine.com"
+      priority = 10
+    }
+    apex_secondary = {
+      name     = local.domain
+      content  = "in2-smtp.messagingengine.com"
+      priority = 20
+    }
+    wildcard_primary = {
+      name     = "*.${local.domain}"
+      content  = "in1-smtp.messagingengine.com"
+      priority = 10
+    }
+    wildcard_secondary = {
+      name     = "*.${local.domain}"
+      content  = "in2-smtp.messagingengine.com"
+      priority = 20
+    }
+  }
+
+  dmarc = {
+    fastmail = "\"v=DMARC1; p=quarantine; rua=mailto:admin@${local.domain}\""
+    cloudflare = "\"v=DMARC1; p=none; rua=mailto:8877933bd64d4f2c9bb00fff76d4aa45@dmarc-reports.cloudflare.net\""
+  }
+}
+
+resource "cloudflare_dns_record" "google_domainconnect" {
+  comment = "Came with Google Domains"
+  content = "connect.domains.google.com"
+  name    = "_domainconnect.${local.domain}"
+  proxied = false
+  ttl     = 1
+  type    = "CNAME"
+  zone_id = local.zone
+  settings = {
+    flatten_cname = false
+  }
+}
+
+resource "cloudflare_dns_record" "dkim_fastmail" {
+  for_each = local.fastmail_dkim
+
+  comment = "Fastmail"
+  content = each.value.content
+  name    = each.value.name
+  proxied = false
+  ttl     = 1
+  type    = "CNAME"
+  zone_id = local.zone
+  settings = {
+    flatten_cname = false
+  }
+}
+
+resource "cloudflare_dns_record" "mx" {
+  for_each = local.mx
+
+  comment  = "Fastmail"
+  content  = each.value.content
+  name     = each.value.name
+  priority = each.value.priority
+  proxied  = false
+  ttl      = 1
+  type     = "MX"
+  zone_id  = local.zone
+}
+
+resource "cloudflare_dns_record" "bsky_atproto" {
+  comment = "BlueSky Social ATP Verification"
+  content = "\"did=did:plc:pxo52v54v5pqxg4vm3m7ezcc\""
+  name    = "_atproto.${local.domain}"
+  proxied = false
+  ttl     = 1
+  type    = "TXT"
+  zone_id = local.zone
+}
+
+resource "cloudflare_dns_record" "dkim_cloudflare" {
+  content = "\"v=DKIM1; h=sha256; k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAiweykoi+o48IOGuP7GR3X0MOExCUDY/BCRHoWBnh3rChl7WhdyCxW3jgq1daEjPPqoi7sJvdg5hEQVsgVRQP4DcnQDVjGMbASQtrY4WmB1VebF+RPJB2ECPsEDTpeiI5ZyUAwJaVX7r6bznU67g7LvFq35yIo4sdlmtZGV+i0H4cpYH9+3JJ78k\" \"m4KXwaf9xUJCWF6nxeD+qG6Fyruw1Qlbds2r85U9dkNDVAS3gioCvELryh1TxKGiVTkg4wqHTyHfWsp7KD3WQHYJn0RyfJJu6YEmL77zonn7p2SRMvTMP3ZEXibnC9gz3nnhR6wcYL8Q7zXypKTMD58bTixDSJwIDAQAB\""
+  name    = "cf2024-1._domainkey.${local.domain}"
+  proxied = false
+  ttl     = 1
+  type    = "TXT"
+  zone_id = local.zone
+}
+
+resource "cloudflare_dns_record" "dmarc" {
+  for_each = local.dmarc
+
+  content = each.value
+  name    = "_dmarc.${local.domain}"
+  proxied = false
+  ttl     = 1
+  type    = "TXT"
+  zone_id = local.zone
+}
+
+resource "cloudflare_dns_record" "fastmail_spf" {
+  comment = "Fastmail"
+  content = "\"v=spf1 include:spf.messagingengine.com ?all\""
+  name    = local.domain
+  proxied = false
+  ttl     = 1
+  type    = "TXT"
+  zone_id = local.zone
+}

--- a/tofu/cloudflare/dnssec.tf
+++ b/tofu/cloudflare/dnssec.tf
@@ -1,0 +1,5 @@
+resource "cloudflare_zone_dnssec" "zebernst_dev_dnssec" {
+  status  = "active"
+  zone_id = cloudflare_zone.zebernst_dev.id
+}
+

--- a/tofu/cloudflare/ruleset.tf
+++ b/tofu/cloudflare/ruleset.tf
@@ -1,0 +1,23 @@
+resource "cloudflare_ruleset" "cache_bypass" {
+  kind    = "zone"
+  name    = "default"
+  phase   = "http_request_cache_settings"
+  zone_id = cloudflare_zone.zebernst_dev.id
+  rules = [
+    {
+      action = "set_cache_settings"
+      action_parameters = { cache = false }
+      expression   = "(http.host eq \"plex.${cloudflare_zone.zebernst_dev.name}\")"
+      description  = "Disable Cloudflare caching for Plex streaming traffic"
+      ref          = "plex_bypass_cache"
+    }, 
+    {
+      action = "set_cache_settings"
+      action_parameters = { cache = false }
+      expression   = "(http.host eq \"s3.${cloudflare_zone.zebernst_dev.name}\")"
+      description  = "Disable Cloudflare caching for object storage endpoints"
+      ref          = "s3_bypass_cache"
+    }
+  ]
+}
+

--- a/tofu/cloudflare/variables.tf
+++ b/tofu/cloudflare/variables.tf
@@ -1,0 +1,4 @@
+variable "account_id" {
+  type        = string
+  description = "Cloudflare account ID"
+}

--- a/tofu/cloudflare/versions.tf
+++ b/tofu/cloudflare/versions.tf
@@ -26,5 +26,4 @@ terraform {
   }
 }
 
-# Authenticated via CLOUDFLARE_API_TOKEN (fnox → 1Password).
 provider "cloudflare" {}

--- a/tofu/cloudflare/versions.tf
+++ b/tofu/cloudflare/versions.tf
@@ -1,0 +1,30 @@
+terraform {
+  required_version = ">= 1.8"
+
+  required_providers {
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 5"
+    }
+  }
+
+  backend "s3" {
+    bucket = "jupiter-tofu-state"
+    key    = "opentofu/cloudflare.tfstate"
+    region = "us-west-001"
+
+    endpoints = {
+      s3 = "https://s3.us-west-001.backblazeb2.com"
+    }
+
+    skip_credentials_validation = true
+    skip_metadata_api_check     = true
+    skip_region_validation      = true
+    skip_requesting_account_id  = true
+    skip_s3_checksum            = true
+    use_path_style              = true
+  }
+}
+
+# Authenticated via CLOUDFLARE_API_TOKEN (fnox → 1Password).
+provider "cloudflare" {}

--- a/tofu/cloudflare/zone.tf
+++ b/tofu/cloudflare/zone.tf
@@ -1,0 +1,8 @@
+resource "cloudflare_zone" "zebernst_dev" {
+  name                = "zebernst.dev"
+  type                = "full"
+  account = {
+    id   = data.cloudflare_account.account.id
+  }
+}
+


### PR DESCRIPTION
## Summary
- Add `tofu/cloudflare` stack for `zebernst.dev`
- Manage zone, DNSSEC, static DNS, cache bypass ruleset, and cloudflared tunnels
- Leave ExternalDNS-owned public records out of state so GitOps keeps owning dynamic DNS

Made with [Cursor](https://cursor.com)